### PR TITLE
Atualização para suporte da nova versão signxml

### DIFF
--- a/pynfe/entidades/certificado.py
+++ b/pynfe/entidades/certificado.py
@@ -64,14 +64,11 @@ class CertificadoA1(Certificado):
             (
                 chave,
                 cert,
-            ) = pkcs12.load_key_and_certificates(
-                cert_conteudo, senha
-            )[:2]
+            ) = pkcs12.load_key_and_certificates(cert_conteudo, senha)[:2]
         except Exception as e:
             if "invalid password" in str(e).lower():
                 raise Exception(
-                    "Falha ao carregar certificado digital A1. Verifique a senha do"
-                    " certificado."
+                    "Falha ao carregar certificado digital A1. Verifique a senha do" " certificado."
                 ) from e
             else:
                 raise Exception(
@@ -84,9 +81,7 @@ class CertificadoA1(Certificado):
                 arqcert.write(cert.public_bytes(Encoding.PEM))
             with tempfile.NamedTemporaryFile(delete=False) as arqchave:
                 arqchave.write(
-                    chave.private_bytes(
-                        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
-                    )
+                    chave.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
                 )
             self.arquivos_temp.append(arqchave.name)
             self.arquivos_temp.append(arqcert.name)
@@ -94,14 +89,8 @@ class CertificadoA1(Certificado):
         else:
             # Certificado
             cert = cert.public_bytes(Encoding.PEM).decode("utf-8")
-            cert = cert.replace("\n", "")
-            cert = cert.replace("-----BEGIN CERTIFICATE-----", "")
-            cert = cert.replace("-----END CERTIFICATE-----", "")
-
             # Chave, string decodificada da chave privada
-            chave = chave.private_bytes(
-                Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
-            )
+            chave = chave.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
 
             return chave, cert
 

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -3,7 +3,6 @@ import signxml
 
 from pynfe.entidades import CertificadoA1
 from pynfe.utils import CustomXMLSigner, etree, remover_acentos
-from pynfe.utils.flags import NAMESPACE_SIG
 
 
 class Assinatura(object):
@@ -48,14 +47,6 @@ class AssinaturaA1(Assinatura):
 
         ref_uri = ("#%s" % reference) if reference else None
         signed_root = signer.sign(xml, key=self.key, cert=self.cert, reference_uri=ref_uri)
-
-        ns = {"ns": NAMESPACE_SIG}
-
-        # coloca o certificado na tag X509Data/X509Certificate
-        cert = self.cert
-        cert = cert.replace("\n", "")
-        tagX509Data = signed_root.find(".//ns:X509Data", namespaces=ns)
-        etree.SubElement(tagX509Data, "X509Certificate").text = cert
         if retorna_string:
             return etree.tostring(signed_root, encoding="unicode", pretty_print=False)
         else:

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -54,8 +54,6 @@ class AssinaturaA1(Assinatura):
         # coloca o certificado na tag X509Data/X509Certificate
         cert = self.cert
         cert = cert.replace("\n", "")
-        cert = cert.replace("-----BEGIN CERTIFICATE-----", "")
-        cert = cert.replace("-----END CERTIFICATE-----", "")
         tagX509Data = signed_root.find(".//ns:X509Data", namespaces=ns)
         etree.SubElement(tagX509Data, "X509Certificate").text = cert
         if retorna_string:

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -51,12 +51,11 @@ class AssinaturaA1(Assinatura):
 
         ns = {"ns": NAMESPACE_SIG}
 
+        # coloca o certificado na tag X509Data/X509Certificate
         cert = self.cert
         cert = cert.replace("\n", "")
         cert = cert.replace("-----BEGIN CERTIFICATE-----", "")
         cert = cert.replace("-----END CERTIFICATE-----", "")
-
-        # coloca o certificado na tag X509Data/X509Certificate
         tagX509Data = signed_root.find(".//ns:X509Data", namespaces=ns)
         etree.SubElement(tagX509Data, "X509Certificate").text = cert
         if retorna_string:

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from pynfe.utils import etree, remover_acentos, CustomXMLSigner
-from pynfe.utils.flags import NAMESPACE_SIG
 import signxml
+
 from pynfe.entidades import CertificadoA1
+from pynfe.utils import CustomXMLSigner, etree, remover_acentos
+from pynfe.utils.flags import NAMESPACE_SIG
 
 
 class Assinatura(object):
@@ -31,9 +32,7 @@ class AssinaturaA1(Assinatura):
         reference = xml.find(".//*[@Id]").attrib["Id"]
 
         # retira acentos
-        xml_str = remover_acentos(
-            etree.tostring(xml, encoding="unicode", pretty_print=False)
-        )
+        xml_str = remover_acentos(etree.tostring(xml, encoding="unicode", pretty_print=False))
         xml = etree.fromstring(xml_str)
 
         signer = CustomXMLSigner(
@@ -48,14 +47,18 @@ class AssinaturaA1(Assinatura):
         signer.namespaces = ns
 
         ref_uri = ("#%s" % reference) if reference else None
-        signed_root = signer.sign(
-            xml, key=self.key, cert=self.cert, reference_uri=ref_uri
-        )
+        signed_root = signer.sign(xml, key=self.key, cert=self.cert, reference_uri=ref_uri)
 
         ns = {"ns": NAMESPACE_SIG}
+
+        cert = self.cert
+        cert = cert.replace("\n", "")
+        cert = cert.replace("-----BEGIN CERTIFICATE-----", "")
+        cert = cert.replace("-----END CERTIFICATE-----", "")
+
         # coloca o certificado na tag X509Data/X509Certificate
         tagX509Data = signed_root.find(".//ns:X509Data", namespaces=ns)
-        etree.SubElement(tagX509Data, "X509Certificate").text = self.cert
+        etree.SubElement(tagX509Data, "X509Certificate").text = cert
         if retorna_string:
             return etree.tostring(signed_root, encoding="unicode", pretty_print=False)
         else:

--- a/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_resposta_v03.py
@@ -305,7 +305,7 @@ CTD_ANON_._AddElement(
 )
 
 
-def _BuildAutomaton_():
+def _BuildAutomaton_(): # noqa
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_

--- a/pynfe/utils/nfse/ginfes/servico_consultar_nfse_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_nfse_resposta_v03.py
@@ -294,7 +294,7 @@ CTD_ANON_._AddElement(
 )
 
 
-def _BuildAutomaton_():
+def _BuildAutomaton_(): # noqa
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_


### PR DESCRIPTION
signxml [recebeu uma nova versão (4.0)](https://github.com/XML-Security/signxml/releases/tag/v4.0.0) o qual substituíram internamente o PyOpenSSL pelo Cryptography, no entanto isso acusou incompatibilidade com algumas parte do código:

1. Não pode mais remover o `-----BEGIN CERTIFICATE-----` e `-----END CERTIFICATE-----` pois eles são usados para validar o inicio e fim do certificado, que agora possui um throw dentro do código quando não encontra as tags: https://github.com/XML-Security/signxml/commit/b42c093f72ba0253256a7d07a842be31a95a23c6
2. signer.sign utilizando o Cryptography automaticamente preenche o X509Certificate com o certificado, sendo não mais necessário esse código dentro do PyNFE

Obs: Favor fazer Squash and Merge para evitar merge dos commits de teste realizados.