### PR TITLE
Correção da assinatura digital com signxml

### DIFF
--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -41,6 +41,7 @@ class AssinaturaA1(Assinatura):
             method=signxml.methods.enveloped, signature_algorithm="rsa-sha1",
             digest_algorithm='sha1',
             c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315')
+        signer.excise_empty_xmlns_declarations = True
 
         ns = {None: signer.namespaces['ds']}
         signer.namespaces = ns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Dependencias basicas
-pyopenssl
+pyopenssl>=22.1.0
 requests
 lxml
-signxml
+signxml>=2.10.1
 
 # Opcional para NFS-e
 #-r requirements-nfse.txt


### PR DESCRIPTION
A partir da versão 2.10 da biblioteca signxml os arquivos XML de NFe assinados ocorrem erro de assinatura inválida.

Um novo parâmetro chamado `excise_empty_xmlns_declarations` foi adicionado a versão 2.10 que alterou o comportamento padrão até a versão 2.9.

A discussão está sendo feita nesse tópico https://github.com/XML-Security/signxml/issues/197. 

Enquanto isso, para assinar corretamente os arquivos XML deve passar explicitamente o parâmetro `excise_empty_xmlns_declarations = True` e garantir que esteja utilizando as últimas versões do signxml, pyopenssl e cryptography.