### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,20 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install bandit black flake8 isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101 . || true  # B101 is assert statements
+      - run: black --check . || true
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install sphinx_rtd_theme tornado -r requirements.txt -r requirements-nfse.txt
+      - run: python ./test.py || true
+      - run: mypy --ignore-missing-imports . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/pynfe/utils/bar_code_128.py
+++ b/pynfe/utils/bar_code_128.py
@@ -162,6 +162,7 @@ class Code128:
       current_charset = None
       pos=sum=0
       skip=False
+      strCode=""
       for c in range(len(code)):
           if skip:
               skip=False


### PR DESCRIPTION
Output: https://github.com/cclauss/PyNFe/actions
* `print()` is a function in Python 3.
* `basestring` and `unicode` were removed in Python 3.

% `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./run_tests.py:26:15: E999 SyntaxError: invalid syntax
        print 'Running "%s"...'%(os.path.splitext(os.path.split(fname)[-1])[0])
              ^
./run_fake_soap_server.py:42:15: E999 SyntaxError: invalid syntax
        print 'Metodo:', tag
              ^
./pynfe/processamento/serializacao.py:463:20: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
                if produto_servico.pis_modalidade is not '99':
                   ^
./pynfe/processamento/serializacao.py:499:20: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
                if produto_servico.cofins_modalidade is not '99':
                   ^
./pynfe/utils/__init__.py:100:32: F821 undefined name 'unicode'
    municipio = municipios.get(unicode(codigo))
                               ^
./pynfe/utils/__init__.py:140:30: F821 undefined name 'basestring'
    if isinstance(codigo_uf, basestring) and codigo_uf.isalpha():
                             ^
./pynfe/utils/__init__.py:144:20: F821 undefined name 'unicode'
    return estados[unicode(codigo_uf)]
                   ^
./pynfe/utils/bar_code_128.py:177:22: F821 undefined name 'strCode'
                     strCode += self.ValueEncodings[current_charset['Code C']]
                     ^
2     E999 SyntaxError: invalid syntax
2     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
4     F821 undefined name 'unicode'
8
```