### PR TITLE
Tipagem do AssinaturaA1.assinar() e melhorias para a assinatura

### DIFF
--- a/pynfe/entidades/certificado.py
+++ b/pynfe/entidades/certificado.py
@@ -46,10 +46,15 @@ class CertificadoA1(Certificado):
         try:
             with open(self.caminho_arquivo, "rb") as cert_arquivo:
                 cert_conteudo = cert_arquivo.read()
-        except (PermissionError, FileNotFoundError) as exc:
-            raise Exception(
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
                 """Falha ao abrir arquivo do certificado digital A1.
-                Verifique local e permissoes do arquivo."""
+                Verifique o local do arquivo."""
+            ) from exc
+        except PermissionError as exc:
+            raise PermissionError(
+                """Falha ao abrir arquivo do certificado digital A1.
+                Verifique as permissoes do arquivo."""
             ) from exc
         except Exception as exc:
             raise Exception(

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -26,7 +26,7 @@ class AssinaturaA1(Assinatura):
     def __init__(self, certificado, senha):
         self.key, self.cert = CertificadoA1(certificado).separar_arquivo(senha)
 
-    def assinar(self, xml, retorna_string=False):
+    def assinar(self, xml: etree._Element, retorna_string=False) -> str | etree._Element:
         # busca tag que tem id(reference_uri), logo nao importa se tem namespace
         reference = xml.find(".//*[@Id]").attrib["Id"]
 

--- a/pynfe/processamento/assinatura.py
+++ b/pynfe/processamento/assinatura.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import signxml
+from typing import Union
 
 from pynfe.entidades import CertificadoA1
 from pynfe.utils import CustomXMLSigner, etree, remover_acentos
@@ -26,7 +27,7 @@ class AssinaturaA1(Assinatura):
     def __init__(self, certificado, senha):
         self.key, self.cert = CertificadoA1(certificado).separar_arquivo(senha)
 
-    def assinar(self, xml: etree._Element, retorna_string=False) -> str | etree._Element:
+    def assinar(self, xml: etree._Element, retorna_string=False) -> Union[str, etree._Element]:
         # busca tag que tem id(reference_uri), logo nao importa se tem namespace
         reference = xml.find(".//*[@Id]").attrib["Id"]
 

--- a/tests/test_certificadoA1.py
+++ b/tests/test_certificadoA1.py
@@ -25,7 +25,7 @@ class CertificadoTestCase(unittest.TestCase):
         self.a1.excluir()
 
     def test_exception_certificado_filenotfounderror(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(FileNotFoundError) as context:
             self.a1 = CertificadoA1(self.certificado_incorreto)
             self.a1.separar_arquivo(
                 senha=self.senha_incorreto, caminho=self.certificado_incorreto
@@ -34,7 +34,7 @@ class CertificadoTestCase(unittest.TestCase):
             str(context.exception),
             (
                 """Falha ao abrir arquivo do certificado digital A1.
-                Verifique local e permissoes do arquivo."""
+                Verifique o local do arquivo."""
             ),
         )
 

--- a/tests/test_nfse_serializacao_ginfes.py
+++ b/tests/test_nfse_serializacao_ginfes.py
@@ -1,7 +1,5 @@
 import unittest
-
 import re
-import pyxb.namespace
 
 from pynfe.entidades.notafiscal import NotaFiscalServico
 from pynfe.processamento.serializacao import SerializacaoNfse
@@ -13,18 +11,15 @@ class SerializacaoNFSeGinfesTestCase(unittest.TestCase):
         nfse = SerializacaoNFSeTest.get_notafiscal_servico()
         nfse_xml = self._serializa_nfse(nfse)
 
-        # TODO: assinatura digital
-        # config = SerializacaoNFSeTest.get_config()
-        # nfse_xml_assinado = SerializacaoNFSeTest.assina_xml(config, nfse_xml)
+        nfse_xml_assinado = SerializacaoNFSeTest.assina_xml(nfse_xml)
+        nfse_esperada = self._get_nfse_esperada()
 
-        self.maxDiff = None
-        result = self._get_nfse_esperada(nfse)
-
-        nfse_xml = self._ajusta_xml_test(nfse_xml)
-        result = self._ajusta_xml_test(result)
+        nfse_xml_assinado = self._ajusta_xml_test(nfse_xml_assinado)
+        nfse_esperada = self._ajusta_xml_test(nfse_esperada)
 
         # Teste do conteúdo das tags do XML
-        self.assertEqual(nfse_xml, result)
+        self.maxDiff = None
+        self.assertEqual(nfse_xml_assinado, nfse_esperada)
 
         # Testa a validação do XML com os schemas XSD
         # SerializacaoNFSeTest.validacao_com_xsd_do_xml_gerado_sem_processar(
