### PR TITLE
Correção a geração do XML do MDFe quando não tem dados do contratante

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1448,7 +1448,7 @@ class SerializacaoMDFe(Serializacao):
                     etree.SubElement(infContratante, 'CNPJ').text = item.cpfcnpj
 
                 # Contrato
-                if item.NroContrato != None:
+                if item.NroContrato:
                     infContrato = etree.SubElement(infContratante, 'infContrato')
                     etree.SubElement(infContrato, 'NroContrato').text = item.NroContrato
                     etree.SubElement(infContrato, 'vContratoGlobal').text = '{:.2f}'.format(item.vContratoGlobal or 0)


### PR DESCRIPTION
Alterada a validação do campo `NroContrato` nas informações do Contratante do MDF-e.