### PR TITLE
Add specific version of PyXB

### DIFF
--- a/requirements-nfse.txt
+++ b/requirements-nfse.txt
@@ -1,3 +1,3 @@
 # Opcional para NFS-e
 suds-jurko
-pyxb
+pyxb=1.2.4


### PR DESCRIPTION
Caros, 

A versão atual do PyXB é a 1.2.6, aparentemente incompatível com o pynfe, que requere a versão 1.2.4. 