### PR TITLE
correções e melhorias diversas

### DIFF
--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -813,7 +813,7 @@ class NotaFiscalProduto(Entidade):
     #  - PIS
     #   - PIS
     #    - Situacao tributaria (obrigatorio - seleciona de lista) - PIS_TIPOS_TRIBUTACAO
-    pis_situacao_tributaria = str()
+    pis_modalidade = str()
 
     #    - Tipo de calculo (seleciona de lista) - PIS_TIPOS_CALCULO
     pis_tipo_calculo = str()

--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -254,7 +254,10 @@ class NotaFiscal(Entidade):
     totais_retencao_retencao_previdencia_social = Decimal()
 
     #  - Valor aproximado total de tributos federais, estaduais e municipais.
-    totais_tributos_aproximado = Decimal()
+    __totais_tributos_aproximado = Decimal()
+    @property
+    def totais_tributos_aproximado(self):
+        return self.__totais_tributos_aproximado
 
     # - Valor Total do FCP (Fundo de Combate à Pobreza)
     totais_fcp = Decimal()
@@ -442,8 +445,7 @@ class NotaFiscal(Entidade):
         self.totais_icms_q_bc_mono_ret += obj.icms_q_bc_mono_ret
         self.totais_icms_v_icms_mono_ret += obj.icms_v_icms_mono_ret
 
-        # TODO calcular impostos aproximados
-        # self.totais_tributos_aproximado += obj.tributos
+        self.__totais_tributos_aproximado += obj.valor_tributos_aprox
 
         self.totais_icms_total_nota += (
             obj.valor_total_bruto
@@ -935,6 +937,8 @@ class NotaFiscalProduto(Entidade):
 
     #   - Valor imposto de importacao
     imposto_importacao_valor = Decimal()
+
+    valor_tributos_aprox = Decimal()
 
     # - Informacoes Adicionais
     #  - Texto livre de informacoes adicionais

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1584,7 +1584,7 @@ class SerializacaoXML(Serializacao):
         if nota_fiscal.totais_icms_v_icms_mono_ret:
             etree.SubElement(icms_total, "vICMSMonoRet").text = "{:.2f}".format(nota_fiscal.totais_icms_v_icms_mono_ret)
 
-        etree.SubElement(icms_total, "vProd").text = str(
+        etree.SubElement(icms_total, "vProd").text = "{:.2f}".format(
             nota_fiscal.totais_icms_total_produtos_e_servicos
         )
         etree.SubElement(icms_total, "vFrete").text = "{:.2f}".format(

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1172,79 +1172,78 @@ class SerializacaoXML(Serializacao):
     def _serializar_imposto_cofins(
         self, produto_servico, modelo, tag_raiz="imposto", retorna_string=True
     ):
-        if modelo == 55:  # apenas nfe
-            cofinsnt = ("04", "05", "06", "07", "08", "09")
-            cofins = etree.SubElement(tag_raiz, "COFINS")
-            if produto_servico.cofins_modalidade in cofinsnt:
-                cofins_item = etree.SubElement(cofins, "COFINSNT")
-                etree.SubElement(
-                    cofins_item, "CST"
-                ).text = produto_servico.cofins_modalidade
-            elif (
-                produto_servico.cofins_modalidade == "01"
-                or produto_servico.cofins_modalidade == "02"
-            ):
-                cofins_item = etree.SubElement(cofins, "COFINSAliq")
-                etree.SubElement(
-                    cofins_item, "CST"
-                ).text = produto_servico.cofins_modalidade
+        cofinsnt = ("04", "05", "06", "07", "08", "09")
+        cofins = etree.SubElement(tag_raiz, "COFINS")
+        if produto_servico.cofins_modalidade in cofinsnt:
+            cofins_item = etree.SubElement(cofins, "COFINSNT")
+            etree.SubElement(
+                cofins_item, "CST"
+            ).text = produto_servico.cofins_modalidade
+        elif (
+            produto_servico.cofins_modalidade == "01"
+            or produto_servico.cofins_modalidade == "02"
+        ):
+            cofins_item = etree.SubElement(cofins, "COFINSAliq")
+            etree.SubElement(
+                cofins_item, "CST"
+            ).text = produto_servico.cofins_modalidade
+            etree.SubElement(cofins_item, "vBC").text = "{:.2f}".format(
+                produto_servico.cofins_valor_base_calculo or 0
+            )
+            etree.SubElement(cofins_item, "pCOFINS").text = "{:.2f}".format(
+                produto_servico.cofins_aliquota_percentual or 0
+            )
+            etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
+                produto_servico.cofins_valor
+            )
+        elif produto_servico.cofins_modalidade == "03":
+            cofins_item = etree.SubElement(cofins, "COFINSQtde")
+            etree.SubElement(
+                cofins_item, "CST"
+            ).text = produto_servico.cofins_modalidade
+            etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
+                produto_servico.quantidade_comercial
+            )
+            etree.SubElement(cofins_item, "vAliqProd").text = "{:.4f}".format(
+                produto_servico.cofins_aliquota_reais
+            )
+            etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
+                produto_servico.cofins_valor
+            )
+        else:
+            cofins_item = etree.SubElement(cofins, "COFINSOutr")
+            etree.SubElement(
+                cofins_item, "CST"
+            ).text = produto_servico.cofins_modalidade
+            if produto_servico.cofins_aliquota_reais > 0:
+                etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
+                    produto_servico.quantidade_comercial
+                )
+                etree.SubElement(cofins_item, "vAliqProd").text = "{:.4f}".format(
+                    produto_servico.cofins_aliquota_reais or 0
+                )
+            else:
                 etree.SubElement(cofins_item, "vBC").text = "{:.2f}".format(
                     produto_servico.cofins_valor_base_calculo or 0
                 )
                 etree.SubElement(cofins_item, "pCOFINS").text = "{:.2f}".format(
                     produto_servico.cofins_aliquota_percentual or 0
                 )
