### PR TITLE
Setar timezone conforme data de emissao e adicionado campo dhSaiEnt

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -532,7 +532,9 @@ class SerializacaoXML(Serializacao):
         # Ex.: NFe35080599999090910270550010000000011518005123
         raiz.attrib['Id'] = nota_fiscal.identificador_unico
 
-        tz = datetime.now().astimezone().strftime('%z')
+        tz = nota_fiscal.data_emissao.strftime('%z')
+        if not tz:
+            tz = datetime.now().astimezone().strftime('%z')
         tz = "{}:{}".format(tz[:-2], tz[-2:])
 
         # Dados da Nota Fiscal
@@ -544,6 +546,8 @@ class SerializacaoXML(Serializacao):
         etree.SubElement(ide, 'serie').text = nota_fiscal.serie
         etree.SubElement(ide, 'nNF').text = str(nota_fiscal.numero_nf)
         etree.SubElement(ide, 'dhEmi').text = nota_fiscal.data_emissao.strftime('%Y-%m-%dT%H:%M:%S') + tz
+        if nota_fiscal.data_saida_entrada:
+            etree.SubElement(ide, 'dhSaiEnt').text = nota_fiscal.data_saida_entrada.strftime('%Y-%m-%dT%H:%M:%S') + tz
         """dhCont Data e Hora da entrada em contingência E B01 D 0-1 Formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal
             Coordinated Time)
             Exemplo: no formato UTC para os campos de Data-Hora, "TZD" pode ser -02:00 (Fernando de Noronha), -03:00 (Brasília) ou -04:00 (Manaus), no


### PR DESCRIPTION
* Adicionada a tag ```dhSaiEnt``` se informado o campo ```nota_fiscal.data_saida_entrada```. Faz-se necessário informar a tag quando a data de saída da mercadoria tem que ser diferente da data de emissão.

* Alterada a seleção do timezone conforme o timezone informado no campo ```nota_fiscal.data_emissao``` e não no datetime.now() do computador local.
  * Necessário ter essa diferenciação porque o Brasil tem quatro fuso horários diferentes e, por exemplo, se o servidor estiver no fuso de Brasília (-04:00) para emissão de uma nota fiscal no fuso horário de Mato Grosso (-03:00) os campos dhEmi e dhSaiEnt também devem estar no fuso horário de Mato Grosso.
  * Exemplos: ```<dhEmi>2021-05-10T22:04:44-03:00</dhEmi>``` e ```<dhSaiEnt>2021-05-10T15:29:39-03:00</dhSaiEnt>```
  * Mantive a compatibilidade caso houver ```nota_fiscal.data_emissao``` sem timezone, continua passando ```datetime.now().astimezone().strftime('%z')```.
  * Segue abaixo exemplo de como informar o timezone no campo ```nota_fiscal.data_emissao```


```python
from datetime import datetime
import pytz


data_emissao = datetime.now()

pytz.timezone("America/Cuiaba").localize(data_emissao).astimezone(pytz.timezone("America/Cuiaba"))
datetime.datetime(2021, 5, 10, 21, 44, 30, 975125)

pytz.timezone("America/Sao_Paulo").localize(data_emissao).astimezone(pytz.timezone("America/Sao_Paulo"))
datetime.datetime(2021, 5, 10, 21, 44, 30, 975125, tzinfo=<DstTzInfo 'America/Sao_Paulo' -03-1 day, 21:00:00 STD>)
```
