### PR TITLE
Atualiza URL de NFCe do Rio de Janeiro.

### DIFF
--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -189,7 +189,7 @@ NFCE = {
 	    	'INUTILIZACAO': '',
 	    	'EVENTOS': '',
 	    	'QR': 'http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode?',
-	    	'URL': 'www.nfce.fazenda.rj.gov.br/consulta'
+	    	'URL': 'www.fazenda.rj.gov.br/nfce/consulta'
 	    },
 	    # Os Web Services de homologação da NFC-e 4.00 são:
 		# https://homologacao.nfce.fazenda.sp.gov.br/ws/NFeAutorizacao4.asmx


### PR DESCRIPTION
Conforme descrito no issue #105

Segue PR para atualização da URL.