### PR TITLE
Correção URL estado de Goiás.

### DIFF
--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -263,8 +263,9 @@ NFCE = {
 	    	'EVENTOS': 'sefaz.go.gov.br/nfe/services/NFeRecepcaoEvento4?wsdl',
 	    	'QR': 'sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?',
 	    	'CADASTRO': 'sefaz.go.gov.br/nfe/services/CadConsultaCadastro4?wsdl',
-	    	'HTTPS': 'http://nfe.',
-	    	'HOMOLOGACAO': 'http://homolog.'
+	    	'HTTPS': 'https://nfe.',
+	    	'HOMOLOGACAO': 'https://homolog.',
+	        'URL': 'sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe'
 	    },
 	    'DF': {
 	    	'QR': 'http://www.fazenda.df.gov.br/nfce/qrcode?',


### PR DESCRIPTION
A Sefaz GO agora usa https e não http.
Adicionado o parâmetro URL necessário para emissão da NFC-e