### PR TITLE
excluir pasta tests da instalação

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft tests
+include AUTHORS PLANEJAMENTO LICENCE *.py *.sh

--- a/requirements-nfse.txt
+++ b/requirements-nfse.txt
@@ -1,3 +1,3 @@
 # Opcional para NFS-e
 suds-jurko
-pyxb=1.2.4
+pyxb==1.2.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     author='TadaSoftware',
     author_email='tadasoftware@gmail.com',
     url='https://github.com/TadaSoftware',
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests', 'tests.*']),
     package_data={
         'pynfe': ['data/**/*.txt'],
     },
@@ -17,6 +17,12 @@ setuptools.setup(
         'lxml',
         'signxml',
     ],
+    extras_require={
+        'nfse': [
+            'suds-jurko',
+            'pyxb==1.2.4',
+        ],
+    },
     zip_safe=False,
     python_requires='>=3.6',
 )


### PR DESCRIPTION
o modulo tests e destinado apenas ao desenvolvimento, e sua inclusão na instalação pode causar conflitos por causa de seu nome genérico

mudanças feitas:

- excluir modulo tests no setup.py
 - criação do arquivo MANIFEST.in
 - inclusão de um extras_require no setup.py para instalação de dependencias do nfse