### PR TITLE
Adiciona campo qBCProd ao cofins

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -497,6 +497,7 @@ class SerializacaoXML(Serializacao):
                 etree.SubElement(cofins_item, 'vBC').text = '{:.2f}'.format(produto_servico.cofins_valor_base_calculo or 0)
                 etree.SubElement(cofins_item, 'pCOFINS').text = '{:.2f}'.format(produto_servico.cofins_aliquota_percentual or 0)
                 if produto_servico.cofins_modalidade != '99' and produto_servico.cofins_modalidade != '49':
+                    etree.SubElement(cofins_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
                     etree.SubElement(cofins_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.cofins_aliquota_percentual or 0)
                 etree.SubElement(cofins_item, 'vCOFINS').text = '{:.2f}'.format(produto_servico.cofins_valor or 0)
 


### PR DESCRIPTION
Corrige a rejeição:

> Rejeicao: Falha no schema XMLcvc-complex-type.2.4.a: Foi detectado um conteudo invalido comecando com o elemento '{"http://www.portalfiscal.inf.br/nfe":vAliqProd}'. Era esperado um dos '{"http://www.portalfiscal.inf.br/nfe":vCOFINS}'

Isso porque a estrutura do COFINS está diferente do PIS.