### PR TITLE
Adicionei municipio Boa Esperança do Norte - MT ao arquivo MunIBGE-UF51

### DIFF
--- a/pynfe/data/MunIBGE/MunIBGE-UF51.txt
+++ b/pynfe/data/MunIBGE/MunIBGE-UF51.txt
@@ -1,4 +1,4 @@
-﻿5100102	Acorizal
+5100102	Acorizal
 5100201	Água Boa
 5100250	Alta Floresta
 5100300	Alto Araguaia
@@ -16,6 +16,7 @@
 5101704	Barra do Bugres
 5101803	Barra do Garças
 5101852	Bom Jesus do Araguaia
+5108404 Boa Esperança do Norte
 5101902	Brasnorte
 5102504	Cáceres
 5102603	Campinápolis
@@ -139,3 +140,4 @@
 5108857	Nova Marilândia
 5108907	Nova Maringá
 5108956	Nova Monte Verde
+


### PR DESCRIPTION
Este pull request adiciona o município de **Boa Esperança do Norte - MT** ao arquivo `MunIBGE-UF51.txt`, conforme publicado no **Informe Técnico 2025.001 v.1.00** do ENCAT.

- Código IBGE: `5108404`
- Fonte oficial: [Informativo SEFAZ](https://www.nfe.fazenda.gov.br/portal/informe.aspx?ehCTG=false)

