### PR TITLE
Utiliza ruff para qualidade de código

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install Flake8-pyproject
+          python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install flake8 pytest
+          pip install ruff pytest
       - name: Lint
-        run: flake8 . --count --show-source --statistics
+        run: ruff check --output-format=github .
       - name: Tests
         run: pytest -v

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Testes
 python -m unittest
 ```
 
+Lint
+-----------
+
+Instalação: `pip install ruff`
+Checar lint: `ruff check .`
+Formatar: `ruff format .`
+
 
 Documentação
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
-[tool.flake8]
-per-file-ignores = [
-    '/pynfe/entidades/__init__.py:F401'
+[tool.ruff]
+exclude = [
+    'pynfe/entidades/__init__.py'
 ]
-max-line-length = 100
+line-length = 100


### PR DESCRIPTION
A proposta é substituir flake8/black/isort pelo ruff (https://docs.astral.sh/ruff).