-                etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
-                    produto_servico.cofins_valor
-                )
-            elif produto_servico.cofins_modalidade == "03":
-                cofins_item = etree.SubElement(cofins, "COFINSQtde")
-                etree.SubElement(
-                    cofins_item, "CST"
-                ).text = produto_servico.cofins_modalidade
-                etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
-                    produto_servico.quantidade_comercial
-                )
-                etree.SubElement(cofins_item, "vAliqProd").text = "{:.4f}".format(
-                    produto_servico.cofins_aliquota_reais
-                )
-                etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
-                    produto_servico.cofins_valor
-                )
-            else:
-                cofins_item = etree.SubElement(cofins, "COFINSOutr")
-                etree.SubElement(
-                    cofins_item, "CST"
-                ).text = produto_servico.cofins_modalidade
-                if produto_servico.cofins_aliquota_reais > 0:
-                    etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
-                        produto_servico.quantidade_comercial
-                    )
-                    etree.SubElement(cofins_item, "vAliqProd").text = "{:.4f}".format(
-                        produto_servico.cofins_aliquota_reais or 0
-                    )
-                else:
-                    etree.SubElement(cofins_item, "vBC").text = "{:.2f}".format(
-                        produto_servico.cofins_valor_base_calculo or 0
-                    )
-                    etree.SubElement(cofins_item, "pCOFINS").text = "{:.2f}".format(
-                        produto_servico.cofins_aliquota_percentual or 0
-                    )
-                etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
-                    produto_servico.cofins_valor or 0
-                )
+            etree.SubElement(cofins_item, "vCOFINS").text = "{:.2f}".format(
+                produto_servico.cofins_valor or 0
+            )
 
-                # COFINSST
-                # cofins_item = etree.SubElement(cofins, 'COFINSOutr')
-                # etree.SubElement(cofins_item, 'vBC').text = produto_servico
-                #   .cofins_valor_base_calculo
-                # etree.SubElement(cofins_item, 'pCOFINS').text = produto_servico
-                #   .cofins_aliquota_percentual
-                # etree.SubElement(cofins_item, 'qBCProd').text = produto_servico
-                #   .quantidade_comercial
-                # etree.SubElement(cofins_item, 'vAliqProd').text = produto_servico
-                #   .cofins_aliquota_percentual
-                # etree.SubElement(cofins_item, 'vCOFINS').text = produto_servico.cofins_valor
+            # COFINSST
+            # cofins_item = etree.SubElement(cofins, 'COFINSOutr')
+            # etree.SubElement(cofins_item, 'vBC').text = produto_servico
+            #   .cofins_valor_base_calculo
+            # etree.SubElement(cofins_item, 'pCOFINS').text = produto_servico
+            #   .cofins_aliquota_percentual
+            # etree.SubElement(cofins_item, 'qBCProd').text = produto_servico
+            #   .quantidade_comercial
+            # etree.SubElement(cofins_item, 'vAliqProd').text = produto_servico
+            #   .cofins_aliquota_percentual
+            # etree.SubElement(cofins_item, 'vCOFINS').text = produto_servico.cofins_valor
 
     def _serializar_imposto_importacao(
         self, produto_servico, modelo, tag_raiz="imposto", retorna_string=True

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -158,6 +158,7 @@ class SerializacaoXML(Serializacao):
             cliente.numero_documento
         )
         if not self._so_cpf:
