### PR TITLE
Fix pytest warning: Regex likes raw strings

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1026,7 +1026,7 @@ class SerializacaoQrcode(object):
         # icms = nfe.xpath('ns:infNFe/ns:total/ns:ICMSTot/ns:vICMS/text()', namespaces=ns)[0]
         digest = nfe.xpath('sig:Signature/sig:SignedInfo/sig:Reference/sig:DigestValue/text()', namespaces=sig)[0].encode()
 
-        lista_dia = re.findall("-\d{2}", str(data))
+        lista_dia = re.findall(r"-\d{2}", str(data))
         dia = str(lista_dia[1])
         dia = dia[1:]
         replacements = {'0': ''}


### PR DESCRIPTION
Fixes pytest warning:
```
=============================== warnings summary ===============================
pynfe/processamento/serializacao.py:1029
  /home/runner/work/PyNFe/PyNFe/pynfe/processamento/serializacao.py:1029: DeprecationWarning: invalid escape sequence '\d'
    lista_dia = re.findall("-\d{2}", str(data))
```
Fourth paragraph of https://docs.python.org/pt-br/3/library/re.html