### PR TITLE
Alteração do cálculo automático do valor total da nota

### DIFF
--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -397,7 +397,7 @@ class NotaFiscal(Entidade):
         self.totais_icms_total_frete += obj.total_frete
         self.totais_icms_total_seguro += obj.total_seguro
         self.totais_icms_total_desconto += obj.desconto
-        # self.totais_icms_total_ii += # tem que entender o cálculo
+        self.totais_icms_total_ii += obj.imposto_importacao_valor
         self.totais_icms_total_ipi += obj.ipi_valor_ipi
         self.totais_icms_total_ipi_dev += obj.ipi_valor_ipi_dev
         self.totais_icms_pis += obj.pis_valor
@@ -413,10 +413,19 @@ class NotaFiscal(Entidade):
         ## TODO calcular impostos aproximados
         #self.totais_tributos_aproximado += obj.tributos
 
-        self.totais_icms_total_nota += obj.valor_total_bruto - obj.desconto + \
-                                       obj.icms_desonerado + obj.icms_st_valor + \
-                                       obj.total_frete + obj.total_seguro + \
-                                       obj.outras_despesas_acessorias + obj.ipi_valor_ipi
+        self.totais_icms_total_nota += (
+            obj.valor_total_bruto
+            + obj.icms_st_valor
+            + obj.fcp_st_valor
+            + obj.total_frete
+            + obj.total_seguro
+            + obj.outras_despesas_acessorias
+            + obj.imposto_importacao_valor
+            + obj.ipi_valor_ipi
+            + obj.ipi_valor_ipi_dev
+            - obj.desconto
+            - obj.icms_desonerado
+        )
 
         return obj
 

--- a/tests/test_nfe_serializacao.py
+++ b/tests/test_nfe_serializacao.py
@@ -951,7 +951,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vPIS, '0.76')
         self.assertEqual(vCOFINS, '3.51')
         self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '117.00')
+        self.assertEqual(vNF, '127.00')
         self.assertEqual(vTotTrib, '21.06')
 
     def total_e_produto_cst40_test(self):
@@ -1053,7 +1053,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vPIS, '0.00')
         self.assertEqual(vCOFINS, '0.00')
         self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '127.00')
+        self.assertEqual(vNF, '107.00')
         self.assertEqual(vTotTrib, '21.06')
 
     def total_e_produto_cst41_test(self):
@@ -1155,7 +1155,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vPIS, '0.00')
         self.assertEqual(vCOFINS, '0.00')
         self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '127.00')
+        self.assertEqual(vNF, '107.00')
         self.assertEqual(vTotTrib, '21.06')
 
     def total_e_produto_cst50_test(self):
@@ -1257,7 +1257,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vPIS, '0.00')
         self.assertEqual(vCOFINS, '0.00')
         self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '127.00')
+        self.assertEqual(vNF, '107.00')
         self.assertEqual(vTotTrib, '21.06')
 
     def total_e_produto_cst51_test(self):
@@ -1601,7 +1601,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vPIS, '0.00')
         self.assertEqual(vCOFINS, '0.00')
         self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '118.44')
+        self.assertEqual(vNF, '118.46')
         self.assertEqual(vTotTrib, '21.06')
 
     def total_e_produto_cst90_test(self):


### PR DESCRIPTION
Alteração do cálculo automático do valor total da nota.

Somando os campos `FCP ST`, `Imposto de Importação`, `IPI Devolução` e subtraindo `ICMS Desonerado`.

Como referências a lib de NFe em PHP [aqui](https://github.com/nfephp-org/sped-nfe/blob/81e154a69d20391bb569ff364ab7d8e1e36fca50/src/Make.php#L7514) 

```php
$this->stdTot->vNF = $this->stdTot->vProd
            - $this->stdTot->vDesc
            - $this->stdTot->vICMSDeson
            + $this->stdTot->vST
            + $this->stdTot->vFCPST
            + $this->stdTot->vFrete
            + $this->stdTot->vSeg
            + $this->stdTot->vOutro
            + $this->stdTot->vII
            + $this->stdTot->vIPI
            + $this->stdTot->vIPIDevol
            + $this->stdISSQNTot->vServ
            + $this->stdTot->vPISST
            + $this->stdTot->vCOFINSST;
```

e a lib de NFe em C# [aqui](https://github.com/ZeusAutomacao/DFe.NET/blob/132db3a54eadc61a5955696d56a008d93ba57fa5/NFe.AppTeste/MainWindow.xaml.cs#L1326.
).

```c#
icmsTot.vNF =
   icmsTot.vProd
   - icmsTot.vDesc
   - icmsTot.vICMSDeson.GetValueOrDefault()
   + icmsTot.vST
   + icmsTot.vFCPST.GetValueOrDefault()
   + icmsTot.vFrete
   + icmsTot.vSeg
   + icmsTot.vOutro
   + icmsTot.vII
   + icmsTot.vIPI
   + icmsTot.vIPIDevol.GetValueOrDefault();
```