+            etree.SubElement(raiz, "xNome").text = cliente.razao_social
             endereco = etree.SubElement(raiz, "enderDest")
             etree.SubElement(endereco, "xLgr").text = cliente.endereco_logradouro
             etree.SubElement(endereco, "nro").text = cliente.endereco_numero
@@ -179,8 +180,7 @@ class SerializacaoXML(Serializacao):
             )
             if cliente.endereco_telefone:
                 etree.SubElement(endereco, "fone").text = cliente.endereco_telefone
-
-        if cliente.razao_social:
+        elif cliente.razao_social:
             etree.SubElement(raiz, "xNome").text = cliente.razao_social
             
         # Indicador da IE do destinatário:

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -2001,21 +2001,11 @@ class SerializacaoQrcode(object):
                 url_chave = NFCE[uf]["HOMOLOGACAO"] + NFCE[uf]["URL"]
         # adicionta tag infNFeSupl com qrcode
         info = etree.Element("infNFeSupl")
-        etree.SubElement(info, "qrCode").text = "<![CDATA[" + qrcode.strip() + "]]>"
+        etree.SubElement(info, "qrCode").text = etree.CDATA(qrcode.strip())
         etree.SubElement(info, "urlChave").text = url_chave
+        
         nfe.insert(1, info)
-        # correção da tag qrCode, retira caracteres pois e CDATA
-        tnfe = (
-            etree.tostring(nfe, encoding="unicode")
-            .replace("\n", "")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("amp;", "")
-        )
-        etree.tostring(nfe.find(".//qrCode"), encoding="unicode").replace(
-            "\n", ""
-        ).replace("&lt;", "<").replace("&gt;", ">").replace("amp;", "")
-        nfe = etree.fromstring(tnfe)
+
         # retorna nfe com o qrcode incluido NT2015/002 e qrcode
         if return_qr:
             return nfe, qrcode.strip()

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -477,7 +477,7 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(icms_item, "modBC").text = str(
                 produto_servico.icms_modalidade_determinacao_bc
             )