@@ -34,8 +29,7 @@ class SerializacaoNFSeGinfesTestCase(unittest.TestCase):
         #     'pynfe/data/XSDs/NFS-e/Ginfes'
         # )
 
-        # Limpa o Namespace para não gerar conflito com outros testes
-        pyxb.namespace.Namespace._Namespace__Registry.clear()
+        SerializacaoNFSeTest.limpa_namespace()
 
     def _serializa_nfse(self, nfse: NotaFiscalServico) -> str:
         serializador = SerializacaoNfse('ginfes')
@@ -48,85 +42,104 @@ class SerializacaoNFSeGinfesTestCase(unittest.TestCase):
     def _ajusta_xml_test(self, xml: str) -> str:
         return re.sub(r'<(ns1:EnviarLoteRpsEnvio)[^>]*>', r'<\1>', xml)
 
-    def _get_nfse_esperada(self, nfse: NotaFiscalServico) -> str:
+    def _get_nfse_esperada(self) -> str:
         return SerializacaoNFSeTest.strip_xml(f"""
-            <?xml version="1.0" ?>
-            <ns1:EnviarLoteRpsEnvio xmlns:ns1="http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd" xmlns:ns2="http://www.ginfes.com.br/tipos_v03.xsd">
+            <ns1:EnviarLoteRpsEnvio xmlns:ns1="http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd"
+                xmlns:ns2="http://www.ginfes.com.br/tipos_v03.xsd">
                 <ns1:LoteRps Id="1">
                     <ns2:NumeroLote>1</ns2:NumeroLote>
                     <ns2:Cnpj>99999999999999</ns2:Cnpj>
                     <ns2:InscricaoMunicipal>000000</ns2:InscricaoMunicipal>
                     <ns2:QuantidadeRps>1</ns2:QuantidadeRps>
                     <ns2:ListaRps>
-                    <ns2:Rps>
-                        <ns2:InfRps Id="50">
-                        <ns2:IdentificacaoRps>
-                            <ns2:Numero>50</ns2:Numero>
-                            <ns2:Serie>A1</ns2:Serie>
-                            <ns2:Tipo>1</ns2:Tipo>
-                        </ns2:IdentificacaoRps>
-                        <ns2:DataEmissao>{nfse.data_emissao.isoformat()[:19]}</ns2:DataEmissao>
-                        <ns2:NaturezaOperacao>1</ns2:NaturezaOperacao>
-                        <ns2:OptanteSimplesNacional>1</ns2:OptanteSimplesNacional>
-                        <ns2:IncentivadorCultural>2</ns2:IncentivadorCultural>
-                        <ns2:Status>1</ns2:Status>
-                        <ns2:Servico>
-                            <ns2:Valores>
-                            <ns2:ValorServicos>100.0</ns2:ValorServicos>
-                            <ns2:ValorDeducoes>10.0</ns2:ValorDeducoes>
-                            <ns2:ValorPis>10.0</ns2:ValorPis>
-                            <ns2:ValorCofins>10.0</ns2:ValorCofins>
-                            <ns2:ValorInss>10.0</ns2:ValorInss>
-                            <ns2:ValorIr>10.0</ns2:ValorIr>
-                            <ns2:ValorCsll>10.0</ns2:ValorCsll>
-                            <ns2:IssRetido>1</ns2:IssRetido>
-                            <ns2:ValorIss>10.0</ns2:ValorIss>
-                            <ns2:ValorIssRetido>10.0</ns2:ValorIssRetido>
-                            <ns2:OutrasRetencoes>10.0</ns2:OutrasRetencoes>
-                            <ns2:BaseCalculo>10.0</ns2:BaseCalculo>
-                            <ns2:Aliquota>10.0</ns2:Aliquota>
-                            <ns2:ValorLiquidoNfse>10.0</ns2:ValorLiquidoNfse>
-                            <ns2:DescontoIncondicionado>10.0</ns2:DescontoIncondicionado>
-                            <ns2:DescontoCondicionado>10.0</ns2:DescontoCondicionado>
-                            </ns2:Valores>
-                            <ns2:ItemListaServico>0101</ns2:ItemListaServico>
-                            <ns2:CodigoCnae>6201501</ns2:CodigoCnae>
-                            <ns2:CodigoTributacaoMunicipio>1234</ns2:CodigoTributacaoMunicipio>
-                            <ns2:Discriminacao>Mensalidade</ns2:Discriminacao>
-                            <ns2:CodigoMunicipio>3149309</ns2:CodigoMunicipio>
-                        </ns2:Servico>
-                        <ns2:Prestador>
-                            <ns2:Cnpj>99999999999999</ns2:Cnpj>
-                            <ns2:InscricaoMunicipal>000000</ns2:InscricaoMunicipal>
-                        </ns2:Prestador>
-                        <ns2:Tomador>
-                            <ns2:IdentificacaoTomador>
-                            <ns2:CpfCnpj>
-                                <ns2:Cnpj>99999999999999</ns2:Cnpj>
-                            </ns2:CpfCnpj>
-                            <ns2:InscricaoMunicipal>1234</ns2:InscricaoMunicipal>
-                            </ns2:IdentificacaoTomador>
-                            <ns2:RazaoSocial>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</ns2:RazaoSocial>
-                            <ns2:Endereco>
-                            <ns2:Endereco>Rua tal</ns2:Endereco>
-                            <ns2:Numero>0</ns2:Numero>
-                            <ns2:Complemento>Ao lado de lugar nenhum</ns2:Complemento>
-                            <ns2:Bairro>Centro</ns2:Bairro>
-                            <ns2:CodigoMunicipio>123</ns2:CodigoMunicipio>
-                            <ns2:Uf>MG</ns2:Uf>
-                            <ns2:Cep>33257010</ns2:Cep>
-                            </ns2:Endereco>
-                            <ns2:Contato>
-                            <ns2:Telefone>12365478945</ns2:Telefone>
-                            <ns2:Email>nome@email.com.br</ns2:Email>
-                            </ns2:Contato>
-                        </ns2:Tomador>
-                        </ns2:InfRps>
-                    </ns2:Rps>
+                        <ns2:Rps>
+                            <ns2:InfRps Id="50">
+                                <ns2:IdentificacaoRps>
+                                    <ns2:Numero>50</ns2:Numero>
+                                    <ns2:Serie>A1</ns2:Serie>
+                                    <ns2:Tipo>1</ns2:Tipo>
+                                </ns2:IdentificacaoRps>
+                                <ns2:DataEmissao>{SerializacaoNFSeTest.data_hora}</ns2:DataEmissao>
+                                <ns2:NaturezaOperacao>1</ns2:NaturezaOperacao>
+                                <ns2:OptanteSimplesNacional>1</ns2:OptanteSimplesNacional>
+                                <ns2:IncentivadorCultural>2</ns2:IncentivadorCultural>
+                                <ns2:Status>1</ns2:Status>
+                                <ns2:Servico>
+                                    <ns2:Valores>
+                                        <ns2:ValorServicos>100.0</ns2:ValorServicos>
+                                        <ns2:ValorDeducoes>10.0</ns2:ValorDeducoes>
+                                        <ns2:ValorPis>10.0</ns2:ValorPis>
+                                        <ns2:ValorCofins>10.0</ns2:ValorCofins>
+                                        <ns2:ValorInss>10.0</ns2:ValorInss>
+                                        <ns2:ValorIr>10.0</ns2:ValorIr>
+                                        <ns2:ValorCsll>10.0</ns2:ValorCsll>
+                                        <ns2:IssRetido>1</ns2:IssRetido>
+                                        <ns2:ValorIss>10.0</ns2:ValorIss>
+                                        <ns2:ValorIssRetido>10.0</ns2:ValorIssRetido>
+                                        <ns2:OutrasRetencoes>10.0</ns2:OutrasRetencoes>
+                                        <ns2:BaseCalculo>10.0</ns2:BaseCalculo>
+                                        <ns2:Aliquota>10.0</ns2:Aliquota>
+                                        <ns2:ValorLiquidoNfse>10.0</ns2:ValorLiquidoNfse>
+                                        <ns2:DescontoIncondicionado>10.0</ns2:DescontoIncondicionado>
+                                        <ns2:DescontoCondicionado>10.0</ns2:DescontoCondicionado>
+                                    </ns2:Valores>
+                                    <ns2:ItemListaServico>0101</ns2:ItemListaServico>
+                                    <ns2:CodigoCnae>6201501</ns2:CodigoCnae>
+                                    <ns2:CodigoTributacaoMunicipio>1234</ns2:CodigoTributacaoMunicipio>
+                                    <ns2:Discriminacao>Mensalidade</ns2:Discriminacao>
+                                    <ns2:CodigoMunicipio>3149309</ns2:CodigoMunicipio>
+                                </ns2:Servico>
+                                <ns2:Prestador>
+                                    <ns2:Cnpj>99999999999999</ns2:Cnpj>
+                                    <ns2:InscricaoMunicipal>000000</ns2:InscricaoMunicipal>
+                                </ns2:Prestador>
+                                <ns2:Tomador>
+                                    <ns2:IdentificacaoTomador>
+                                        <ns2:CpfCnpj>
+                                            <ns2:Cnpj>99999999999999</ns2:Cnpj>
+                                        </ns2:CpfCnpj>
+                                        <ns2:InscricaoMunicipal>1234</ns2:InscricaoMunicipal>
+                                    </ns2:IdentificacaoTomador>
+                                    <ns2:RazaoSocial>NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL</ns2:RazaoSocial>
+                                    <ns2:Endereco>
+                                        <ns2:Endereco>Rua tal</ns2:Endereco>
+                                        <ns2:Numero>0</ns2:Numero>
+                                        <ns2:Complemento>Ao lado de lugar nenhum</ns2:Complemento>
+                                        <ns2:Bairro>Centro</ns2:Bairro>
+                                        <ns2:CodigoMunicipio>123</ns2:CodigoMunicipio>
+                                        <ns2:Uf>MG</ns2:Uf>
+                                        <ns2:Cep>33257010</ns2:Cep>
+                                    </ns2:Endereco>
+                                    <ns2:Contato>
+                                        <ns2:Telefone>12365478945</ns2:Telefone>
+                                        <ns2:Email>nome@email.com.br</ns2:Email>
+                                    </ns2:Contato>
+                                </ns2:Tomador>
+                            </ns2:InfRps>
+                        </ns2:Rps>
                     </ns2:ListaRps>
                 </ns1:LoteRps>
-            </ns1:EnviarLoteRpsEnvio>
-        """)
+                <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+                    <SignedInfo>
+                        <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                        <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+                        <Reference URI="#1">
+                            <Transforms>
+                                <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                                <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                            </Transforms>
+                            <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                            <DigestValue>qFoEQUv7n6YrTR3yg3zBBtTR/VU=</DigestValue>
+                        </Reference>
+                    </SignedInfo>
+                    <SignatureValue>fM8cbCN5s31qeu2Oy89keXXh01l9x8gHpQYXrdjz6jtt0CDZ3fBMb7PwDZjUFVKM5U33IeBX8m0RRKJXZuQWWFCI1vux+uoVG7JWhYXfPysjGUNz7LNfr5FkjVWWobI5YzZitY15aDkzwYyeGt/h22dDZim5CooEs4AUI63fwKM=</SignatureValue>
+                    <KeyInfo>
+                        <X509Data>
+                            <X509Certificate>MIICMTCCAZqgAwIBAgIQfYOsIEVuAJ1FwwcTrY0t1DANBgkqhkiG9w0BAQUFADBXMVUwUwYDVQQDHkwAewA1ADkARgAxAEUANAA2ADEALQBEAEQARQA1AC0ANABEADIARgAtAEEAMAAxAEEALQA4ADMAMwAyADIAQQA5AEUAQgA4ADMAOAB9MB4XDTE1MDYxNTA1NDc1N1oXDTE2MDYxNDExNDc1N1owVzFVMFMGA1UEAx5MAHsANQA5AEYAMQBFADQANgAxAC0ARABEAEUANQAtADQARAAyAEYALQBBADAAMQBBAC0AOAAzADMAMgAyAEEAOQBFAEIAOAAzADgAfTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAk41GnqXXLaiOC/y0/cA4tbS+NZCqI+x4EsztgDFvPPlHstiVYcLRkni4i93gK9zoC6g0mh66HMVzAfE8vRNwW5b7m6nWS1SiHBon7/Mqsw4MIq3SC+J/fTbKpqwyfAuH2YZlAiQuQc85fyllAMLh2WrA7JgOLR/5tF3kLtpbHdECAwEAATANBgkqhkiG9w0BAQUFAAOBgQArdh+RyT6VxKGsXk1zhHsgwXfToe6GpTF4W8PHI1+T0WIsNForDhvst6nmQtgAhuZM9rxpOJuNKc+pM29EixpAiZZiRMCSWEItNyEVdUIi+YnKBcAHd88TwO86d126MWQ2O8cu5W1VoDp7hYBYKOnLbYi11/StO+0rzK+oPYAvIw==</X509Certificate>
+                        </X509Data>
+                    </KeyInfo>
+                </Signature>
+            </ns1:EnviarLoteRpsEnvio>""")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Neste PR:

- Acrescento a tipagem de parâmetros de entrada do método `AssinaturaA1.assinar()`;
- Melhoria no disparo de erros de leitura do certificado `pfx`;
- Acrescento testes unitários para validar a assinatura digital das NFSe.

Closes #340.