### PR TITLE
Atualiza criptografia A1 para utilizar Cryptography no Lugar de OpenSSL

### DIFF
--- a/pynfe/entidades/certificado.py
+++ b/pynfe/entidades/certificado.py
@@ -57,7 +57,7 @@ class CertificadoA1(Certificado):
                 chave,
                 cert,
                 _,
-            ) = pkcs12.load_key_and_certificates(cert_conteudo, senha)
+            ) = pkcs12.load_key_and_certificates(cert_conteudo, str.encode(senha))
         except ValueError as e:
             if "bad decrypt" in str(e).lower():
                 raise Exception(

--- a/pynfe/entidades/certificado.py
+++ b/pynfe/entidades/certificado.py
@@ -56,16 +56,19 @@ class CertificadoA1(Certificado):
                 "Falha ao abrir arquivo do certificado digital A1. Causa desconhecida."
             ) from exc
 
+        if not isinstance(senha, bytes):
+            senha = str.encode(senha)
+
         # Carrega o arquivo .pfx, erro pode ocorrer se a senha estiver errada ou formato invalido.
         try:
             (
                 chave,
                 cert,
             ) = pkcs12.load_key_and_certificates(
-                cert_conteudo, str.encode(senha)
+                cert_conteudo, senha
             )[:2]
-        except ValueError as e:
-            if "bad decrypt" in str(e).lower():
+        except Exception as e:
+            if "invalid password" in str(e).lower():
                 raise Exception(
                     "Falha ao carregar certificado digital A1. Verifique a senha do"
                     " certificado."
@@ -82,7 +85,7 @@ class CertificadoA1(Certificado):
             with tempfile.NamedTemporaryFile(delete=False) as arqchave:
                 arqchave.write(
                     chave.private_bytes(
-                        Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()
+                        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
                     )
                 )
             self.arquivos_temp.append(arqchave.name)
@@ -97,7 +100,7 @@ class CertificadoA1(Certificado):
 
             # Chave, string decodificada da chave privada
             chave = chave.private_bytes(
-                Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()
+                Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
             )
 
             return chave, cert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # Dependencias basicas
-pyopenssl>=23.0.0
 requests
 lxml
 signxml
-
+cryptography
 # Opcional para NFS-e
 #-r requirements-nfse.txt


### PR DESCRIPTION
## Escopo
pyopenssl removeu a função [OpenSSL.crypto.loads_pkcs12](https://www.pyopenssl.org/en/latest/changelog.html#deprecations) que era utilizada pelo PyNFE para puxar o certificado e chave privada do A1.
Na verdade a lib do pyopenssl usava o **cryptography** por baixo dos panos nessa função **loads_pkcs12**, então eu mudei para ele, já que só usamos para isso atualmente.
Já está funcionando em produção normalmente e passando nos testes.