### PR TITLE
Falha no Schema ao consultar status do serviço do CT-e #248

### DIFF
--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -1034,9 +1034,8 @@ class ComunicacaoCTe(Comunicacao):
         """
         url = self._get_url('STATUS')
         # Monta XML do corpo da requisição
-        raiz = etree.Element('consStatServ', versao=self._versao, xmlns=NAMESPACE_CTE)
+        raiz = etree.Element('consStatServCte', versao=self._versao, xmlns=NAMESPACE_CTE)
         etree.SubElement(raiz, 'tpAmb').text = str(self._ambiente)
-        etree.SubElement(raiz, 'cUF').text = CODIGOS_ESTADOS[self.uf.upper()]
         etree.SubElement(raiz, 'xServ').text = 'STATUS'
         xml = self._construir_xml_soap('CteStatusServico', raiz)
         return self._post(url, xml)


### PR DESCRIPTION
Foi realizado o ajuste na montagem do XML utilizado na requisição da consulta de status do serviço do CT-e.

Após o ajuste, a consulta retorna a informação de forma correta.

`<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><cteCabecMsg xmlns="http://www.portalfiscal.inf.br/cte/wsdl/CteStatusServico"><cUF>43</cUF><versaoDados>3.00</versaoDados></cteCabecMsg></soap:Header><soap:Body><cteStatusServicoCTResult xmlns="http://www.portalfiscal.inf.br/cte/wsdl/CteStatusServico"><retConsStatServCte xmlns="http://www.portalfiscal.inf.br/cte" versao="3.00"><tpAmb>2</tpAmb><verAplic>RS20220908175702</verAplic><cStat>107</cStat><xMotivo>Servico em Operacao</xMotivo><cUF>43</cUF><dhRecbto>2022-12-14T10:55:59-03:00</dhRecbto><tMed>1</tMed></retConsStatServCte></cteStatusServicoCTResult></soap:Body></soap:Envelope>`