### PR TITLE
Adiciona lib extra para impressão de documentos fiscais

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Lint
 Documentação
 -----------
 - https://github.com/TadaSoftware/PyNFe/wiki
-- http://pynfe.readthedocs.org/pt/latest/
 
 
 Suporte

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Dependências
   - Biblioteca para a comunicação com os webservices via wsdl
 - pyxb (*apenas para NFS-e)
   - Biblioteca para geração de bindings a partir de XML Schema(xsd)
+- brazilfiscalreport (*apenas para Impressão)
+  - Biblioteca para impressão de DANFE e DAMDFE
 
 Referências
 -----------
@@ -105,24 +107,30 @@ Referências
 - Validador de assinaturas
   - https://servicos.receita.fazenda.gov.br/servicos/assinadoc/ValidadorAssinaturas.app/valida.aspx
 
+- Impressão de Documentos Fiscais
+  - https://github.com/Engenere/BrazilFiscalReport
+  - https://engenere.github.io/BrazilFiscalReport
+
+
 Instalação
 -----------
 
-```sh
-pip install pynfe
-```
+* Instalar a versão estável: `pip install pynfe`
 
-Instalar versão de desenvolvimento:
+* Instalar as dependências da NFSe: `pip install 'pynfe[nfse]'`
 
+* Instalar as dependências para Impressão: `pip install 'pynfe[impressao]'`
+
+* Instalar versão de desenvolvimento:
 ```sh
 pip install https://github.com/TadaSoftware/PyNFe/archive/refs/heads/main.zip
 ```
 
-Opcional para NFS-e:
-
+* Opcional para NFS-e:
 ```sh
 pip install --user -r https://github.com/TadaSoftware/PyNFe/blob/main/requirements-nfse.txt
 ```
+
 
 Exemplos de uso
 -----------

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setuptools.setup(
             "suds-jurko",
             "pyxb==1.2.4",
         ],
+        "impressao": [
+            "brazilfiscalreport[damdfe]"
+        ]
     },
     zip_safe=False,
     python_requires=">=3.8",


### PR DESCRIPTION
Adicionei o BrazilFiscalReport como dependência extra (não obrigatória) para impressão de documentos fiscais em PDF a partir do XML nativamente com python.

Documentação:
  - https://github.com/Engenere/BrazilFiscalReport
  - https://engenere.github.io/BrazilFiscalReport

O uso é muito simples e a geração é rápida, exemplo:

```python
from brazilfiscalreport.danfe import Danfe

xml_file_path = 'nfe.xml'

with open(xml_file_path, "r", encoding="utf8") as file:
    xml_content = file.read()

danfe = Danfe(xml=xml_content)
danfe.output('output_danfe.pdf')
```

@antoniospneto



