### PR TITLE
Adiciona CI com testes e lint para todas as versões do python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: PyNFe CI
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install flake8 pytest
+      - name: Lint
+        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Tests
+        run: pytest -v

--- a/pynfe/utils/bar_code_128.py
+++ b/pynfe/utils/bar_code_128.py
@@ -162,6 +162,7 @@ class Code128:
       current_charset = None
       pos=sum=0
       skip=False
+      strCode=""
       for c in range(len(code)):
           if skip:
               skip=False


### PR DESCRIPTION
Esse script tem somente a verificação de poucas regras da pep8, roda todos os testes feitos e roda nas versões 3.6 até 3.10 suportadas pelo projeto e não tem tantas dependências como o PR #110.

Podemos inclui mais regras do pep8 com o tempo.

Um teste do resultado do CI: https://github.com/leogregianin/PyNFe/actions/runs/1762397534