-            etree.SubElement(icms_item, "vBC").text = str(
+            etree.SubElement(icms_item, "vBC").text = "{:.2f}".format(
                 produto_servico.icms_valor_base_calculo
             )  # Valor da BC do ICMS
             etree.SubElement(icms_item, "pICMS").text = "{:.2f}".format(
@@ -513,7 +513,7 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(icms_item, "modBC").text = str(
                 produto_servico.icms_modalidade_determinacao_bc
             )
-            etree.SubElement(icms_item, "vBC").text = str(
+            etree.SubElement(icms_item, "vBC").text = "{:.2f}".format(
                 produto_servico.icms_valor_base_calculo
             )  # Valor da BC do ICMS
             etree.SubElement(icms_item, "pICMS").text = "{:.2f}".format(
@@ -1617,7 +1617,7 @@ class SerializacaoXML(Serializacao):
         etree.SubElement(icms_total, "vOutro").text = "{:.2f}".format(
             nota_fiscal.totais_icms_outras_despesas_acessorias
         )
-        etree.SubElement(icms_total, "vNF").text = str(
+        etree.SubElement(icms_total, "vNF").text = "{:.2f}".format(
             nota_fiscal.totais_icms_total_nota
         )
         if nota_fiscal.totais_tributos_aproximado:

--- a/tests/test_nfce_serializacao.py
+++ b/tests/test_nfce_serializacao.py
@@ -109,7 +109,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("1.01"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -139,7 +138,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("0.00"),
             cofins_aliquota_percentual=Decimal("0.00"),
             cofins_valor=Decimal("0.00"),
-            valor_tributos_aprox="1.01",
+            valor_tributos_aprox=Decimal("1.01"),
             informacoes_adicionais="Informações adicionais",
         )
 

--- a/tests/test_nfce_serializacao.py
+++ b/tests/test_nfce_serializacao.py
@@ -416,7 +416,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, "0")
         self.assertEqual(CST, "00")
         self.assertEqual(modBC, "0")
-        self.assertEqual(vBC, "0")
+        self.assertEqual(vBC, "0.00")
         self.assertEqual(pICMS, "0.00")
         self.assertEqual(vICMS, "0.00")
         self.assertEqual(pFCP, None)

--- a/tests/test_nfce_serializacao_sem_cliente.py
+++ b/tests/test_nfce_serializacao_sem_cliente.py
@@ -363,7 +363,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, "0")
         self.assertEqual(CST, "00")
         self.assertEqual(modBC, "0")
-        self.assertEqual(vBC, "0")
+        self.assertEqual(vBC, "0.00")
         self.assertEqual(pICMS, "0.00")
         self.assertEqual(vICMS, "0.00")
         self.assertEqual(pFCP, None)

--- a/tests/test_nfce_serializacao_sem_cliente.py
+++ b/tests/test_nfce_serializacao_sem_cliente.py
@@ -92,7 +92,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("1.01"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -122,7 +121,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("0.00"),
             cofins_aliquota_percentual=Decimal("0.00"),
             cofins_valor=Decimal("0.00"),
-            valor_tributos_aprox="1.01",
+            valor_tributos_aprox=Decimal("1.01"),
             informacoes_adicionais="Informações adicionais",
         )
 

--- a/tests/test_nfce_serializacao_somente_cpf.py
+++ b/tests/test_nfce_serializacao_somente_cpf.py
@@ -101,7 +101,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("1.01"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -131,7 +130,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("0.00"),
             cofins_aliquota_percentual=Decimal("0.00"),
             cofins_valor=Decimal("0.00"),
-            valor_tributos_aprox="1.01",
+            valor_tributos_aprox=Decimal("1.01"),
             informacoes_adicionais="Informações adicionais",
         )
 

--- a/tests/test_nfce_serializacao_somente_cpf.py
+++ b/tests/test_nfce_serializacao_somente_cpf.py
@@ -378,7 +378,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, "0")
         self.assertEqual(CST, "00")
         self.assertEqual(modBC, "0")
-        self.assertEqual(vBC, "0")
+        self.assertEqual(vBC, "0.00")
         self.assertEqual(pICMS, "0.00")
         self.assertEqual(vICMS, "0.00")
         self.assertEqual(pFCP, None)

--- a/tests/test_nfe_serializacao_csosn_101.py
+++ b/tests/test_nfe_serializacao_csosn_101.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -146,7 +145,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_102.py
+++ b/tests/test_nfe_serializacao_csosn_102.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -144,7 +143,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_103.py
+++ b/tests/test_nfe_serializacao_csosn_103.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -144,7 +143,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_201.py
+++ b/tests/test_nfe_serializacao_csosn_201.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -155,7 +154,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_202.py
+++ b/tests/test_nfe_serializacao_csosn_202.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -151,7 +150,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_203.py
+++ b/tests/test_nfe_serializacao_csosn_203.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -151,7 +150,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_300.py
+++ b/tests/test_nfe_serializacao_csosn_300.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -144,7 +143,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_400.py
+++ b/tests/test_nfe_serializacao_csosn_400.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -144,7 +143,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_500.py
+++ b/tests/test_nfe_serializacao_csosn_500.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -144,7 +143,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_csosn_900.py
+++ b/tests/test_nfe_serializacao_csosn_900.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -159,7 +158,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_00.py
+++ b/tests/test_nfe_serializacao_cst_00.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -142,7 +141,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_00.py
+++ b/tests/test_nfe_serializacao_cst_00.py
@@ -265,7 +265,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, "0")
         self.assertEqual(CST, "00")
         self.assertEqual(modBC, "0")
-        self.assertEqual(vBC, "0")
+        self.assertEqual(vBC, "0.00")
         self.assertEqual(pICMS, "0.00")
         self.assertEqual(vICMS, "0.00")
         # self.assertEqual(pFCP, '0.00')

--- a/tests/test_nfe_serializacao_cst_10.py
+++ b/tests/test_nfe_serializacao_cst_10.py
@@ -278,7 +278,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, "0")
         self.assertEqual(CST, "10")
         self.assertEqual(modBC, "0")
