### PR TITLE
Fix signxml

### DIFF
--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from pynfe.utils import etree, remover_acentos
+from pynfe.utils import etree, remover_acentos, CustomXMLSigner
 from pynfe.utils.flags import NAMESPACE_SIG
 import subprocess
 import signxml
-from signxml import XMLSigner
 from pynfe.entidades import CertificadoA1
 
 
@@ -37,7 +36,7 @@ class AssinaturaA1(Assinatura):
         xml_str = remover_acentos(etree.tostring(xml, encoding="unicode", pretty_print=False))
         xml = etree.fromstring(xml_str)
 
-        signer = XMLSigner(
+        signer = CustomXMLSigner(
             method=signxml.methods.enveloped, signature_algorithm="rsa-sha1",
             digest_algorithm='sha1',
             c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315')

--- a/pynfe/utils/__init__.py
+++ b/pynfe/utils/__init__.py
@@ -3,6 +3,7 @@
 import codecs
 import os
 from unicodedata import normalize
+from signxml import XMLSigner
 
 try:
     from lxml import etree
@@ -155,3 +156,10 @@ def obter_uf_por_codigo(codigo_uf):
 
 def remover_acentos(txt):
     return normalize('NFKD', txt).encode('ASCII', 'ignore').decode('ASCII')
+
+class CustomXMLSigner(XMLSigner):
+    def __init__(self, method, signature_algorithm, digest_algorithm, c14n_algorithm):
+        super().__init__(method, signature_algorithm, digest_algorithm, c14n_algorithm)
+
+    def check_deprecated_methods(self):
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 pyopenssl>=23.0.0
 requests
 lxml
-signxml==2.10.1
+signxml
 
 # Opcional para NFS-e
 #-r requirements-nfse.txt

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         'pyopenssl>=23.0.0',
         'requests',
         'lxml',
-        'signxml==2.10.1',
+        'signxml',
     ],
     extras_require={
         'nfse': [


### PR DESCRIPTION
A partir da [versão 3.1.0 do signxml](https://github.com/XML-Security/signxml/releases) o algoritmo de criptografia SHA1 exigido pelos documentos fiscais (NFe, NFCe, MDFe, etc) para assinar os XMLs está obsoleto por padrão.

Para resolver deve-se sobrescrever o método check_deprecated_methodsda classe XMLSigner para não [entrar no raise exception](https://xml-security.github.io/signxml/_modules/signxml/signer.html#XMLSigner.check_deprecated_methods).