### PR TITLE
Correção da estrutura do xml para notas referenciadas

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -605,8 +605,8 @@ class SerializacaoXML(Serializacao):
         # Apenas NF-e
         if nota_fiscal.modelo == 55:
             if nota_fiscal.notas_fiscais_referenciadas:
-                nfref = etree.SubElement(ide, 'NFref')
                 for refNFe in nota_fiscal.notas_fiscais_referenciadas:
+                    nfref = etree.SubElement(ide, 'NFref')
                     etree.SubElement(nfref, 'refNFe').text = refNFe.chave_acesso
 
         ### CONTINGENCIA ###


### PR DESCRIPTION
Hoje está gerando dessa forma:
```xml
<NFref>
    <refNFe>41090501234567801235500100000999999999</refNFe>
    <refNFe>41090501234567801235500110000888888888</refNFe>
</NFref>
```

e deveria gerar dessa forma:
```xml
<NFref>
    <refNFe>41090501234567801235500100000999999999</refNFe>
</NFref>
<NFref>
    <refNFe>41090501234567801235500110000888888888</refNFe>
</NFref>
```