### PR TITLE
Adiciona serialização de fatura e duplicatas

### DIFF
--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1774,6 +1774,34 @@ class SerializacaoXML(Serializacao):
                                     lacres, "nLacre"
                                 ).text = lacre.numero_lacre
 
+        # Cobrança
+        if (nota_fiscal.fatura_numero) or (nota_fiscal.duplicatas and len(nota_fiscal.duplicatas) > 0):
+            cobr = etree.SubElement(raiz, "cobr")
+
+            # Fatura 0-1
+            if nota_fiscal.fatura_numero:
+                fat = etree.SubElement(cobr, "fat")
+                etree.SubElement(fat, "nFat").text = nota_fiscal.fatura_numero
+                etree.SubElement(fat, "vOrig").text = "{:.2f}".format(
+                    nota_fiscal.fatura_valor_original
+                )
+                etree.SubElement(fat, "vDesc").text = "{:.2f}".format(
+                    nota_fiscal.fatura_valor_desconto
+                )
+                etree.SubElement(fat, "vLiq").text = "{:.2f}".format(
+                    nota_fiscal.fatura_valor_liquido
+                )
+
+            # Duplicata 0-N
+            if nota_fiscal.duplicatas and len(nota_fiscal.duplicatas) > 0:
+                for num, item in enumerate(nota_fiscal.duplicatas):
+                    dup = etree.SubElement(cobr, "dup")
+                    etree.SubElement(dup, "nDup").text = item.numero
+                    etree.SubElement(dup, "dVenc").text = item.data_vencimento.strftime(
+                        "%Y-%m-%d"
+                    )
+                    etree.SubElement(dup, "vDup").text = "{:.2f}".format(item.valor)
+
         # Pagamento
         """ Obrigatório o preenchimento do Grupo Informações de Pagamento para NF-e e NFC-e.
         Para as notas com finalidade de Ajuste ou Devolução

--- a/tests/test_nfe_serializacao_geral.py
+++ b/tests/test_nfe_serializacao_geral.py
@@ -113,6 +113,10 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("21.06"),
+            fatura_numero="12345",
+            fatura_valor_original=Decimal("117.00"),
+            fatura_valor_desconto=Decimal("0.00"),
+            fatura_valor_liquido=Decimal("117.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -163,7 +167,25 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
+        self.notafiscal.adicionar_duplicata(
+            numero='1',
+            data_vencimento=datetime.datetime(2025, 1, 27, 12, 0, 0, tzinfo=utc),
+            valor=Decimal("39.00"),
+        )
+
+        self.notafiscal.adicionar_duplicata(
+            numero='1',
+            data_vencimento=datetime.datetime(2025, 1, 28, 12, 0, 0, tzinfo=utc),
+            valor=Decimal("39.00"),
+        )
+
+        self.notafiscal.adicionar_duplicata(
+            numero='1',
+            data_vencimento=datetime.datetime(2025, 1, 29, 12, 0, 0, tzinfo=utc),
+            valor=Decimal("39.00"),
+        )
+
         self.notafiscal.adicionar_pagamento(
             t_pag="03",
             x_pag="Cartao Credito",
@@ -396,6 +418,68 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(chave_1, "12345678901234567890123456789012345678900001")
         self.assertEqual(chave_2, "12345678901234567890123456789012345678900002")
 
+    def fatura_test(self):
+        numero_fatura = self.xml_assinado.xpath("//ns:cobr/ns:fat/ns:nFat", namespaces=self.ns)[
+            0
+        ].text
+        valor_original = self.xml_assinado.xpath("//ns:cobr/ns:fat/ns:vOrig", namespaces=self.ns)[
+            0
+        ].text
+        valor_desconto = self.xml_assinado.xpath("//ns:cobr/ns:fat/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        valor_liquido = self.xml_assinado.xpath("//ns:cobr/ns:fat/ns:vLiq", namespaces=self.ns)[
+            0
+        ].text
+
+        self.assertEqual(numero_fatura, "12345")
+        self.assertEqual(valor_original, "117.00")
+        self.assertEqual(valor_desconto, "0.00")
+        self.assertEqual(valor_liquido, "117.00")
+
+    def duplicatas_test(self):
+        numero_duplicata_1 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:nDup", namespaces=self.ns
+        )[0].text
+        data_vencimento_1 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
+        )[0].text
+        valor_duplicata_1 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
+        )[0].text
+
+        numero_duplicata_2 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:nDup", namespaces=self.ns
+        )[1].text
+        data_vencimento_2 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
+        )[1].text
+        valor_duplicata_2 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
+        )[1].text
+
+        numero_duplicata_3 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:nDup", namespaces=self.ns
+        )[2].text
+        data_vencimento_3 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
+        )[2].text
+        valor_duplicata_3 = self.xml_assinado.xpath(
+            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
+        )[2].text
+
+        self.assertEqual(numero_duplicata_1, "1")
+        self.assertEqual(data_vencimento_1, "2025-01-27")
+        self.assertEqual(valor_duplicata_1, "39.00")
+
+        self.assertEqual(numero_duplicata_2, "1")
+        self.assertEqual(data_vencimento_2, "2025-01-28")
+        self.assertEqual(valor_duplicata_2, "39.00")
+
+        self.assertEqual(numero_duplicata_3, "1")
+        self.assertEqual(data_vencimento_3, "2025-01-29")
+        self.assertEqual(valor_duplicata_3, "39.00")
+
     def responsavel_tecnico_test(self):
         cnpj = self.xml_assinado.xpath("//ns:infRespTec/ns:CNPJ", namespaces=self.ns)[
             0
@@ -437,6 +521,8 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.dados_emitente_test()
         self.dados_destinatario_test()
         self.notas_referenciadas_test()
+        self.fatura_test()
+        self.duplicatas_test()
         self.responsavel_tecnico_test()
         self.digestvalue_da_assinatura_test()
 


### PR DESCRIPTION
Issue #350 

Informar os dados de Fatura na classe NotaFiscal:
```
     self.notafiscal = NotaFiscal(
            emitente=self.emitente,
            cliente=self.cliente,
            ...
            fatura_numero="12345",
            fatura_valor_original=Decimal("117.00"),
            fatura_valor_desconto=Decimal("0.00"),
            fatura_valor_liquido=Decimal("117.00"),
```

Adicionar as duplicatas na função própria, pois é 0-N:

```
        self.notafiscal.adicionar_duplicata(
            numero='1',
            data_vencimento=datetime.datetime(2025, 1, 27, 12, 0, 0, tzinfo=utc),
            valor=Decimal("39.00"),
        )


```
