### PR TITLE
Possibilidade de adicionar um código numérico aleatório e não gerar automaticamente.

### DIFF
--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import random
+from decimal import Decimal
 
-from .base import Entidade
 from pynfe import get_version
-from pynfe.utils.flags import NF_STATUS, CODIGOS_ESTADOS
 
 # from pynfe.utils import so_numeros, memoize
 from pynfe.utils import so_numeros
+from pynfe.utils.flags import CODIGOS_ESTADOS, NF_STATUS
 
-from decimal import Decimal
+from .base import Entidade
 
 
 class NotaFiscal(Entidade):
@@ -465,7 +465,8 @@ class NotaFiscal(Entidade):
         return obj
 
     def _codigo_numerico_aleatorio(self):
-        self.codigo_numerico_aleatorio = str(random.randint(0, 99999999)).zfill(8)
+        if not self.codigo_numerico_aleatorio:
+            self.codigo_numerico_aleatorio = str(random.randint(0, 99999999)).zfill(8)
         return self.codigo_numerico_aleatorio
 
     def _dv_codigo_numerico(self, key):


### PR DESCRIPTION
Meu caso de uso:
1. Alguém cadastrou um produto com um imposto errado.
2. O Ponto de Venda faz a emissão em contingência e informa a chave de acesso no documento.
3. A chave de acesso possui um código numérico aleatório gerado para o XML em questão que está em contingência.
4. O imposto é ajustado horas depois, o XML é gerado novamente com a informação correta e uma nova assinatura.
5. Por não poder informar o mesmo código numérico utilizado anteriormente, é gerada uma nova chave de acesso invalidando a que está no cupom fiscal.

Por conta disso, a chave de acesso informada anteriormente não pode ser utilizada pelo site da UF para consulta.
Com essa PR, será possível informar manualmente um código numérico, garantindo a geração da exata mesma chave de acesso.