### PR TITLE
Erro de validação do grupo pis cofins

### DIFF
--- a/pynfe/entidades/produto.py
+++ b/pynfe/entidades/produto.py
@@ -122,12 +122,14 @@ class Produto(Entidade):
     pis_valor_base_calculo = str()
     pis_aliquota_percentual = str()
     pis_valor = str()
+    pis_aliquota_reais = str()
 
     # # COFINS
     cofins_modalidade = str()
     cofins_valor_base_calculo = str()
     cofins_aliquota_percentual = str()
     cofins_valor = str()
+    cofins_aliquota_reais = str()
 
     # # Fundo de Combate a Pobreza
     fcp_base_calculo = Decimal()

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -643,7 +643,7 @@ class SerializacaoXML(Serializacao):
                 if produto_servico.pis_modalidade != '99' and produto_servico.pis_modalidade != '49':
                     etree.SubElement(pis_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
                     etree.SubElement(pis_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.pis_aliquota_percentual or 0)
-                etree.SubElement(pis_item, 'vPIS').text = '{:.2f}'.format(produto_servico.pis_valor_base_calculo or 0)
+                etree.SubElement(pis_item, 'vPIS').text = '{:.2f}'.format(produto_servico.pis_valor or 0)
 
                 ## PISST
                 # pis_item = etree.SubElement(pis, 'PISST')

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -633,16 +633,17 @@ class SerializacaoXML(Serializacao):
                 pis_item = etree.SubElement(pis, 'PISQtde')
                 etree.SubElement(pis_item, 'CST').text = produto_servico.pis_modalidade
                 etree.SubElement(pis_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
-                etree.SubElement(pis_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.pis_aliquota_percentual or 0)
-                etree.SubElement(pis_item, 'vPIS').text = '{:.2f}'.format(produto_servico.pis_valor_base_calculo or 0)
+                etree.SubElement(pis_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.pis_aliquota_reais or 0)
+                etree.SubElement(pis_item, 'vPIS').text = '{:.2f}'.format(produto_servico.pis_valor or 0)
             else:
                 pis_item = etree.SubElement(pis, 'PISOutr')
                 etree.SubElement(pis_item, 'CST').text = produto_servico.pis_modalidade
-                etree.SubElement(pis_item, 'vBC').text = '{:.2f}'.format(produto_servico.pis_valor_base_calculo or 0)
-                etree.SubElement(pis_item, 'pPIS').text = '{:.2f}'.format(produto_servico.pis_aliquota_percentual or 0)
-                if produto_servico.pis_modalidade != '99' and produto_servico.pis_modalidade != '49':
+                if produto_servico.pis_aliquota_reais > 0:
                     etree.SubElement(pis_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
-                    etree.SubElement(pis_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.pis_aliquota_percentual or 0)
+                    etree.SubElement(pis_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.pis_aliquota_reais or 0)
+                else:
+                    etree.SubElement(pis_item, 'vBC').text = '{:.2f}'.format(produto_servico.pis_valor_base_calculo or 0)
+                    etree.SubElement(pis_item, 'pPIS').text = '{:.2f}'.format(produto_servico.pis_aliquota_percentual or 0)
                 etree.SubElement(pis_item, 'vPIS').text = '{:.2f}'.format(produto_servico.pis_valor or 0)
 
                 ## PISST
@@ -670,16 +671,17 @@ class SerializacaoXML(Serializacao):
                 cofins_item = etree.SubElement(cofins, 'COFINSQtde')
                 etree.SubElement(cofins_item, 'CST').text = produto_servico.cofins_modalidade
                 etree.SubElement(cofins_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
-                etree.SubElement(cofins_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.cofins_aliquota_percentual)
+                etree.SubElement(cofins_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.cofins_aliquota_reais)
                 etree.SubElement(cofins_item, 'vCOFINS').text = '{:.2f}'.format(produto_servico.cofins_valor)
             else:
                 cofins_item = etree.SubElement(cofins, 'COFINSOutr')
                 etree.SubElement(cofins_item, 'CST').text = produto_servico.cofins_modalidade
-                etree.SubElement(cofins_item, 'vBC').text = '{:.2f}'.format(produto_servico.cofins_valor_base_calculo or 0)
-                etree.SubElement(cofins_item, 'pCOFINS').text = '{:.2f}'.format(produto_servico.cofins_aliquota_percentual or 0)
-                if produto_servico.cofins_modalidade != '99' and produto_servico.cofins_modalidade != '49':
+                if produto_servico.cofins_aliquota_reais > 0:
                     etree.SubElement(cofins_item, 'qBCProd').text = '{:.4f}'.format(produto_servico.quantidade_comercial)
-                    etree.SubElement(cofins_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.cofins_aliquota_percentual or 0)
+                    etree.SubElement(cofins_item, 'vAliqProd').text = '{:.4f}'.format(produto_servico.cofins_aliquota_reais or 0)
+                else:
+                    etree.SubElement(cofins_item, 'vBC').text = '{:.2f}'.format(produto_servico.cofins_valor_base_calculo or 0)
+                    etree.SubElement(cofins_item, 'pCOFINS').text = '{:.2f}'.format(produto_servico.cofins_aliquota_percentual or 0)
                 etree.SubElement(cofins_item, 'vCOFINS').text = '{:.2f}'.format(produto_servico.cofins_valor or 0)
 
                 ## COFINSST

--- a/pynfe/processamento/validacao.py
+++ b/pynfe/processamento/validacao.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 
 from os import path
+import io
 
 try:
     from lxml import etree
@@ -57,5 +58,11 @@ class Validacao(object):
             xsd_doc = etree.parse(xsd_file)
             xsd_schema = etree.XMLSchema(xsd_doc)
             self.MEM_CACHE[xsd_file] = xsd_schema
+
+            with io.StringIO() as buffer:
+                buffer.write(etree.tostring(xml_doc).decode("utf-8"))
+                buffer.seek(0)
+                xml_doc = etree.parse(buffer)
+
         return use_assert and xsd_schema.assertValid(xml_doc) \
                or xsd_schema.validate(xml_doc)

--- a/tests/test_nfe_serializacao.py
+++ b/tests/test_nfe_serializacao.py
@@ -137,8 +137,14 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_modalidade='00',
             icms_origem=0,
             icms_csosn='400',
-            pis_modalidade='07',
-            cofins_modalidade='07',
+            pis_modalidade='51',
+            cofins_modalidade='51',
+            pis_valor_base_calculo=Decimal('117.00'),
+            pis_aliquota_percentual=Decimal('0.65'),
+            pis_valor=Decimal('0.76'),
+            cofins_valor_base_calculo=Decimal('117.00'),
+            cofins_aliquota_percentual=Decimal('3.00'),
+            cofins_valor=Decimal('3.51'),
             valor_tributos_aprox='21.06',
             numero_pedido='12345',
             numero_item='1',
@@ -700,7 +706,8 @@ class SerializacaoNFeTestCase(unittest.TestCase):
     def validacao_com_xsd_do_xml_gerado_sem_processar(self):
         self.validacao.validar_etree(
             xml_doc=self.xml_assinado,
-            xsd_file=self.xsd_nfe
+            xsd_file=self.xsd_nfe,
+            use_assert=True
         )
 
     def grupo_ide_test(self):
@@ -843,6 +850,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(nItemPed, '1')
 
         # Impostos
+        # ICMS
         orig = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:orig', namespaces=self.ns)[0].text
         CST = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:CST', namespaces=self.ns)[0].text
         modBC = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:modBC', namespaces=self.ns)[0].text
@@ -864,6 +872,14 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         # self.assertEqual(vFCP, '0.00')
         self.assertEqual(pFCP, None)
         self.assertEqual(vFCP, None)
+
+        # PIS
+        CST_PIS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST', namespaces=self.ns)[0].text
+        self.assertEqual(CST_PIS, '51')
+
+        # # COFINS
+        CST_COFINS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST', namespaces=self.ns)[0].text
+        self.assertEqual(CST_COFINS, '51')
 
         # Totalizadores
         vBC = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vBC', namespaces=self.ns)[0].text
@@ -902,8 +918,8 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vII, '0.00')
         self.assertEqual(vIPI, '0.00')
         self.assertEqual(vIPIDevol, '0.00')
-        self.assertEqual(vPIS, '0.00')
-        self.assertEqual(vCOFINS, '0.00')
+        self.assertEqual(vPIS, '0.76')
+        self.assertEqual(vCOFINS, '3.51')
         self.assertEqual(vOutro, '0.00')
         self.assertEqual(vNF, '117.00')
         self.assertEqual(vTotTrib, '21.06')


### PR DESCRIPTION
Teste que demonstra o erro da issue #130 

```
lxml.etree.DocumentInvalid: Element '{http://www.portalfiscal.inf.br/nfe}qBCProd': This element is not expected. Expected is ( {http://www.portalfiscal.inf.br/nfe}vPIS )., line 1
```