-        self.assertEqual(vBC, "0")
+        self.assertEqual(vBC, "0.00")
         self.assertEqual(pICMS, "0.00")
         self.assertEqual(vICMS, "0.00")
         # self.assertEqual(pFCP, '0.00')

--- a/tests/test_nfe_serializacao_cst_10.py
+++ b/tests/test_nfe_serializacao_cst_10.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -142,7 +141,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_20.py
+++ b/tests/test_nfe_serializacao_cst_20.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -142,7 +141,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_30.py
+++ b/tests/test_nfe_serializacao_cst_30.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -148,7 +147,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_40.py
+++ b/tests/test_nfe_serializacao_cst_40.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_41.py
+++ b/tests/test_nfe_serializacao_cst_41.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_50.py
+++ b/tests/test_nfe_serializacao_cst_50.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_51.py
+++ b/tests/test_nfe_serializacao_cst_51.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_60.py
+++ b/tests/test_nfe_serializacao_cst_60.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_70.py
+++ b/tests/test_nfe_serializacao_cst_70.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_cst_90.py
+++ b/tests/test_nfe_serializacao_cst_90.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -136,7 +135,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             icms_csosn="",
             pis_modalidade="07",
             cofins_modalidade="07",
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_geral.py
+++ b/tests/test_nfe_serializacao_geral.py
@@ -112,7 +112,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
-            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -142,7 +141,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal("117.00"),
             cofins_aliquota_percentual=Decimal("3.00"),
             cofins_valor=Decimal("3.51"),
-            valor_tributos_aprox="21.06",
+            valor_tributos_aprox=Decimal("21.06"),
             numero_pedido="12345",
             numero_item="1",
             nfci="12345678-AAAA-FFFF-1234-000000000000",

--- a/tests/test_nfe_serializacao_ii_di_ipi.py
+++ b/tests/test_nfe_serializacao_ii_di_ipi.py
@@ -275,7 +275,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(orig, '0')
         self.assertEqual(CST, '00')
         self.assertEqual(modBC, '0')
-        self.assertEqual(vBC, '0')
+        self.assertEqual(vBC, '0.00')
         self.assertEqual(pICMS, '0.00')
         self.assertEqual(vICMS, '0.00')
         # self.assertEqual(pFCP, '0.00')

--- a/tests/test_nfe_serializacao_ii_di_ipi.py
+++ b/tests/test_nfe_serializacao_ii_di_ipi.py
@@ -119,7 +119,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             processo_emissao='0',  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco='Mensagem complementar',
-            totais_tributos_aproximado=Decimal('21.06'),
         )
 
         # Adicionar informações da Declaração de Importação
@@ -179,7 +178,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             cofins_valor_base_calculo=Decimal('117.00'),
             cofins_aliquota_percentual=Decimal('3.00'),
             cofins_valor=Decimal('3.51'),
-            valor_tributos_aprox='21.06',
+            valor_tributos_aprox=Decimal('21.06'),
             numero_pedido='12345',
             numero_item='1',
             nfci='12345678-AAAA-FFFF-1234-000000000000',


### PR DESCRIPTION
FIX: Corrigido problema de exception com mensagem vazia quando o campo `cliente.inscricao_estadual`esta nulo e o `indidacador_ie` != 2 ou `not client.isento_icms`, tornando dificil a identificação doi problema.

FIX: NFC-e deve permitir informar apenas o CPF e o Nome, no entanto não estava sendo gerado o nome do destinatario caso informado.

FIX: removido validação incorreta onde não permitia PIS/COFINS para NFC-e

ADDED: adicionado tag EXTIPI na serialização do XML

REFACTORY: removido prop `pis_situacao_tributaria` não utilizada no objeto `NotaFiscalProduto` e adicionado `pis_modalidade` que é utilizado pela serialização, esta incongruencia gerava confusão na hora de informar os dados do pis.