### PR TITLE
ajuste busca de outros documentos no consulta cadastro

### DIFF
--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -238,11 +238,12 @@ class ComunicacaoSefaz(Comunicacao):
 
         return self._post(url, xml)
 
-    def consulta_cadastro(self, modelo, cnpj):
+    def consulta_cadastro(self, modelo, documento, tipo):
         """
         Consulta de cadastro
         :param modelo: Modelo da nota
-        :param cnpj: CNPJ da empresa
+        :param documento: Documento (CNPJ, CPF ou IE)
+        :tipo do documento: 1: CNPJ, 2: CPF, 3: IE
         :return:
         """
         # UF que utilizam a SVRS - Sefaz Virtual do RS:
@@ -265,7 +266,18 @@ class ComunicacaoSefaz(Comunicacao):
         info = etree.SubElement(raiz, "infCons")
         etree.SubElement(info, "xServ").text = "CONS-CAD"
         etree.SubElement(info, "UF").text = self.uf.upper()
-        etree.SubElement(info, "CNPJ").text = cnpj
+
+        tipo_doc = None
+
+        if tipo == 1:
+            tipo_doc = 'CNPJ'
+        elif tipo == 2:
+            tipo_doc = 'CPF'
+        elif tipo == 3:
+            tipo_doc = 'IE'
+
+        etree.SubElement(info, tipo_doc).text = documento
+        
         # etree.SubElement(info, 'CPF').text = cpf
 
         # Monta XML para envio da requisição

--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -268,8 +268,7 @@ class ComunicacaoSefaz(Comunicacao):
         etree.SubElement(info, "UF").text = self.uf.upper()
         
         # Monta tipo de documento CNPJ, CPF ou IE
-        tipo.upper()
-        etree.SubElement(info, tipo).text = documento
+        etree.SubElement(info, tipo.upper()).text = documento
         
         # etree.SubElement(info, 'CPF').text = cpf
 

--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -266,7 +266,9 @@ class ComunicacaoSefaz(Comunicacao):
         info = etree.SubElement(raiz, "infCons")
         etree.SubElement(info, "xServ").text = "CONS-CAD"
         etree.SubElement(info, "UF").text = self.uf.upper()
-
+        
+        # Monta tipo de documento CNPJ, CPF ou IE
+        tipo.upper()
         etree.SubElement(info, tipo).text = documento
         
         # etree.SubElement(info, 'CPF').text = cpf

--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -238,12 +238,12 @@ class ComunicacaoSefaz(Comunicacao):
 
         return self._post(url, xml)
 
-    def consulta_cadastro(self, modelo, documento, tipo):
+    def consulta_cadastro(self, modelo, documento, tipo='CNPJ'):
         """
         Consulta de cadastro
         :param modelo: Modelo da nota
         :param documento: Documento (CNPJ, CPF ou IE)
-        :tipo do documento: 1: CNPJ, 2: CPF, 3: IE
+        :tipo do documento: CNPJ, CPF, IE
         :return:
         """
         # UF que utilizam a SVRS - Sefaz Virtual do RS:
@@ -267,16 +267,7 @@ class ComunicacaoSefaz(Comunicacao):
         etree.SubElement(info, "xServ").text = "CONS-CAD"
         etree.SubElement(info, "UF").text = self.uf.upper()
 
-        tipo_doc = None
-
-        if tipo == 1:
-            tipo_doc = 'CNPJ'
-        elif tipo == 2:
-            tipo_doc = 'CPF'
-        elif tipo == 3:
-            tipo_doc = 'IE'
-
-        etree.SubElement(info, tipo_doc).text = documento
+        etree.SubElement(info, tipo).text = documento
         
         # etree.SubElement(info, 'CPF').text = cpf
 


### PR DESCRIPTION
este PR realiza melhorias no método de consulta cadastro, anteriormente era possível apenas consultar cadastros pelo CNPJ, após os ajustes agora é possível realizar também pelo CPF e IE.

Ajuste realizado conforme manual da nf-e disponibilizado pela sefaz

![image](https://github.com/user-attachments/assets/656c7663-6df7-4485-bb3c-49f5fcedc4f0)
