### PR TITLE
Correção de importação do arquivo "base.py" no arquivo "fonte_dados.py". Faltava um "."

### DIFF
--- a/pynfe/entidades/fonte_dados.py
+++ b/pynfe/entidades/fonte_dados.py
@@ -73,7 +73,7 @@ class FonteDados(object):
         removido. Caso o argumento _objeto seja uma lista de objetos, eles serão
         removidos também."""
 
-        from base import Entidade
+        from .base import Entidade
 
         lista = None
 


### PR DESCRIPTION
Necessário. A importação da função em terminal não consegue encontrar o arquivo "base", não sei se está afetando outras importações também.