### PR TITLE
Buscar código ibge com nome da cidade com e sem apóstrofo

### DIFF
--- a/pynfe/utils/__init__.py
+++ b/pynfe/utils/__init__.py
@@ -45,6 +45,7 @@ CARACTERS_ACENTUADOS = {
     ord(u'ô'): u'o',
     ord(u'ú'): u'u',
     ord(u'ç'): u'c',
+    ord(u"'"): u'',
 }
 
 


### PR DESCRIPTION
Dependendo da base de dados utilizada os nomes das cidades são enviadas sem apóstrofo.
Ocorre o erro abaixo:

```shell
Python 3.7.3 (default, Jan 22 2021, 20:04:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
>>> from terceiros.PyNFe.pynfe.utils import *
>>> obter_codigo_por_municipio("Conquista D'Oeste", 'MT')
'5103361'
>>> obter_codigo_por_municipio("Conquista DOeste", 'MT')
Traceback (most recent call last):
  File "/usr/lib/python3.7/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/home/leo/Documentos/lucrorural/backend/terceiros/PyNFe/pynfe/utils/__init__.py", line 98, in obter_codigo_por_municipio
    return municipios[normalizar_municipio(municipio)]
KeyError: 'CONQUISTA DOESTE'
>>> 
```

Após aplicar esse PR posso utilizar das duas formas como segue abaixo:

```shell
Python 3.7.3 (default, Jan 22 2021, 20:04:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> 
>>> from terceiros.PyNFe.pynfe.utils import *
>>> obter_codigo_por_municipio("Conquista D'Oeste", 'MT')
'5103361'
>>> obter_codigo_por_municipio("Conquista DOeste", 'MT')
'5103361'
>>> 
```
