### PR TITLE
Formata todos os arquivos para o padrão do Ruff e coloca verificação no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [
-          "3.8",
-          "3.9",
-          "3.10",
-          "3.11",
-          "3.12",
-          "3.13"
-        ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,7 +18,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-nfse.txt
-          pip install ruff pytest
+          pip install -r requirements-dev.txt
+      - name: Check formatting
+        run: ruff format --check .
       - name: Lint
         run: ruff check --output-format=github .
       - name: Tests

--- a/pynfe/entidades/certificado.py
+++ b/pynfe/entidades/certificado.py
@@ -71,7 +71,7 @@ class CertificadoA1(Certificado):
         except Exception as e:
             if "invalid password" in str(e).lower():
                 raise Exception(
-                    "Falha ao carregar certificado digital A1. Verifique a senha do" " certificado."
+                    "Falha ao carregar certificado digital A1. Verifique a senha do certificado."
                 ) from e
             else:
                 raise Exception(

--- a/pynfe/entidades/evento.py
+++ b/pynfe/entidades/evento.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-    @author: Junior Tada, Leonardo Tada
+@author: Junior Tada, Leonardo Tada
 """
 
 from decimal import Decimal

--- a/pynfe/entidades/servico.py
+++ b/pynfe/entidades/servico.py
@@ -1,5 +1,5 @@
 """
-    @author: Junior Tada, Leonardo Tada
+@author: Junior Tada, Leonardo Tada
 """
 
 from .base import Entidade

--- a/pynfe/processamento/autorizador_nfse.py
+++ b/pynfe/processamento/autorizador_nfse.py
@@ -344,9 +344,7 @@ class SerializacaoGinfes(InterfaceAutorizador):
         id_prestador.Cnpj = emitente.cnpj
         id_prestador.InscricaoMunicipal = emitente.inscricao_municipal
 
-        consulta = (
-            servico_consultar_situacao_lote_rps_envio_v03.ConsultarSituacaoLoteRpsEnvio()
-        )
+        consulta = servico_consultar_situacao_lote_rps_envio_v03.ConsultarSituacaoLoteRpsEnvio()
         consulta.Prestador = id_prestador
         consulta.Protocolo = str(numero)
 
@@ -387,9 +385,7 @@ class SerializacaoGinfes(InterfaceAutorizador):
         if nfse.servico.aliquota:
             valores_servico.Aliquota = nfse.servico.aliquota
         if nfse.servico.desconto_incondicionado:
-            valores_servico.DescontoIncondicionado = (
-                nfse.servico.desconto_incondicionado
-            )
+            valores_servico.DescontoIncondicionado = nfse.servico.desconto_incondicionado
         if nfse.servico.desconto_condicionado:
             valores_servico.DescontoCondicionado = nfse.servico.desconto_condicionado
 
@@ -525,9 +521,7 @@ class SerializacaoGinfes(InterfaceAutorizador):
 
         ns1 = "http://www.ginfes.com.br/servico_cancelar_nfse_envio"
         ns2 = "http://www.ginfes.com.br/tipos"
-        raiz = etree.Element(
-            "{%s}CancelarNfseEnvio" % ns1, nsmap={"ns1": ns1, "ns2": ns2}
-        )
+        raiz = etree.Element("{%s}CancelarNfseEnvio" % ns1, nsmap={"ns1": ns1, "ns2": ns2})
         prestador = etree.SubElement(raiz, "{%s}Prestador" % ns1)
         etree.SubElement(prestador, "{%s}Cnpj" % ns2).text = nfse.emitente.cnpj
         etree.SubElement(

--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -102,17 +102,11 @@ class ComunicacaoSefaz(Comunicacao):
                         # Estados como GO vem com a tag header
                         inf_prot = prot[1][0]
 
-                    lote_status = inf_prot.xpath(
-                        "ns:retEnviNFe/ns:cStat", namespaces=ns
-                    )[0].text
+                    lote_status = inf_prot.xpath("ns:retEnviNFe/ns:cStat", namespaces=ns)[0].text
                     # Lote processado
                     if lote_status == "104":
-                        prot_nfe = inf_prot.xpath(
-                            "ns:retEnviNFe/ns:protNFe", namespaces=ns
-                        )[0]
-                        status = prot_nfe.xpath("ns:infProt/ns:cStat", namespaces=ns)[
-                            0
-                        ].text
+                        prot_nfe = inf_prot.xpath("ns:retEnviNFe/ns:protNFe", namespaces=ns)[0]
+                        status = prot_nfe.xpath("ns:infProt/ns:cStat", namespaces=ns)[0].text
                         # autorizado usa da NF-e
                         # retorna xml final (protNFe+NFe)
                         if status in ["100", "150"]:
@@ -131,9 +125,7 @@ class ComunicacaoSefaz(Comunicacao):
                 status = rec.xpath("ns:retEnviNFe/ns:cStat", namespaces=ns)[0].text
                 # Lote Recebido com Sucesso!
                 if status == "103":
-                    nrec = rec.xpath("ns:retEnviNFe/ns:infRec/ns:nRec", namespaces=ns)[
-                        0
-                    ].text
+                    nrec = rec.xpath("ns:retEnviNFe/ns:infRec/ns:nRec", namespaces=ns)[0].text
                     return 0, nrec, nota_fiscal
         return 1, retorno, nota_fiscal
 
@@ -238,7 +230,7 @@ class ComunicacaoSefaz(Comunicacao):
 
         return self._post(url, xml)
 
-    def consulta_cadastro(self, modelo, documento, tipo='CNPJ', uf=None):
+    def consulta_cadastro(self, modelo, documento, tipo="CNPJ", uf=None):
         """
         Consulta de cadastro
         :param modelo: Modelo da nota
@@ -248,10 +240,24 @@ class ComunicacaoSefaz(Comunicacao):
         :return:
         """
         # UF que utilizam a SVRS - Sefaz Virtual do RS:
-        lista_svrs = ["AC", "AL", "AP", "CE",
-                      "DF", "ES", "PA", "PB",
-                      "PI", "RJ", "RN", "RO",
-                      "RR", "SC", "SE", "TO"]
+        lista_svrs = [
+            "AC",
+            "AL",
+            "AP",
+            "CE",
+            "DF",
+            "ES",
+            "PA",
+            "PB",
+            "PI",
+            "RJ",
+            "RN",
+            "RO",
+            "RR",
+            "SC",
+            "SE",
+            "TO",
+        ]
 
         # Se não informada UF nos parâmetros da função,
         # utiliza a UF do construtor
@@ -274,10 +280,10 @@ class ComunicacaoSefaz(Comunicacao):
         info = etree.SubElement(raiz, "infCons")
         etree.SubElement(info, "xServ").text = "CONS-CAD"
         etree.SubElement(info, "UF").text = uf.upper()
-        
+
         # Monta tipo de documento CNPJ, CPF ou IE
         etree.SubElement(info, tipo.upper()).text = documento
-        
+
         # etree.SubElement(info, 'CPF').text = cpf
 
         # Monta XML para envio da requisição
@@ -365,18 +371,15 @@ class ComunicacaoSefaz(Comunicacao):
 
         # Identificador da TAG a ser assinada formada com Código da UF + Ano (2 posições) +
         #  CNPJ + modelo + série + nro inicial e nro final precedida do literal “ID”
-        id_unico = (
-            "ID%(uf)s%(ano)s%(cnpj)s%(modelo)s%(serie)s%(num_ini)s%(num_fin)s"
-            % {
-                "uf": uf,
-                "ano": ano,
-                "cnpj": cnpjcpf_chaveacesso,
-                "modelo": "55" if modelo == "nfe" else "65",  # 55=NF-e; 65=NFC-e;
-                "serie": str(serie).zfill(3),
-                "num_ini": str(numero_inicial).zfill(9),
-                "num_fin": str(numero_final).zfill(9),
-            }
-        )
+        id_unico = "ID%(uf)s%(ano)s%(cnpj)s%(modelo)s%(serie)s%(num_ini)s%(num_fin)s" % {
+            "uf": uf,
+            "ano": ano,
+            "cnpj": cnpjcpf_chaveacesso,
+            "modelo": "55" if modelo == "nfe" else "65",  # 55=NF-e; 65=NFC-e;
+            "serie": str(serie).zfill(3),
+            "num_ini": str(numero_inicial).zfill(9),
+            "num_fin": str(numero_final).zfill(9),
+        }
 
         # Monta XML do corpo da requisição # FIXME
         raiz = etree.Element("inutNFe", versao=VERSAO_PADRAO, xmlns=NAMESPACE_NFE)
@@ -457,9 +460,7 @@ class ComunicacaoSefaz(Comunicacao):
                     # nfce Ex: https://homologacao.nfce.fazenda.pr.gov.br/nfce/NFeStatusServico3
                     self.url = NFCE["SVRS"][ambiente] + NFCE["SVRS"][consulta]
                 else:
-                    raise Exception(
-                        'Modelo não encontrado! Defina modelo="nfe" ou "nfce"'
-                    )
+                    raise Exception('Modelo não encontrado! Defina modelo="nfe" ou "nfce"')
             elif self.uf.upper() in contingencia_svan:
                 if self._ambiente == 1:
                     ambiente = "HTTPS"
@@ -472,9 +473,7 @@ class ComunicacaoSefaz(Comunicacao):
                     # nfce Ex: https://homologacao.nfce.fazenda.pr.gov.br/nfce/NFeStatusServico3
                     self.url = NFCE["SVRS"][ambiente] + NFCE["SVRS"][consulta]
                 else:
-                    raise Exception(
-                        'Modelo não encontrado! Defina modelo="nfe" ou "nfce"'
-                    )
+                    raise Exception('Modelo não encontrado! Defina modelo="nfe" ou "nfce"')
             return self.url
 
         # estado que implementam webservices proprios
@@ -490,19 +489,14 @@ class ComunicacaoSefaz(Comunicacao):
                     self.url = NFE["SVRS"][ambiente] + NFE["SVRS"][consulta]
                 else:
                     # nfe Ex: https://nfe.fazenda.pr.gov.br/nfe/NFeStatusServico3
-                    self.url = (
-                        NFE[self.uf.upper()][ambiente] + NFE[self.uf.upper()][consulta]
-                    )
+                    self.url = NFE[self.uf.upper()][ambiente] + NFE[self.uf.upper()][consulta]
             elif modelo == "nfce":
                 # PE e BA são as únicas UF'sque possuem NFE proprio e SVRS para NFCe
                 if self.uf.upper() == "PE" or self.uf.upper() == "BA":
                     self.url = NFCE["SVRS"][ambiente] + NFCE["SVRS"][consulta]
                 else:
                     # nfce Ex: https://homologacao.nfce.fazenda.pr.gov.br/nfce/NFeStatusServico3
-                    self.url = (
-                        NFCE[self.uf.upper()][ambiente]
-                        + NFCE[self.uf.upper()][consulta]
-                    )
+                    self.url = NFCE[self.uf.upper()][ambiente] + NFCE[self.uf.upper()][consulta]
             else:
                 raise Exception('Modelo não encontrado! Defina modelo="nfe" ou "nfce"')
         # Estados que utilizam outros ambientes
@@ -536,9 +530,7 @@ class ComunicacaoSefaz(Comunicacao):
                     # nfce Ex: https://homologacao.nfce.fazenda.pr.gov.br/nfce/NFeStatusServico3
                     self.url = NFCE["SVRS"][ambiente] + NFCE["SVRS"][consulta]
                 else:
-                    raise Exception(
-                        'Modelo não encontrado! Defina modelo="nfe" ou "nfce"'
-                    )
+                    raise Exception('Modelo não encontrado! Defina modelo="nfe" ou "nfce"')
             # unico UF que utiliza SVAN ainda para NF-e
             # SVRS para NFC-e
             elif self.uf.upper() == "MA":
@@ -553,13 +545,9 @@ class ComunicacaoSefaz(Comunicacao):
                     # nfce Ex: https://homologacao.nfce.fazenda.pr.gov.br/nfce/NFeStatusServico3
                     self.url = NFCE["SVRS"][ambiente] + NFCE["SVRS"][consulta]
                 else:
-                    raise Exception(
-                        'Modelo não encontrado! Defina modelo="nfe" ou "nfce"'
-                    )
+                    raise Exception('Modelo não encontrado! Defina modelo="nfe" ou "nfce"')
             else:
-                raise Exception(
-                    f"Url não encontrada para {modelo} e {consulta} {self.uf.upper()}"
-                )
+                raise Exception(f"Url não encontrada para {modelo} e {consulta} {self.uf.upper()}")
         return self.url
 
     def _construir_xml_soap(self, metodo, dados, cabecalho=False):
@@ -571,14 +559,10 @@ class ComunicacaoSefaz(Comunicacao):
         body = etree.SubElement(raiz, "{%s}Body" % NAMESPACE_SOAP)
         # distribuição tem um corpo de xml diferente
         if metodo == "NFeDistribuicaoDFe":
-            x = etree.SubElement(
-                body, "nfeDistDFeInteresse", xmlns=NAMESPACE_METODO + metodo
-            )
+            x = etree.SubElement(body, "nfeDistDFeInteresse", xmlns=NAMESPACE_METODO + metodo)
             a = etree.SubElement(x, "nfeDadosMsg")
         elif metodo == "CadConsultaCadastro4" and self.uf.upper() == "MT":
-            x = etree.SubElement(
-                body, "consultaCadastro", xmlns=NAMESPACE_METODO + metodo
-            )
+            x = etree.SubElement(body, "consultaCadastro", xmlns=NAMESPACE_METODO + metodo)
             a = etree.SubElement(x, "nfeDadosMsg")
         else:
             a = etree.SubElement(body, "nfeDadosMsg", xmlns=NAMESPACE_METODO + metodo)
@@ -598,9 +582,7 @@ class ComunicacaoSefaz(Comunicacao):
 
     def _post(self, url, xml, timeout=None):
         certificado_a1 = CertificadoA1(self.certificado)
-        chave, cert = certificado_a1.separar_arquivo(
-            self.certificado_senha, caminho=True
-        )
+        chave, cert = certificado_a1.separar_arquivo(self.certificado_senha, caminho=True)
         chave_cert = (cert, chave)
         # Abre a conexão HTTPS
         try:
@@ -609,10 +591,7 @@ class ComunicacaoSefaz(Comunicacao):
             # limpa xml com caracteres bugados para infNFeSupl em NFC-e
             xml = re.sub(
                 "<qrCode>(.*?)</qrCode>",
-                lambda x: x.group(0)
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", ""),
+                lambda x: x.group(0).replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", ""),
                 etree.tostring(xml, encoding="unicode").replace("\n", ""),
             )
             xml = xml_declaration + xml
@@ -752,13 +731,12 @@ class ComunicacaoNfse(Comunicacao):
             nsmap={"ns2": self._namespace, "xsi": NAMESPACE_XSI},
             versao=self._versao,
         )
-        etree.SubElement(
-            raiz, "{%s}versaoDados" % self._namespace).text = self._versao
+        etree.SubElement(raiz, "{%s}versaoDados" % self._namespace).text = self._versao
 
         if retorna_string:
-            cabecalho = etree.tostring(
-                raiz, encoding="unicode", pretty_print=False
-            ).replace("\n", "")
+            cabecalho = etree.tostring(raiz, encoding="unicode", pretty_print=False).replace(
+                "\n", ""
+            )
             cabecalho = xml_declaration + cabecalho
             return cabecalho
         else:
@@ -775,9 +753,9 @@ class ComunicacaoNfse(Comunicacao):
         etree.SubElement(raiz, "versaoDados").text = self._versao
 
         if retorna_string:
-            cabecalho = etree.tostring(
-                raiz, encoding="unicode", pretty_print=False
-            ).replace("\n", "")
+            cabecalho = etree.tostring(raiz, encoding="unicode", pretty_print=False).replace(
+                "\n", ""
+            )
             cabecalho = xml_declaration + cabecalho
             return cabecalho
         else:
@@ -836,13 +814,9 @@ class ComunicacaoNfse(Comunicacao):
             from pynfe.utils.https_nfse import HttpAuthenticated
 
             certificadoA1 = CertificadoA1(self.certificado)
-            chave, cert = certificadoA1.separar_arquivo(
-                self.certificado_senha, caminho=True
-            )
+            chave, cert = certificadoA1.separar_arquivo(self.certificado_senha, caminho=True)
 
-            cliente = Client(
-                url, transport=HttpAuthenticated(key=chave, cert=cert, endereco=url)
-            )
+            cliente = Client(url, transport=HttpAuthenticated(key=chave, cert=cert, endereco=url))
 
             # gerar nfse
             if metodo == "gerar":
@@ -949,24 +923,16 @@ class ComunicacaoMDFe(Comunicacao):
                 try:
                     # Protocolo com envio OK
                     inf_prot = prot[1][0]
-                    lote_status = inf_prot.xpath(
-                        "ns:retEnviMDFe/ns:cStat", namespaces=ns
-                    )[0].text
+                    lote_status = inf_prot.xpath("ns:retEnviMDFe/ns:cStat", namespaces=ns)[0].text
 
                     # Lote processado
                     if lote_status == self._edoc_situacao_lote_processado:
-                        prot_mdfe = inf_prot.xpath(
-                            "ns:retEnviMDFe/ns:protMDFe", namespaces=ns
-                        )[0]
-                        status = prot_mdfe.xpath("ns:infProt/ns:cStat", namespaces=ns)[
-                            0
-                        ].text
+                        prot_mdfe = inf_prot.xpath("ns:retEnviMDFe/ns:protMDFe", namespaces=ns)[0]
+                        status = prot_mdfe.xpath("ns:infProt/ns:cStat", namespaces=ns)[0].text
 
                         # autorizado uso do MDF-e
                         # retorna xml final (protMDFe + MDFe)
-                        if (
-                            status in self._edoc_situacao_ja_enviado
-                        ):  # if status == '100':
+                        if status in self._edoc_situacao_ja_enviado:  # if status == '100':
                             raiz = etree.Element(
                                 "mdfeProc", xmlns=NAMESPACE_MDFE, versao=VERSAO_MDFE
                             )
@@ -985,18 +951,14 @@ class ComunicacaoMDFe(Comunicacao):
                     self._edoc_situacao_arquivo_recebido_com_sucesso,
                     self._edoc_situacao_em_processamento,
                 ):
-                    nrec = rec.xpath("ns:retEnviMDFe/ns:infRec/ns:nRec", namespaces=ns)[
-                        0
-                    ].text
+                    nrec = rec.xpath("ns:retEnviMDFe/ns:infRec/ns:nRec", namespaces=ns)[0].text
                     return 0, nrec, manifesto
         return 1, retorno, manifesto
 
     def status_servico(self):
         url = self._get_url("STATUS")
         # Monta XML do corpo da requisição
-        raiz = etree.Element(
-            "consStatServMDFe", versao=self._versao, xmlns=NAMESPACE_MDFE
-        )
+        raiz = etree.Element("consStatServMDFe", versao=self._versao, xmlns=NAMESPACE_MDFE)
         etree.SubElement(raiz, "tpAmb").text = str(self._ambiente)
         etree.SubElement(raiz, "xServ").text = "STATUS"
         xml = self._construir_xml_soap("MDFeStatusServico", raiz)
@@ -1016,9 +978,7 @@ class ComunicacaoMDFe(Comunicacao):
     def consulta_nao_encerrados(self, cpfcnpj):
         url = self._get_url("NAO_ENCERRADOS")
         # Monta XML do corpo da requisição
-        raiz = etree.Element(
-            "consMDFeNaoEnc", xmlns=NAMESPACE_MDFE, versao=self._versao
-        )
+        raiz = etree.Element("consMDFeNaoEnc", xmlns=NAMESPACE_MDFE, versao=self._versao)
         etree.SubElement(raiz, "tpAmb").text = str(self._ambiente)
         etree.SubElement(raiz, "xServ").text = "CONSULTAR NÃO ENCERRADOS"
         if len(cpfcnpj) == 11:
@@ -1075,9 +1035,7 @@ class ComunicacaoMDFe(Comunicacao):
 
         body = etree.SubElement(raiz, "{%s}Body" % self._namespace_soap)
 
-        a = etree.SubElement(
-            body, self._envio_mensagem, xmlns=self._namespace_metodo + metodo
-        )
+        a = etree.SubElement(body, self._envio_mensagem, xmlns=self._namespace_metodo + metodo)
 
         # if metodo == 'MDFeRecepcaoSinc':
         #     body_base64 = base64.b16encode(a).decode()
@@ -1093,9 +1051,9 @@ class ComunicacaoMDFe(Comunicacao):
 
         # PE é a únca UF que exige SOAPAction no header
         if soap_webservice_method:
-            header[b"SOAPAction"] = (
-                self._namespace_metodo + soap_webservice_method
-            ).encode("utf-8")
+            header[b"SOAPAction"] = (self._namespace_metodo + soap_webservice_method).encode(
+                "utf-8"
+            )
 
         if self._accept:
             header[b"Accept"] = b"application/soap+xml; charset=utf-8;"
@@ -1104,9 +1062,7 @@ class ComunicacaoMDFe(Comunicacao):
 
     def _post(self, url, xml):
         certificado_a1 = CertificadoA1(self.certificado)
-        chave, cert = certificado_a1.separar_arquivo(
-            self.certificado_senha, caminho=True
-        )
+        chave, cert = certificado_a1.separar_arquivo(self.certificado_senha, caminho=True)
         chave_cert = (cert, chave)
         # Abre a conexão HTTPS
         try:
@@ -1115,16 +1071,11 @@ class ComunicacaoMDFe(Comunicacao):
             # limpa xml com caracteres bugados para infMDFeSupl em NFC-e
             xml = re.sub(
                 "<qrCodMDFe>(.*?)</qrCodMDFe>",
-                lambda x: x.group(0)
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("amp;", ""),
+                lambda x: x.group(0).replace("&lt;", "<").replace("&gt;", ">").replace("amp;", ""),
                 etree.tostring(xml, encoding="unicode").replace("\n", ""),
             )
             xml = xml_declaration + xml
-            xml = xml.encode(
-                "utf8"
-            )  # necessário para o evento "CONSULTAR NÃO ENCERRADOS"
+            xml = xml.encode("utf8")  # necessário para o evento "CONSULTAR NÃO ENCERRADOS"
 
             print(xml)
             print("-" * 20)
@@ -1189,15 +1140,15 @@ class ComunicacaoCTe(Comunicacao):
         """
         url = self._get_url("STATUS")
         # Monta XML do corpo da requisição
-        raiz = etree.Element(
-            "consStatServCte", versao=self._versao, xmlns=NAMESPACE_CTE
-        )
+        raiz = etree.Element("consStatServCte", versao=self._versao, xmlns=NAMESPACE_CTE)
         etree.SubElement(raiz, "tpAmb").text = str(self._ambiente)
         etree.SubElement(raiz, "xServ").text = "STATUS"
         xml = self._construir_xml_soap("CteStatusServico", raiz)
         return self._post(url, xml)
 
-    def consulta_distribuicao(self, cnpj=None, cpf=None, chave=None, nsu=0, consulta_nsu_especifico=False):
+    def consulta_distribuicao(
+        self, cnpj=None, cpf=None, chave=None, nsu=0, consulta_nsu_especifico=False
+    ):
         """
             O XML do pedido de distribuição suporta três tipos de consultas que são
             definidas de acordo com a tag informada no XML.
@@ -1247,7 +1198,7 @@ class ComunicacaoCTe(Comunicacao):
         # Monta XML para envio da requisição
         xml = self._construir_xml_soap("CTeDistribuicaoDFe", raiz)
         return self._post(url, xml)
-    
+
     def consulta(self, chave):
         url = self._get_url("CONSULTA")
         # Monta XML do corpo da requisição
@@ -1345,14 +1296,10 @@ class ComunicacaoCTe(Comunicacao):
         body = etree.SubElement(raiz, "{%s}Body" % NAMESPACE_SOAP)
         # distribuição tem um corpo de xml diferente
         if metodo == "CTeDistribuicaoDFe":
-            x = etree.SubElement(
-                body, "cteDistDFeInteresse", xmlns=NAMESPACE_CTE_METODO + metodo
-            )
+            x = etree.SubElement(body, "cteDistDFeInteresse", xmlns=NAMESPACE_CTE_METODO + metodo)
             a = etree.SubElement(x, "cteDadosMsg")
         else:
-            a = etree.SubElement(
-                body, "cteDadosMsg", xmlns=NAMESPACE_CTE_METODO + metodo
-            )
+            a = etree.SubElement(body, "cteDadosMsg", xmlns=NAMESPACE_CTE_METODO + metodo)
         a.append(dados)
         return raiz
 
@@ -1367,9 +1314,7 @@ class ComunicacaoCTe(Comunicacao):
 
     def _post(self, url, xml):
         certificado_a1 = CertificadoA1(self.certificado)
-        chave, cert = certificado_a1.separar_arquivo(
-            self.certificado_senha, caminho=True
-        )
+        chave, cert = certificado_a1.separar_arquivo(self.certificado_senha, caminho=True)
         chave_cert = (cert, chave)
         # Abre a conexão HTTPS
         try:
@@ -1378,10 +1323,7 @@ class ComunicacaoCTe(Comunicacao):
             # limpa xml com caracteres bugados para infNFeSupl em NFC-e
             xml = re.sub(
                 "<qrCode>(.*?)</qrCode>",
-                lambda x: x.group(0)
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", ""),
+                lambda x: x.group(0).replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", ""),
                 etree.tostring(xml, encoding="unicode").replace("\n", ""),
             )
             xml = xml_declaration + xml

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -36,9 +36,7 @@ class Serializacao(object):
 
     _fonte_dados = None
     _ambiente = 1  # 1 = Produção, 2 = Homologação
-    _contingencia = (
-        None  # Justificativa da entrada em contingência (min 20, max 256 caracteres)
-    )
+    _contingencia = None  # Justificativa da entrada em contingência (min 20, max 256 caracteres)
     _so_cpf = False  # Destinatário com apenas o cpf do cliente
     _nome_aplicacao = "PyNFe"
 
@@ -128,17 +126,13 @@ class SerializacaoXML(Serializacao):
         etree.SubElement(endereco, "UF").text = emitente.endereco_uf
         etree.SubElement(endereco, "CEP").text = so_numeros(emitente.endereco_cep)
         etree.SubElement(endereco, "cPais").text = emitente.endereco_pais
-        etree.SubElement(endereco, "xPais").text = obter_pais_por_codigo(
-            emitente.endereco_pais
-        )
+        etree.SubElement(endereco, "xPais").text = obter_pais_por_codigo(emitente.endereco_pais)
         if emitente.endereco_telefone:
             etree.SubElement(endereco, "fone").text = emitente.endereco_telefone
         etree.SubElement(raiz, "IE").text = emitente.inscricao_estadual
         # Apenas NF-e
         if emitente.inscricao_estadual_subst_tributaria:
-            etree.SubElement(
-                raiz, "IEST"
-            ).text = emitente.inscricao_estadual_subst_tributaria
+            etree.SubElement(raiz, "IEST").text = emitente.inscricao_estadual_subst_tributaria
         # Inscricao Municipal
         if emitente.inscricao_municipal:
             etree.SubElement(raiz, "IM").text = emitente.inscricao_municipal
@@ -151,15 +145,11 @@ class SerializacaoXML(Serializacao):
         else:
             return raiz
 
-    def _serializar_cliente(
-        self, cliente, modelo, tag_raiz="dest", retorna_string=True
-    ):
+    def _serializar_cliente(self, cliente, modelo, tag_raiz="dest", retorna_string=True):
         raiz = etree.Element(tag_raiz)
 
         # Dados do cliente (destinatário)
-        etree.SubElement(raiz, cliente.tipo_documento).text = so_numeros(
-            cliente.numero_documento
-        )
+        etree.SubElement(raiz, cliente.tipo_documento).text = so_numeros(cliente.numero_documento)
         if not self._so_cpf:
             if cliente.razao_social:
                 etree.SubElement(raiz, "xNome").text = cliente.razao_social
@@ -175,13 +165,9 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(endereco, "xMun").text = cliente.endereco_municipio
             etree.SubElement(endereco, "UF").text = cliente.endereco_uf
             if cliente.endereco_cep:
-                etree.SubElement(endereco, "CEP").text = so_numeros(
-                    cliente.endereco_cep
-                )
+                etree.SubElement(endereco, "CEP").text = so_numeros(cliente.endereco_cep)
             etree.SubElement(endereco, "cPais").text = cliente.endereco_pais
-            etree.SubElement(endereco, "xPais").text = obter_pais_por_codigo(
-                cliente.endereco_pais
-            )
+            etree.SubElement(endereco, "xPais").text = obter_pais_por_codigo(cliente.endereco_pais)
             if cliente.endereco_telefone:
                 etree.SubElement(endereco, "fone").text = cliente.endereco_telefone
         # Indicador da IE do destinatário:
@@ -220,9 +206,9 @@ class SerializacaoXML(Serializacao):
 
         # Dados da transportadora
         if transportadora.numero_documento:
-            etree.SubElement(
-                raiz, transportadora.tipo_documento.upper()
-            ).text = so_numeros(transportadora.numero_documento)
+            etree.SubElement(raiz, transportadora.tipo_documento.upper()).text = so_numeros(
+                transportadora.numero_documento
+            )
         if transportadora.razao_social:
             etree.SubElement(raiz, "xNome").text = transportadora.razao_social
         if transportadora.inscricao_estadual:
@@ -274,13 +260,9 @@ class SerializacaoXML(Serializacao):
         raiz = etree.Element(tag_raiz)
 
         if len(so_numeros(autorizados_baixar_xml.CPFCNPJ)) == 11:
-            etree.SubElement(raiz, "CPF").text = so_numeros(
-                autorizados_baixar_xml.CPFCNPJ
-            )
+            etree.SubElement(raiz, "CPF").text = so_numeros(autorizados_baixar_xml.CPFCNPJ)
         else:
-            etree.SubElement(raiz, "CNPJ").text = so_numeros(
-                autorizados_baixar_xml.CPFCNPJ
-            )
+            etree.SubElement(raiz, "CNPJ").text = so_numeros(autorizados_baixar_xml.CPFCNPJ)
 
         if retorna_string:
             return etree.tostring(raiz, encoding="unicode", pretty_print=True)
@@ -308,9 +290,7 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(prod, "cBenef").text = produto_servico.cbenef
         etree.SubElement(prod, "CFOP").text = produto_servico.cfop
         etree.SubElement(prod, "uCom").text = produto_servico.unidade_comercial
-        etree.SubElement(prod, "qCom").text = str(
-            produto_servico.quantidade_comercial or 0
-        )
+        etree.SubElement(prod, "qCom").text = str(produto_servico.quantidade_comercial or 0)
         etree.SubElement(prod, "vUnCom").text = str("{:.10f}").format(
             produto_servico.valor_unitario_comercial or 0
         )
@@ -328,28 +308,20 @@ class SerializacaoXML(Serializacao):
         )
         etree.SubElement(prod, "cEANTrib").text = produto_servico.ean_tributavel
         etree.SubElement(prod, "uTrib").text = produto_servico.unidade_tributavel
-        etree.SubElement(prod, "qTrib").text = str(
-            produto_servico.quantidade_tributavel
-        )
+        etree.SubElement(prod, "qTrib").text = str(produto_servico.quantidade_tributavel)
         etree.SubElement(prod, "vUnTrib").text = "{:.10f}".format(
             produto_servico.valor_unitario_tributavel or 0
         )
 
         # frete
         if produto_servico.total_frete:
-            etree.SubElement(prod, "vFrete").text = "{:.2f}".format(
-                produto_servico.total_frete
-            )
+            etree.SubElement(prod, "vFrete").text = "{:.2f}".format(produto_servico.total_frete)
         # seguro
         if produto_servico.total_seguro:
-            etree.SubElement(prod, "vSeg").text = "{:.2f}".format(
-                produto_servico.total_seguro
-            )
+            etree.SubElement(prod, "vSeg").text = "{:.2f}".format(produto_servico.total_seguro)
         # desconto
         if produto_servico.desconto:
-            etree.SubElement(prod, "vDesc").text = "{:.2f}".format(
-                produto_servico.desconto
-            )
+            etree.SubElement(prod, "vDesc").text = "{:.2f}".format(produto_servico.desconto)
         # outras despesas acessórias
         if produto_servico.outras_despesas_acessorias:
             etree.SubElement(prod, "vOutro").text = "{:.2f}".format(
@@ -364,7 +336,8 @@ class SerializacaoXML(Serializacao):
 
         # DI - Declaração de Importação
         self._serializar_declaracao_importacao(
-            produto_servico=produto_servico, tag_raiz=prod, retorna_string=False)
+            produto_servico=produto_servico, tag_raiz=prod, retorna_string=False
+        )
 
         """ Informação de interesse do emissor para controle do B2B.(v2.0) """
         # Número do Pedido de Compra. Tam 1-15
@@ -383,13 +356,21 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(combustivel, "cProdANP").text = str(produto_servico.cProdANP)
             etree.SubElement(combustivel, "descANP").text = str(produto_servico.descANP)
             if produto_servico.pGLP:
-                etree.SubElement(combustivel, "pGLP").text = "{:.4f}".format(produto_servico.pGLP or 0)
+                etree.SubElement(combustivel, "pGLP").text = "{:.4f}".format(
+                    produto_servico.pGLP or 0
+                )
             if produto_servico.pGNn:
-                etree.SubElement(combustivel, "pGNn").text = "{:.4f}".format(produto_servico.pGNn or 0)
+                etree.SubElement(combustivel, "pGNn").text = "{:.4f}".format(
+                    produto_servico.pGNn or 0
+                )
             if produto_servico.pGNi:
-                etree.SubElement(combustivel, "pGNi").text = "{:.4f}".format(produto_servico.pGNi or 0)
+                etree.SubElement(combustivel, "pGNi").text = "{:.4f}".format(
+                    produto_servico.pGNi or 0
+                )
             if produto_servico.vPart:
-                etree.SubElement(combustivel, "vPart").text = "{:.2f}".format(produto_servico.vPart or 0)
+                etree.SubElement(combustivel, "vPart").text = "{:.2f}".format(
+                    produto_servico.vPart or 0
+                )
             if produto_servico.comb_codif:
                 etree.SubElement(combustivel, "CODIF").text = produto_servico.comb_codif
             if produto_servico.comb_q_temp:
@@ -403,11 +384,17 @@ class SerializacaoXML(Serializacao):
                 if produto_servico.comb_n_bomba:
                     etree.SubElement(encerrante, "nBomba").text = str(produto_servico.comb_n_bomba)
                 etree.SubElement(encerrante, "nTanque").text = str(produto_servico.comb_n_tanque)
-                etree.SubElement(encerrante, "vEncIni").text = "{:.3f}".format(produto_servico.comb_v_enc_ini)
-                etree.SubElement(encerrante, "vEncFin").text = "{:.3f}".format(produto_servico.comb_v_enc_fin)
+                etree.SubElement(encerrante, "vEncIni").text = "{:.3f}".format(
+                    produto_servico.comb_v_enc_ini
+                )
+                etree.SubElement(encerrante, "vEncFin").text = "{:.3f}".format(
+                    produto_servico.comb_v_enc_fin
+                )
 
             if produto_servico.comb_p_bio:
-                etree.SubElement(combustivel, "pBio").text = "{:.4f}".format(produto_servico.comb_p_bio or 0)
+                etree.SubElement(combustivel, "pBio").text = "{:.4f}".format(
+                    produto_servico.comb_p_bio or 0
+                )
 
         # Imposto
         imposto = etree.SubElement(raiz, "imposto")
@@ -415,9 +402,7 @@ class SerializacaoXML(Serializacao):
         # Lei da transparencia
         # Tributos aprox por item
         if produto_servico.valor_tributos_aprox:
-            etree.SubElement(imposto, "vTotTrib").text = str(
-                produto_servico.valor_tributos_aprox
-            )
+            etree.SubElement(imposto, "vTotTrib").text = str(produto_servico.valor_tributos_aprox)
 
         # ICMS
         self._serializar_imposto_icms(
@@ -466,18 +451,14 @@ class SerializacaoXML(Serializacao):
 
         # Informações adicionais do produto
         if produto_servico.informacoes_adicionais:
-            etree.SubElement(
-                raiz, "infAdProd"
-            ).text = produto_servico.informacoes_adicionais
+            etree.SubElement(raiz, "infAdProd").text = produto_servico.informacoes_adicionais
 
         if retorna_string:
             return etree.tostring(raiz, encoding="unicode", pretty_print=True)
         else:
             return raiz
 
-    def _serializar_imposto_icms(
-        self, produto_servico, tag_raiz="imposto", retorna_string=True
-    ):
+    def _serializar_imposto_icms(self, produto_servico, tag_raiz="imposto", retorna_string=True):
         icms = etree.SubElement(tag_raiz, "ICMS")
 
         # 00=Tributada integralmente
@@ -512,9 +493,15 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CST").text = produto_servico.icms_modalidade
 
-            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(produto_servico.icms_q_bc_mono or 0)
-            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(produto_servico.icms_ad_rem_icms or 0)
-            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(produto_servico.icms_v_icms_mono or 0)
+            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(
+                produto_servico.icms_q_bc_mono or 0
+            )
+            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(
+                produto_servico.icms_ad_rem_icms or 0
+            )
+            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(
+                produto_servico.icms_v_icms_mono or 0
+            )
 
         # 10=Tributada e com cobrança do ICMS por substituição tributária
         elif produto_servico.icms_modalidade == "10":
@@ -580,23 +567,37 @@ class SerializacaoXML(Serializacao):
                     produto_servico.fcp_st_valor or 0
                 )
 
-
         # 15=Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis
         elif produto_servico.icms_modalidade == "15":
             icms_item = etree.SubElement(icms, "ICMS" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CST").text = produto_servico.icms_modalidade
 
-            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(produto_servico.icms_q_bc_mono or 0)
-            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(produto_servico.icms_ad_rem_icms or 0)
-            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(produto_servico.icms_v_icms_mono or 0)
-            etree.SubElement(icms_item, "qBCMonoReten").text = "{:.4f}".format(produto_servico.icms_q_bc_mono_reten or 0)
-            etree.SubElement(icms_item, "adRemICMSReten").text = "{:.4f}".format(produto_servico.icms_ad_rem_icms_reten or 0)
-            etree.SubElement(icms_item, "vICMSMonoReten").text = "{:.2f}".format(produto_servico.icms_v_icms_mono_reten or 0)
+            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(
+                produto_servico.icms_q_bc_mono or 0
+            )
+            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(
+                produto_servico.icms_ad_rem_icms or 0
+            )
+            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(
+                produto_servico.icms_v_icms_mono or 0
+            )
+            etree.SubElement(icms_item, "qBCMonoReten").text = "{:.4f}".format(
+                produto_servico.icms_q_bc_mono_reten or 0
+            )
+            etree.SubElement(icms_item, "adRemICMSReten").text = "{:.4f}".format(
+                produto_servico.icms_ad_rem_icms_reten or 0
+            )
+            etree.SubElement(icms_item, "vICMSMonoReten").text = "{:.2f}".format(
+                produto_servico.icms_v_icms_mono_reten or 0
+            )
             if produto_servico.icms_p_red_ad_rem:
-                etree.SubElement(icms_item, "pRedAdRem").text = "{:.2f}".format(produto_servico.icms_p_red_ad_rem or 0)
-                etree.SubElement(icms_item, "motRedAdRem").text = str(produto_servico.icms_mot_red_ad_rem)
-
+                etree.SubElement(icms_item, "pRedAdRem").text = "{:.2f}".format(
+                    produto_servico.icms_p_red_ad_rem or 0
+                )
+                etree.SubElement(icms_item, "motRedAdRem").text = str(
+                    produto_servico.icms_mot_red_ad_rem
+                )
 
         # 20=Com redução de base de cálculo
         elif produto_servico.icms_modalidade == "20":
@@ -687,9 +688,7 @@ class SerializacaoXML(Serializacao):
         elif produto_servico.icms_modalidade in ["40", "41", "50"]:
             icms_item = etree.SubElement(icms, "ICMS40")
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
-            etree.SubElement(icms_item, "CST").text = str(
-                produto_servico.icms_modalidade
-            )
+            etree.SubElement(icms_item, "CST").text = str(produto_servico.icms_modalidade)
 
             if produto_servico.icms_desonerado > 0:
                 etree.SubElement(icms_item, "vICMSDeson").text = "{:.2f}".format(
@@ -719,31 +718,45 @@ class SerializacaoXML(Serializacao):
                     produto_servico.fcp_valor or 0
                 )  # Valor Fundo Combate a Pobreza
 
-
         # 53=Tributação monofásica sobre combustíveis com recolhimento diferido
         elif produto_servico.icms_modalidade == "53":
             icms_item = etree.SubElement(icms, "ICMS" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CST").text = produto_servico.icms_modalidade
 
-            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(produto_servico.icms_q_bc_mono or 0)
-            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(produto_servico.icms_ad_rem_icms or 0)
-            etree.SubElement(icms_item, "vICMSMonoOp").text = "{:.2f}".format(produto_servico.icms_v_icms_mono_op or 0)
-            etree.SubElement(icms_item, "pDif").text = "{:.4f}".format(produto_servico.icms_p_dif  or 0)
-            etree.SubElement(icms_item, "vICMSMonoDif").text = "{:.4f}".format(produto_servico.icms_v_icms_mono_dif or 0)
-            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(produto_servico.icms_v_icms_mono or 0)
-
+            etree.SubElement(icms_item, "qBCMono").text = "{:.4f}".format(
+                produto_servico.icms_q_bc_mono or 0
+            )
+            etree.SubElement(icms_item, "adRemICMS").text = "{:.4f}".format(
+                produto_servico.icms_ad_rem_icms or 0
+            )
+            etree.SubElement(icms_item, "vICMSMonoOp").text = "{:.2f}".format(
+                produto_servico.icms_v_icms_mono_op or 0
+            )
+            etree.SubElement(icms_item, "pDif").text = "{:.4f}".format(
+                produto_servico.icms_p_dif or 0
+            )
+            etree.SubElement(icms_item, "vICMSMonoDif").text = "{:.4f}".format(
+                produto_servico.icms_v_icms_mono_dif or 0
+            )
+            etree.SubElement(icms_item, "vICMSMono").text = "{:.2f}".format(
+                produto_servico.icms_v_icms_mono or 0
+            )
 
         # 60=ICMS cobrado anteriormente por substituição tributária
         elif produto_servico.icms_modalidade in ["ST", "60"]:
             icms_item = etree.SubElement(icms, "ICMS" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CST").text = "60"
-            etree.SubElement(icms_item, "vBCSTRet").text = "{:.2f}".format(produto_servico.icms_st_ret_base_calculo or 0)
-            etree.SubElement(icms_item, "pST").text = "{:.2f}".format(produto_servico.icms_st_ret_aliquota or 0)
-            etree.SubElement(
-                icms_item, "vICMSSTRet"
-            ).text = "{:.2f}".format(produto_servico.icms_st_ret_valor or 0)
+            etree.SubElement(icms_item, "vBCSTRet").text = "{:.2f}".format(
+                produto_servico.icms_st_ret_base_calculo or 0
+            )
+            etree.SubElement(icms_item, "pST").text = "{:.2f}".format(
+                produto_servico.icms_st_ret_aliquota or 0
+            )
+            etree.SubElement(icms_item, "vICMSSTRet").text = "{:.2f}".format(
+                produto_servico.icms_st_ret_valor or 0
+            )
 
             if produto_servico.fcp_st_ret_valor:
                 etree.SubElement(icms_item, "vBCFCPSTRet").text = "{:.2f}".format(
@@ -755,7 +768,7 @@ class SerializacaoXML(Serializacao):
                 etree.SubElement(icms_item, "vFCPSTRet").text = "{:.2f}".format(
                     produto_servico.fcp_st_ret_valor or 0
                 )
-        
+
         # 61=Tributação monofásica sobre combustíveis cobrada anteriormente
         elif produto_servico.icms_modalidade == "61":
             icms_item = etree.SubElement(icms, "ICMS" + produto_servico.icms_modalidade)
@@ -847,9 +860,7 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CST").text = "90"
 
-            if (produto_servico.icms_valor_base_calculo > 0) and (
-                produto_servico.icms_valor > 0
-            ):
+            if (produto_servico.icms_valor_base_calculo > 0) and (produto_servico.icms_valor > 0):
                 etree.SubElement(icms_item, "modBC").text = str(
                     produto_servico.icms_modalidade_determinacao_bc
                 )
@@ -922,9 +933,7 @@ class SerializacaoXML(Serializacao):
 
         # 101=Tributada pelo Simples Nacional com permissão de crédito
         elif produto_servico.icms_modalidade == "101":
-            icms_item = etree.SubElement(
-                icms, "ICMSSN" + produto_servico.icms_modalidade
-            )
+            icms_item = etree.SubElement(icms, "ICMSSN" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CSOSN").text = produto_servico.icms_csosn
             etree.SubElement(icms_item, "pCredSN").text = "{:.2f}".format(
@@ -996,23 +1005,17 @@ class SerializacaoXML(Serializacao):
 
         # 500=ICMS cobrado anteriormente por ST (substituído) ou por antecipação
         elif produto_servico.icms_modalidade == "500":
-            icms_item = etree.SubElement(
-                icms, "ICMSSN" + produto_servico.icms_modalidade
-            )
+            icms_item = etree.SubElement(icms, "ICMSSN" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CSOSN").text = produto_servico.icms_csosn
 
         # 900=Outros
         elif produto_servico.icms_modalidade == "900":
-            icms_item = etree.SubElement(
-                icms, "ICMSSN" + produto_servico.icms_modalidade
-            )
+            icms_item = etree.SubElement(icms, "ICMSSN" + produto_servico.icms_modalidade)
             etree.SubElement(icms_item, "orig").text = str(produto_servico.icms_origem)
             etree.SubElement(icms_item, "CSOSN").text = produto_servico.icms_csosn
 
-            if (produto_servico.icms_valor_base_calculo > 0) and (
-                produto_servico.icms_valor > 0
-            ):
+            if (produto_servico.icms_valor_base_calculo > 0) and (produto_servico.icms_valor > 0):
                 etree.SubElement(icms_item, "modBC").text = str(
                     produto_servico.icms_modalidade_determinacao_bc
                 )
@@ -1074,16 +1077,12 @@ class SerializacaoXML(Serializacao):
         else:
             raise NotImplementedError
 
-    def _serializar_imposto_ipi(
-        self, produto_servico, tag_raiz="imposto", retorna_string=True
-    ):
+    def _serializar_imposto_ipi(self, produto_servico, tag_raiz="imposto", retorna_string=True):
         ipint_lista = ("01", "02", "03", "04", "05", "51", "52", "53", "54", "55")
         if produto_servico.ipi_codigo_enquadramento in ipint_lista:
             ipi = etree.SubElement(tag_raiz, "IPI")
             # Preenchimento conforme Atos Normativos editados pela Receita Federal (Observação 2)
-            etree.SubElement(
-                ipi, "cEnq"
-            ).text = produto_servico.ipi_classe_enquadramento
+            etree.SubElement(ipi, "cEnq").text = produto_servico.ipi_classe_enquadramento
             if produto_servico.ipi_classe_enquadramento == "":
                 etree.SubElement(ipi, "cEnq").text = "999"
 
@@ -1091,39 +1090,46 @@ class SerializacaoXML(Serializacao):
             # 01=Entrada tributada com alíquota zero 02=Entrada isenta 03=Entrada não-tributada
             # 04=Entrada imune 05=Entrada com suspensão 51=Saída tributada com alíquota zero
             # 52=Saída isenta 53=Saída não-tributada 54=Saída imune 55=Saída com suspensão
-            etree.SubElement(
-                ipint, "CST"
-            ).text = produto_servico.ipi_codigo_enquadramento
+            etree.SubElement(ipint, "CST").text = produto_servico.ipi_codigo_enquadramento
         else:
-            if (produto_servico.ipi_valor_base_calculo > 0) and\
-               (produto_servico.ipi_aliquota > 0) and\
-               (produto_servico.ipi_valor_ipi > 0):
-                ipi = etree.SubElement(tag_raiz, 'IPI')
+            if (
+                (produto_servico.ipi_valor_base_calculo > 0)
+                and (produto_servico.ipi_aliquota > 0)
+                and (produto_servico.ipi_valor_ipi > 0)
+            ):
+                ipi = etree.SubElement(tag_raiz, "IPI")
 
                 # Preenchimento conforme Atos Normativos editados pela Receita Federal
                 # (Observação 2)
-                etree.SubElement(ipi, 'cEnq').text = produto_servico.ipi_classe_enquadramento
-                if produto_servico.ipi_classe_enquadramento == '':
-                    etree.SubElement(ipi, 'cEnq').text = '999'
+                etree.SubElement(ipi, "cEnq").text = produto_servico.ipi_classe_enquadramento
+                if produto_servico.ipi_classe_enquadramento == "":
+                    etree.SubElement(ipi, "cEnq").text = "999"
 
-                ipi_item = etree.SubElement(ipi, 'IPITrib')
-                etree.SubElement(ipi_item, 'CST').text = produto_servico.ipi_codigo_enquadramento
-                etree.SubElement(ipi_item, 'vBC').text = '{:.2f}'.format(
-                    produto_servico.ipi_valor_base_calculo or 0)
-                etree.SubElement(ipi_item, 'pIPI').text = '{:.2f}'.format(
-                    produto_servico.ipi_aliquota or 0)
-                etree.SubElement(ipi_item, 'vIPI').text = '{:.2f}'.format(
-                    produto_servico.ipi_valor_ipi or 0)
+                ipi_item = etree.SubElement(ipi, "IPITrib")
+                etree.SubElement(ipi_item, "CST").text = produto_servico.ipi_codigo_enquadramento
+                etree.SubElement(ipi_item, "vBC").text = "{:.2f}".format(
+                    produto_servico.ipi_valor_base_calculo or 0
+                )
+                etree.SubElement(ipi_item, "pIPI").text = "{:.2f}".format(
+                    produto_servico.ipi_aliquota or 0
+                )
+                etree.SubElement(ipi_item, "vIPI").text = "{:.2f}".format(
+                    produto_servico.ipi_valor_ipi or 0
+                )
 
     def _serializar_imposto_pis(
         self, produto_servico, modelo, tag_raiz="imposto", retorna_string=True
     ):
         # Para NFC-e (65), o grupo de tributação do PIS/COFINS são opcionais.
-        if (modelo != 55) and \
-           ((produto_servico.pis_valor_base_calculo == 0) and
-            (produto_servico.pis_aliquota_percentual == 0) and
-            (produto_servico.pis_valor == 0) and
-            (produto_servico.pis_modalidade not in ("04", "05", "06", "07", "08", "09", "49", "99"))):
+        if (modelo != 55) and (
+            (produto_servico.pis_valor_base_calculo == 0)
+            and (produto_servico.pis_aliquota_percentual == 0)
+            and (produto_servico.pis_valor == 0)
+            and (
+                produto_servico.pis_modalidade
+                not in ("04", "05", "06", "07", "08", "09", "49", "99")
+            )
+        ):
             return
 
         pisnt = ("04", "05", "06", "07", "08", "09")
@@ -1131,10 +1137,7 @@ class SerializacaoXML(Serializacao):
         if produto_servico.pis_modalidade in pisnt:
             pis_item = etree.SubElement(pis, "PISNT")
             etree.SubElement(pis_item, "CST").text = produto_servico.pis_modalidade
-        elif (
-            produto_servico.pis_modalidade == "01"
-            or produto_servico.pis_modalidade == "02"
-        ):
+        elif produto_servico.pis_modalidade == "01" or produto_servico.pis_modalidade == "02":
             pis_item = etree.SubElement(pis, "PISAliq")
             etree.SubElement(pis_item, "CST").text = produto_servico.pis_modalidade
             etree.SubElement(pis_item, "vBC").text = "{:.2f}".format(
@@ -1192,28 +1195,25 @@ class SerializacaoXML(Serializacao):
         self, produto_servico, modelo, tag_raiz="imposto", retorna_string=True
     ):
         # Para NFC-e (65), o grupo de tributação do PIS/COFINS são opcionais.
-        if (modelo != 55) and \
-           ((produto_servico.cofins_valor_base_calculo == 0) and
-            (produto_servico.cofins_aliquota_percentual == 0) and
-            (produto_servico.cofins_valor == 0) and
-            (produto_servico.cofins_modalidade not in ("04", "05", "06", "07", "08", "09", "49", "99"))):
+        if (modelo != 55) and (
+            (produto_servico.cofins_valor_base_calculo == 0)
+            and (produto_servico.cofins_aliquota_percentual == 0)
+            and (produto_servico.cofins_valor == 0)
+            and (
+                produto_servico.cofins_modalidade
+                not in ("04", "05", "06", "07", "08", "09", "49", "99")
+            )
+        ):
             return
 
         cofinsnt = ("04", "05", "06", "07", "08", "09")
         cofins = etree.SubElement(tag_raiz, "COFINS")
         if produto_servico.cofins_modalidade in cofinsnt:
             cofins_item = etree.SubElement(cofins, "COFINSNT")
-            etree.SubElement(
-                cofins_item, "CST"
-            ).text = produto_servico.cofins_modalidade
-        elif (
-            produto_servico.cofins_modalidade == "01"
-            or produto_servico.cofins_modalidade == "02"
-        ):
+            etree.SubElement(cofins_item, "CST").text = produto_servico.cofins_modalidade
+        elif produto_servico.cofins_modalidade == "01" or produto_servico.cofins_modalidade == "02":
             cofins_item = etree.SubElement(cofins, "COFINSAliq")
-            etree.SubElement(
-                cofins_item, "CST"
-            ).text = produto_servico.cofins_modalidade
+            etree.SubElement(cofins_item, "CST").text = produto_servico.cofins_modalidade
             etree.SubElement(cofins_item, "vBC").text = "{:.2f}".format(
                 produto_servico.cofins_valor_base_calculo or 0
             )
@@ -1225,9 +1225,7 @@ class SerializacaoXML(Serializacao):
             )
         elif produto_servico.cofins_modalidade == "03":
             cofins_item = etree.SubElement(cofins, "COFINSQtde")
-            etree.SubElement(
-                cofins_item, "CST"
-            ).text = produto_servico.cofins_modalidade
+            etree.SubElement(cofins_item, "CST").text = produto_servico.cofins_modalidade
             etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
                 produto_servico.quantidade_comercial
             )
@@ -1239,9 +1237,7 @@ class SerializacaoXML(Serializacao):
             )
         else:
             cofins_item = etree.SubElement(cofins, "COFINSOutr")
-            etree.SubElement(
-                cofins_item, "CST"
-            ).text = produto_servico.cofins_modalidade
+            etree.SubElement(cofins_item, "CST").text = produto_servico.cofins_modalidade
             if produto_servico.cofins_aliquota_reais > 0:
                 etree.SubElement(cofins_item, "qBCProd").text = "{:.4f}".format(
                     produto_servico.quantidade_comercial
@@ -1297,52 +1293,56 @@ class SerializacaoXML(Serializacao):
             )
 
     def _serializar_declaracao_importacao(
-            self, produto_servico, tag_raiz='prod', retorna_string=True
+        self, produto_servico, tag_raiz="prod", retorna_string=True
     ):
         # DI de 0-100
-        if produto_servico.declaracoes_importacao and\
-           len(produto_servico.declaracoes_importacao) > 0:
+        if (
+            produto_servico.declaracoes_importacao
+            and len(produto_servico.declaracoes_importacao) > 0
+        ):
             for item_di in produto_servico.declaracoes_importacao:
-                di = etree.SubElement(tag_raiz, 'DI')
+                di = etree.SubElement(tag_raiz, "DI")
                 # Número do Documento de Importação (DI, DSI, DIRE, ...)
-                etree.SubElement(di, 'nDI').text = str(item_di.numero_di_dsi_da)
+                etree.SubElement(di, "nDI").text = str(item_di.numero_di_dsi_da)
                 # Data de Registro do documento
-                etree.SubElement(di, 'dDI').text = item_di.data_registro.strftime('%Y-%m-%d')
+                etree.SubElement(di, "dDI").text = item_di.data_registro.strftime("%Y-%m-%d")
                 # Local de desembaraço
-                etree.SubElement(di, 'xLocDesemb').text = str(item_di.desembaraco_aduaneiro_local)
+                etree.SubElement(di, "xLocDesemb").text = str(item_di.desembaraco_aduaneiro_local)
                 # UF onde ocorreu o Desembaraço Aduaneiro
-                etree.SubElement(di, 'UFDesemb').text = str(item_di.desembaraco_aduaneiro_uf)
+                etree.SubElement(di, "UFDesemb").text = str(item_di.desembaraco_aduaneiro_uf)
                 # Data do Desembaraço Aduaneiro
-                etree.SubElement(di, 'dDesemb').text = \
-                    item_di.desembaraco_aduaneiro_data.strftime('%Y-%m-%d')
+                etree.SubElement(di, "dDesemb").text = item_di.desembaraco_aduaneiro_data.strftime(
+                    "%Y-%m-%d"
+                )
                 # Via de transporte internacional informada na Declaração de Importação (DI)
-                etree.SubElement(di, 'tpViaTransp').text = str(item_di.tipo_via_transporte)
+                etree.SubElement(di, "tpViaTransp").text = str(item_di.tipo_via_transporte)
                 # Valor da AFRMM - Adicional ao Frete para Renovação da Marinha Mercante
                 if item_di.valor_afrmm:
-                    etree.SubElement(di, 'vAFRMM').text = '{:.2f}'.format(item_di.valor_afrmm or 0)
+                    etree.SubElement(di, "vAFRMM").text = "{:.2f}".format(item_di.valor_afrmm or 0)
                 # tpIntermedio
-                etree.SubElement(di, 'tpIntermedio').text = str(item_di.tipo_intermediacao)
+                etree.SubElement(di, "tpIntermedio").text = str(item_di.tipo_intermediacao)
                 # CNPJ
                 if item_di.cnpj_adquirente:
-                    etree.SubElement(di, 'CNPJ').text = so_numeros(item_di.cnpj_adquirente)
+                    etree.SubElement(di, "CNPJ").text = so_numeros(item_di.cnpj_adquirente)
                 # UFTerceiro
                 if item_di.uf_terceiro:
-                    etree.SubElement(di, 'UFTerceiro').text = item_di.uf_terceiro
+                    etree.SubElement(di, "UFTerceiro").text = item_di.uf_terceiro
                 # cExportador
-                etree.SubElement(di, 'cExportador').text = str(item_di.codigo_exportador)
+                etree.SubElement(di, "cExportador").text = str(item_di.codigo_exportador)
 
                 # Adições 1-100
                 for adicao in item_di.adicoes:
-                    adi = etree.SubElement(di, 'adi')
-                    etree.SubElement(adi, 'nAdicao').text = str(adicao.numero)
-                    etree.SubElement(adi, 'nSeqAdic').text = str(adicao.sequencia)
-                    etree.SubElement(adi, 'cFabricante').text = str(adicao.codigo_fabricante)
+                    adi = etree.SubElement(di, "adi")
+                    etree.SubElement(adi, "nAdicao").text = str(adicao.numero)
+                    etree.SubElement(adi, "nSeqAdic").text = str(adicao.sequencia)
+                    etree.SubElement(adi, "cFabricante").text = str(adicao.codigo_fabricante)
                     if adicao.desconto:
-                        etree.SubElement(adi, 'vDescDI').text = \
-                            '{:.2f}'.format(adicao.desconto or 0)
+                        etree.SubElement(adi, "vDescDI").text = "{:.2f}".format(
+                            adicao.desconto or 0
+                        )
                     # Número do ato concessório de Drawback
                     if adicao.numero_drawback:
-                        etree.SubElement(adi, 'nDraw').text = str(adicao.numero_drawback)
+                        etree.SubElement(adi, "nDraw").text = str(adicao.numero_drawback)
 
     def _serializar_responsavel_tecnico(
         self, responsavel_tecnico, tag_raiz="infRespTec", retorna_string=True
@@ -1358,22 +1358,17 @@ class SerializacaoXML(Serializacao):
         else:
             return raiz
 
-    def _serializar_pagamentos_antigo_deprecado(self, tipo_pagamento, finalidade_emissao, totais_icms_total_nota):
-        pag = etree.Element('pag')
+    def _serializar_pagamentos_antigo_deprecado(
+        self, tipo_pagamento, finalidade_emissao, totais_icms_total_nota
+    ):
+        pag = etree.Element("pag")
         detpag = etree.SubElement(pag, "detPag")
-        if (
-            str(finalidade_emissao) == "3"
-            or str(finalidade_emissao) == "4"
-        ):
+        if str(finalidade_emissao) == "3" or str(finalidade_emissao) == "4":
             etree.SubElement(detpag, "tPag").text = "90"
             etree.SubElement(detpag, "vPag").text = "{:.2f}".format(0)
         else:
-            etree.SubElement(detpag, "tPag").text = str(
-                tipo_pagamento
-            ).zfill(2)
-            etree.SubElement(detpag, "vPag").text = "{:.2f}".format(
-                totais_icms_total_nota
-            )
+            etree.SubElement(detpag, "tPag").text = str(tipo_pagamento).zfill(2)
+            etree.SubElement(detpag, "vPag").text = "{:.2f}".format(totais_icms_total_nota)
             if tipo_pagamento == 3 or tipo_pagamento == 4:
                 cartao = etree.SubElement(detpag, "card")
                 """ Tipo de Integração do processo de pagamento com
@@ -1394,9 +1389,11 @@ class SerializacaoXML(Serializacao):
             # etree.SubElement(pag, 'vTroco').text = str('')
         return pag
 
-    def _serializar_pagamentos(self, pagamentos: list(), finalidade_emissao='', valor_troco = 0.00, retorna_string=True):
-        pag = etree.Element('pag')
-        if (finalidade_emissao in [3, 4]):
+    def _serializar_pagamentos(
+        self, pagamentos: list(), finalidade_emissao="", valor_troco=0.00, retorna_string=True
+    ):
+        pag = etree.Element("pag")
+        if finalidade_emissao in [3, 4]:
             detpag = etree.SubElement(pag, "detPag")
             etree.SubElement(detpag, "tPag").text = "90"
             etree.SubElement(detpag, "vPag").text = "{:.2f}".format(0)
@@ -1405,8 +1402,8 @@ class SerializacaoXML(Serializacao):
                 det = etree.Element("detPag")
                 xmlw.write_txt(det, "indPag", item.ind_pag, False)
                 xmlw.write_txt(det, "tPag", item.t_pag, True)
-                xmlw.write_txt(det, 'xPag', item.x_pag, False)
-                xmlw.write_float(det, 'vPag', item.v_pag, True, 2, 2)
+                xmlw.write_txt(det, "xPag", item.x_pag, False)
+                xmlw.write_float(det, "vPag", item.v_pag, True, 2, 2)
                 if item.tp_integra:
                     card = etree.SubElement(det, "card")
                     xmlw.write_txt(card, "tpIntegra", item.tp_integra, True)
@@ -1416,16 +1413,14 @@ class SerializacaoXML(Serializacao):
                 pag.append(det)
 
         # troco
-        xmlw.write_float(pag, 'vTroco', valor_troco, False, 2, 2)
+        xmlw.write_float(pag, "vTroco", valor_troco, False, 2, 2)
 
         if retorna_string:
             return etree.tostring(pag, encoding="unicode", pretty_print=False)
         else:
             return pag
 
-    def _serializar_nota_fiscal(
-        self, nota_fiscal, tag_raiz="infNFe", retorna_string=True
-    ):
+    def _serializar_nota_fiscal(self, nota_fiscal, tag_raiz="infNFe", retorna_string=True):
         raiz = etree.Element(tag_raiz, versao=self._versao)
 
         # 'Id' da tag raiz
@@ -1457,9 +1452,7 @@ class SerializacaoXML(Serializacao):
             """ dhCont Data e Hora da entrada em contingência E B01 D 0-1
                 Formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time)
             """
-        etree.SubElement(ide, "tpNF").text = str(
-            nota_fiscal.tipo_documento
-        )  # 0=entrada 1=saida
+        etree.SubElement(ide, "tpNF").text = str(nota_fiscal.tipo_documento)  # 0=entrada 1=saida
         """ nfce suporta apenas operação interna
             Identificador de local de destino da operação
             1=Operação interna;2=Operação interestadual;3=Operação com exterior.
@@ -1494,17 +1487,11 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(ide, "indPres").text = str(1)
         else:
             etree.SubElement(ide, "indFinal").text = str(nota_fiscal.cliente_final)
-            etree.SubElement(ide, "indPres").text = str(
-                nota_fiscal.indicador_presencial
-            )
+            etree.SubElement(ide, "indPres").text = str(nota_fiscal.indicador_presencial)
         # Rejeição 435: NF-e não pode ter o indicativo do intermediador quando for modelo 55
         #               e informando o indicativo de presença (indPres) igual a 0, 1 ou 5.
-        if (nota_fiscal.modelo in [55, 65]) and (
-            nota_fiscal.indicador_presencial not in [0, 1, 5]
-        ):
-            etree.SubElement(ide, "indIntermed").text = str(
-                nota_fiscal.indicador_intermediador
-            )
+        if (nota_fiscal.modelo in [55, 65]) and (nota_fiscal.indicador_presencial not in [0, 1, 5]):
+            etree.SubElement(ide, "indIntermed").text = str(nota_fiscal.indicador_intermediador)
         etree.SubElement(ide, "procEmi").text = str(nota_fiscal.processo_emissao)
         etree.SubElement(ide, "verProc").text = "%s %s" % (
             self._nome_aplicacao,
@@ -1524,30 +1511,20 @@ class SerializacaoXML(Serializacao):
                     elif refNFe.tipo == "Nota Fiscal":
                         refNF = etree.SubElement(nfref, "refNF")
                         etree.SubElement(refNF, "cUF").text = str(refNFe.uf)
-                        etree.SubElement(refNF, "AAMM").text = str(
-                            refNFe.mes_ano_emissao
-                        )
+                        etree.SubElement(refNF, "AAMM").text = str(refNFe.mes_ano_emissao)
                         etree.SubElement(refNF, "CNPJ").text = so_numeros(refNFe.cnpj)
-                        etree.SubElement(refNF, "mod").text = str(
-                            refNFe.modelo
-                        )  # 1 ou 2
+                        etree.SubElement(refNF, "mod").text = str(refNFe.modelo)  # 1 ou 2
                         etree.SubElement(refNF, "serie").text = str(refNFe.serie)
                         etree.SubElement(refNF, "nNF").text = str(refNFe.numero)
 
                     elif refNFe.tipo == "Nota Fiscal produtor":
                         refNFP = etree.SubElement(nfref, "refNFP")
                         etree.SubElement(refNFP, "cUF").text = str(refNFe.uf)
-                        etree.SubElement(refNFP, "AAMM").text = str(
-                            refNFe.mes_ano_emissao
-                        )
+                        etree.SubElement(refNFP, "AAMM").text = str(refNFe.mes_ano_emissao)
                         if len(so_numeros(refNFe.cnpj)) == 11:
-                            etree.SubElement(refNFP, "CPF").text = so_numeros(
-                                refNFe.cnpj
-                            )
+                            etree.SubElement(refNFP, "CPF").text = so_numeros(refNFe.cnpj)
                         else:
-                            etree.SubElement(refNFP, "CNPJ").text = so_numeros(
-                                refNFe.cnpj
-                            )
+                            etree.SubElement(refNFP, "CNPJ").text = so_numeros(refNFe.cnpj)
                         etree.SubElement(refNFP, "IE").text = so_numeros(refNFe.ie)
                         etree.SubElement(refNFP, "mod").text = "04"
                         etree.SubElement(refNFP, "serie").text = str(refNFe.serie)
@@ -1570,9 +1547,7 @@ class SerializacaoXML(Serializacao):
             )  # Justificativa da entrada em contingência (min 20, max 256 caracteres)
 
         # Emitente
-        raiz.append(
-            self._serializar_emitente(nota_fiscal.emitente, retorna_string=False)
-        )
+        raiz.append(self._serializar_emitente(nota_fiscal.emitente, retorna_string=False))
 
         # Destinatário
         try:
@@ -1609,9 +1584,7 @@ class SerializacaoXML(Serializacao):
 
         # Autorizados a baixar o XML
         for num, item in enumerate(nota_fiscal.autorizados_baixar_xml):
-            raiz.append(
-                self._serializar_autorizados_baixar_xml(item, retorna_string=False)
-            )
+            raiz.append(self._serializar_autorizados_baixar_xml(item, retorna_string=False))
 
         # Itens
         for num, item in enumerate(nota_fiscal.produtos_e_servicos):
@@ -1628,9 +1601,7 @@ class SerializacaoXML(Serializacao):
         etree.SubElement(icms_total, "vBC").text = "{:.2f}".format(
             nota_fiscal.totais_icms_base_calculo
         )
-        etree.SubElement(icms_total, "vICMS").text = "{:.2f}".format(
-            nota_fiscal.totais_icms_total
-        )
+        etree.SubElement(icms_total, "vICMS").text = "{:.2f}".format(nota_fiscal.totais_icms_total)
         etree.SubElement(icms_total, "vICMSDeson").text = "{:.2f}".format(
             nota_fiscal.totais_icms_desonerado
         )  # Valor Total do ICMS desonerado
@@ -1646,35 +1617,41 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(icms_total, "vICMSUFRemet").text = "{:.2f}".format(
                 nota_fiscal.totais_icms_remetente
             )
-        etree.SubElement(icms_total, "vFCP").text = "{:.2f}".format(
-            nota_fiscal.totais_fcp
-        )
+        etree.SubElement(icms_total, "vFCP").text = "{:.2f}".format(nota_fiscal.totais_fcp)
         etree.SubElement(icms_total, "vBCST").text = "{:.2f}".format(
             nota_fiscal.totais_icms_st_base_calculo
         )
-        etree.SubElement(icms_total, "vST").text = "{:.2f}".format(
-            nota_fiscal.totais_icms_st_total
-        )
-        etree.SubElement(icms_total, "vFCPST").text = "{:.2f}".format(
-            nota_fiscal.totais_fcp_st
-        )
+        etree.SubElement(icms_total, "vST").text = "{:.2f}".format(nota_fiscal.totais_icms_st_total)
+        etree.SubElement(icms_total, "vFCPST").text = "{:.2f}".format(nota_fiscal.totais_fcp_st)
         etree.SubElement(icms_total, "vFCPSTRet").text = "{:.2f}".format(
             nota_fiscal.totais_fcp_st_ret
         )
 
         # ICMS monofasico
         if nota_fiscal.totais_icms_q_bc_mono:
-            etree.SubElement(icms_total, "qBCMono").text = "{:.2f}".format(nota_fiscal.totais_icms_q_bc_mono)
+            etree.SubElement(icms_total, "qBCMono").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_q_bc_mono
+            )
         if nota_fiscal.totais_icms_v_icms_mono:
-            etree.SubElement(icms_total, "vICMSMono").text = "{:.2f}".format(nota_fiscal.totais_icms_v_icms_mono)
+            etree.SubElement(icms_total, "vICMSMono").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_v_icms_mono
+            )
         if nota_fiscal.totais_icms_q_bc_mono_reten:
-            etree.SubElement(icms_total, "qBCMonoReten").text = "{:.2f}".format(nota_fiscal.totais_icms_q_bc_mono_reten)
+            etree.SubElement(icms_total, "qBCMonoReten").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_q_bc_mono_reten
+            )
         if nota_fiscal.totais_icms_v_icms_mono_reten:
-            etree.SubElement(icms_total, "vICMSMonoReten").text = "{:.2f}".format(nota_fiscal.totais_icms_v_icms_mono_reten)
+            etree.SubElement(icms_total, "vICMSMonoReten").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_v_icms_mono_reten
+            )
         if nota_fiscal.totais_icms_q_bc_mono_ret:
-            etree.SubElement(icms_total, "qBCMonoRet").text = "{:.2f}".format(nota_fiscal.totais_icms_q_bc_mono_ret)
+            etree.SubElement(icms_total, "qBCMonoRet").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_q_bc_mono_ret
+            )
         if nota_fiscal.totais_icms_v_icms_mono_ret:
-            etree.SubElement(icms_total, "vICMSMonoRet").text = "{:.2f}".format(nota_fiscal.totais_icms_v_icms_mono_ret)
+            etree.SubElement(icms_total, "vICMSMonoRet").text = "{:.2f}".format(
+                nota_fiscal.totais_icms_v_icms_mono_ret
+            )
 
         etree.SubElement(icms_total, "vProd").text = "{:.2f}".format(
             nota_fiscal.totais_icms_total_produtos_e_servicos
@@ -1690,18 +1667,14 @@ class SerializacaoXML(Serializacao):
         )
 
         # Tributos
-        etree.SubElement(icms_total, "vII").text = "{:.2f}".format(
-            nota_fiscal.totais_icms_total_ii
-        )
+        etree.SubElement(icms_total, "vII").text = "{:.2f}".format(nota_fiscal.totais_icms_total_ii)
         etree.SubElement(icms_total, "vIPI").text = "{:.2f}".format(
             nota_fiscal.totais_icms_total_ipi
         )
         etree.SubElement(icms_total, "vIPIDevol").text = "{:.2f}".format(
             nota_fiscal.totais_icms_total_ipi_dev
         )
-        etree.SubElement(icms_total, "vPIS").text = "{:.2f}".format(
-            nota_fiscal.totais_icms_pis
-        )
+        etree.SubElement(icms_total, "vPIS").text = "{:.2f}".format(nota_fiscal.totais_icms_pis)
         etree.SubElement(icms_total, "vCOFINS").text = "{:.2f}".format(
             nota_fiscal.totais_icms_cofins
         )
@@ -1719,9 +1692,7 @@ class SerializacaoXML(Serializacao):
 
         # Transporte
         transp = etree.SubElement(raiz, "transp")
-        etree.SubElement(transp, "modFrete").text = str(
-            nota_fiscal.transporte_modalidade_frete
-        )
+        etree.SubElement(transp, "modFrete").text = str(nota_fiscal.transporte_modalidade_frete)
 
         # Apenas NF-e
         if nota_fiscal.modelo == 55:
@@ -1735,10 +1706,7 @@ class SerializacaoXML(Serializacao):
                 )
 
             # Veículo
-            if (
-                nota_fiscal.transporte_veiculo_placa
-                and nota_fiscal.transporte_veiculo_uf
-            ):
+            if nota_fiscal.transporte_veiculo_placa and nota_fiscal.transporte_veiculo_uf:
                 veiculo = etree.SubElement(transp, "veicTransp")
                 etree.SubElement(
                     veiculo, "placa"
@@ -1746,25 +1714,16 @@ class SerializacaoXML(Serializacao):
                 etree.SubElement(veiculo, "UF").text = nota_fiscal.transporte_veiculo_uf
                 # Registro Nacional de Transportador de Carga (ANTT)
                 if nota_fiscal.transporte_veiculo_rntc:
-                    etree.SubElement(
-                        veiculo, "RNTC"
-                    ).text = nota_fiscal.transporte_veiculo_rntc
+                    etree.SubElement(veiculo, "RNTC").text = nota_fiscal.transporte_veiculo_rntc
 
             # Reboque
-            if (
-                nota_fiscal.transporte_reboque_placa
-                and nota_fiscal.transporte_reboque_uf
-            ):
+            if nota_fiscal.transporte_reboque_placa and nota_fiscal.transporte_reboque_uf:
                 reboque = etree.SubElement(transp, "reboque")
-                etree.SubElement(
-                    reboque, "placa"
-                ).text = nota_fiscal.transporte_reboque_placa
+                etree.SubElement(reboque, "placa").text = nota_fiscal.transporte_reboque_placa
                 etree.SubElement(reboque, "UF").text = nota_fiscal.transporte_reboque_uf
                 # Registro Nacional de Transportador de Carga (ANTT)
                 if nota_fiscal.transporte_reboque_rntc:
-                    etree.SubElement(
-                        reboque, "RNTC"
-                    ).text = nota_fiscal.transporte_reboque_rntc
+                    etree.SubElement(reboque, "RNTC").text = nota_fiscal.transporte_reboque_rntc
 
             # Volumes
             if nota_fiscal.transporte_volumes:
@@ -1784,12 +1743,12 @@ class SerializacaoXML(Serializacao):
                         if volume.lacres:
                             lacres = etree.SubElement(vol, "lacres")
                             for lacre in volume.lacres:
-                                etree.SubElement(
-                                    lacres, "nLacre"
-                                ).text = lacre.numero_lacre
+                                etree.SubElement(lacres, "nLacre").text = lacre.numero_lacre
 
         # Cobrança
-        if (nota_fiscal.fatura_numero) or (nota_fiscal.duplicatas and len(nota_fiscal.duplicatas) > 0):
+        if (nota_fiscal.fatura_numero) or (
+            nota_fiscal.duplicatas and len(nota_fiscal.duplicatas) > 0
+        ):
             cobr = etree.SubElement(raiz, "cobr")
 
             # Fatura 0-1
@@ -1811,16 +1770,14 @@ class SerializacaoXML(Serializacao):
                 for num, item in enumerate(nota_fiscal.duplicatas):
                     dup = etree.SubElement(cobr, "dup")
                     etree.SubElement(dup, "nDup").text = item.numero
-                    etree.SubElement(dup, "dVenc").text = item.data_vencimento.strftime(
-                        "%Y-%m-%d"
-                    )
+                    etree.SubElement(dup, "dVenc").text = item.data_vencimento.strftime("%Y-%m-%d")
                     etree.SubElement(dup, "vDup").text = "{:.2f}".format(item.valor)
 
         # Pagamento
         """ Obrigatório o preenchimento do Grupo Informações de Pagamento para NF-e e NFC-e.
         Para as notas com finalidade de Ajuste ou Devolução
         o campo Forma de Pagamento deve ser preenchido com 90=Sem Pagamento. """
-        if (nota_fiscal.tipo_pagamento is not None):
+        if nota_fiscal.tipo_pagamento is not None:
             warnings.warn(
                 "O campo 'tipo_pagamento' está obsoleto e será removido em versões futuras. "
                 "Utilize o campo 'pagamentos' em seu lugar.",
@@ -1836,10 +1793,10 @@ class SerializacaoXML(Serializacao):
         else:
             raiz.append(
                 self._serializar_pagamentos(
-                    pagamentos=nota_fiscal.pagamentos, 
+                    pagamentos=nota_fiscal.pagamentos,
                     finalidade_emissao=nota_fiscal.finalidade_emissao,
                     valor_troco=nota_fiscal.valor_troco,
-                    retorna_string=False
+                    retorna_string=False,
                 )
             )
 
@@ -1905,9 +1862,7 @@ class SerializacaoXML(Serializacao):
         else:
             return raiz
 
-    def serializar_evento_mdfe(
-        self, evento, tag_raiz="eventoMDFe", retorna_string=False
-    ):
+    def serializar_evento_mdfe(self, evento, tag_raiz="eventoMDFe", retorna_string=False):
         tz = datetime.now().astimezone().strftime("%z")
         tz = "{}:{}".format(tz[:-2], tz[-2:])
         raiz = etree.Element(tag_raiz, versao=VERSAO_MDFE, xmlns=NAMESPACE_MDFE)
@@ -1934,9 +1889,7 @@ class SerializacaoXML(Serializacao):
             encerramento = etree.SubElement(det, "evEncMDFe")
             etree.SubElement(encerramento, "descEvento").text = evento.descricao
             etree.SubElement(encerramento, "nProt").text = evento.protocolo
-            etree.SubElement(encerramento, "dtEnc").text = evento.dtenc.strftime(
-                "%Y-%m-%d"
-            )
+            etree.SubElement(encerramento, "dtEnc").text = evento.dtenc.strftime("%Y-%m-%d")
             etree.SubElement(encerramento, "cUF").text = str(evento.cuf)
             etree.SubElement(encerramento, "cMun").text = str(evento.cmun)
         elif evento.descricao == "Inclusão Condutor":
@@ -1962,9 +1915,7 @@ class SerializacaoXML(Serializacao):
 
             # Viagens
             infViagens = etree.SubElement(pagamento, "infViagens")
-            etree.SubElement(infViagens, "qtdViagens").text = evento.qtd_viagens.zfill(
-                5
-            )
+            etree.SubElement(infViagens, "qtdViagens").text = evento.qtd_viagens.zfill(5)
             etree.SubElement(infViagens, "nroViagem").text = evento.nro_viagens.zfill(5)
 
             # Informações do pagamento
@@ -1981,24 +1932,16 @@ class SerializacaoXML(Serializacao):
             etree.SubElement(Comp, "vComp").text = "{:.2f}".format(evento.vComp)
 
             # Continuação das Informações do pagamento
-            etree.SubElement(infPag, "vContrato").text = "{:.2f}".format(
-                evento.vContrato
-            )
+            etree.SubElement(infPag, "vContrato").text = "{:.2f}".format(evento.vContrato)
             etree.SubElement(infPag, "indPag").text = evento.indPag
 
             # Se indPag == 1 (0=A vista e 1=A prazo)
             if evento.indPag != "":
                 if int(evento.indPag) == 1:
                     infPrazo = etree.SubElement(infPag, "infPrazo")
-                    etree.SubElement(infPrazo, "nParcela").text = evento.nParcela.zfill(
-                        3
-                    )
-                    etree.SubElement(infPrazo, "dVenc").text = evento.dVenc.strftime(
-                        "%Y-%m-%d"
-                    )
-                    etree.SubElement(infPrazo, "vParcela").text = "{:.2f}".format(
-                        evento.vParcela
-                    )
+                    etree.SubElement(infPrazo, "nParcela").text = evento.nParcela.zfill(3)
+                    etree.SubElement(infPrazo, "dVenc").text = evento.dVenc.strftime("%Y-%m-%d")
+                    etree.SubElement(infPrazo, "vParcela").text = "{:.2f}".format(evento.vParcela)
 
             # Informações bancárias
             infBanc = etree.SubElement(infPag, "infBanc")
@@ -2039,9 +1982,7 @@ class SerializacaoQrcode(object):
                 cpf = nfe.xpath("ns:infNFe/ns:dest/ns:CNPJ/text()", namespaces=ns)[0]
             except IndexError:
                 cpf = None  # noqa: F841
-        total = nfe.xpath("ns:infNFe/ns:total/ns:ICMSTot/ns:vNF/text()", namespaces=ns)[
-            0
-        ]
+        total = nfe.xpath("ns:infNFe/ns:total/ns:ICMSTot/ns:vNF/text()", namespaces=ns)[0]
         # icms = nfe.xpath('ns:infNFe/ns:total/ns:ICMSTot/ns:vICMS/text()', namespaces=ns)[0]
         digest = nfe.xpath(
             "sig:Signature/sig:SignedInfo/sig:Reference/sig:DigestValue/text()",
@@ -2112,7 +2053,7 @@ class SerializacaoQrcode(object):
         info = etree.Element("infNFeSupl")
         etree.SubElement(info, "qrCode").text = etree.CDATA(qrcode.strip())
         etree.SubElement(info, "urlChave").text = url_chave
-        
+
         nfe.insert(1, info)
 
         # retorna nfe com o qrcode incluido NT2015/002 e qrcode
@@ -2303,9 +2244,7 @@ class SerializacaoMDFe(Serializacao):
         else:
             return raiz
 
-    def _serializar_percurso(
-        self, percurso, tag_raiz="infPercurso", retorna_string=True
-    ):
+    def _serializar_percurso(self, percurso, tag_raiz="infPercurso", retorna_string=True):
         raiz = etree.Element(tag_raiz)
         etree.SubElement(raiz, "UFPer").text = percurso.UFPer
 
@@ -2377,9 +2316,9 @@ class SerializacaoMDFe(Serializacao):
                 if item.NroContrato:
                     infContrato = etree.SubElement(infContratante, "infContrato")
                     etree.SubElement(infContrato, "NroContrato").text = item.NroContrato
-                    etree.SubElement(
-                        infContrato, "vContratoGlobal"
-                    ).text = "{:.2f}".format(item.vContratoGlobal or 0)
+                    etree.SubElement(infContrato, "vContratoGlobal").text = "{:.2f}".format(
+                        item.vContratoGlobal or 0
+                    )
 
         # Veículo Tração
         if len(modal_rodoviario.veiculo_tracao) != 1:
@@ -2393,12 +2332,8 @@ class SerializacaoMDFe(Serializacao):
             if item.RENAVAM:
                 etree.SubElement(veicTracao, "RENAVAM").text = item.RENAVAM
             etree.SubElement(veicTracao, "tara").text = "{:.0f}".format(item.tara or 0)
-            etree.SubElement(veicTracao, "capKG").text = "{:.0f}".format(
-                item.capKG or 0
-            )
-            etree.SubElement(veicTracao, "capM3").text = "{:.0f}".format(
-                item.capM3 or 0
-            )
+            etree.SubElement(veicTracao, "capKG").text = "{:.0f}".format(item.capKG or 0)
+            etree.SubElement(veicTracao, "capM3").text = "{:.0f}".format(item.capM3 or 0)
 
             # Propritario do veículo Tração
             if item.proprietario:
@@ -2410,14 +2345,10 @@ class SerializacaoMDFe(Serializacao):
                     etree.SubElement(prop, "CNPJ").text = item.proprietario.cpfcnpj
 
                 if item.proprietario.rntrc:
-                    etree.SubElement(
-                        prop, "RNTRC"
-                    ).text = item.proprietario.rntrc.zfill(8)
+                    etree.SubElement(prop, "RNTRC").text = item.proprietario.rntrc.zfill(8)
                 etree.SubElement(prop, "xNome").text = item.proprietario.nome
                 if item.proprietario.inscricao_estudual is not None:
-                    etree.SubElement(
-                        prop, "IE"
-                    ).text = item.proprietario.inscricao_estudual
+                    etree.SubElement(prop, "IE").text = item.proprietario.inscricao_estudual
                 etree.SubElement(prop, "UF").text = item.proprietario.uf
                 # tpProp: 0=TACAgregado; 1=TACIndependente; 2=Outros
                 etree.SubElement(prop, "tpProp").text = item.proprietario.tipo
@@ -2426,9 +2357,7 @@ class SerializacaoMDFe(Serializacao):
             if item.condutor is not None:
                 for num, item_condutor in enumerate(item.condutor):
                     condutor = etree.SubElement(veicTracao, "condutor")
-                    etree.SubElement(
-                        condutor, "xNome"
-                    ).text = item_condutor.nome_motorista
+                    etree.SubElement(condutor, "xNome").text = item_condutor.nome_motorista
                     etree.SubElement(condutor, "CPF").text = item_condutor.cpf_motorista
             # fim-condutor
 
@@ -2446,9 +2375,7 @@ class SerializacaoMDFe(Serializacao):
                 etree.SubElement(veicReboque, "placa").text = item_reboque.placa
                 if item_reboque.RENAVAM:
                     etree.SubElement(veicReboque, "RENAVAM").text = item_reboque.RENAVAM
-                etree.SubElement(veicReboque, "tara").text = "{:.0f}".format(
-                    item_reboque.tara or 0
-                )
+                etree.SubElement(veicReboque, "tara").text = "{:.0f}".format(item_reboque.tara or 0)
                 etree.SubElement(veicReboque, "capKG").text = "{:.0f}".format(
                     item_reboque.capKG or 0
                 )
@@ -2461,30 +2388,22 @@ class SerializacaoMDFe(Serializacao):
                     prop = etree.SubElement(veicReboque, "prop")
 
                     if len(item_reboque.proprietario.cpfcnpj) == 11:
-                        etree.SubElement(
-                            prop, "CPF"
-                        ).text = item_reboque.proprietario.cpfcnpj
+                        etree.SubElement(prop, "CPF").text = item_reboque.proprietario.cpfcnpj
                     elif len(item_reboque.proprietario.cpfcnpj) == 14:
-                        etree.SubElement(
-                            prop, "CNPJ"
-                        ).text = item_reboque.proprietario.cpfcnpj
+                        etree.SubElement(prop, "CNPJ").text = item_reboque.proprietario.cpfcnpj
 
                     if item_reboque.proprietario.rntrc:
                         etree.SubElement(
                             prop, "RNTRC"
                         ).text = item_reboque.proprietario.rntrc.zfill(8)
-                    etree.SubElement(
-                        prop, "xNome"
-                    ).text = item_reboque.proprietario.nome
+                    etree.SubElement(prop, "xNome").text = item_reboque.proprietario.nome
                     if item_reboque.proprietario.inscricao_estudual is not None:
                         etree.SubElement(
                             prop, "IE"
                         ).text = item_reboque.proprietario.inscricao_estudual
                     etree.SubElement(prop, "UF").text = item_reboque.proprietario.uf
                     # tpProp: 0=TACAgregado; 1=TACIndependente; 2=Outros
-                    etree.SubElement(
-                        prop, "tpProp"
-                    ).text = item_reboque.proprietario.tipo
+                    etree.SubElement(prop, "tpProp").text = item_reboque.proprietario.tipo
 
                 etree.SubElement(veicReboque, "tpCar").text = item_reboque.tpCar
                 etree.SubElement(veicReboque, "UF").text = item_reboque.UF
@@ -2495,9 +2414,7 @@ class SerializacaoMDFe(Serializacao):
         else:
             return raiz
 
-    def _serializar_documentos(
-        self, documentos, tag_raiz="infDoc", retorna_string=True
-    ):
+    def _serializar_documentos(self, documentos, tag_raiz="infDoc", retorna_string=True):
         raiz = etree.Element(tag_raiz)
 
         if len(documentos) <= 0:
@@ -2660,15 +2577,11 @@ class SerializacaoMDFe(Serializacao):
 
         # infModal rodo
         raiz.append(
-            self._serializar_modal_rodoviario(
-                manifesto.modal_rodoviario, retorna_string=False
-            )
+            self._serializar_modal_rodoviario(manifesto.modal_rodoviario, retorna_string=False)
         )
 
         # infDoc infCTe ou infNFe
-        raiz.append(
-            self._serializar_documentos(manifesto.documentos, retorna_string=False)
-        )
+        raiz.append(self._serializar_documentos(manifesto.documentos, retorna_string=False))
 
         # seg
         if len(manifesto.seguradora) > 0:
@@ -2677,9 +2590,7 @@ class SerializacaoMDFe(Serializacao):
 
         # prodPred
         if len(manifesto.produto) > 0:
-            raiz.append(
-                self._serializar_produto(manifesto.produto[0], retorna_string=False)
-            )
+            raiz.append(self._serializar_produto(manifesto.produto[0], retorna_string=False))
 
         # totais
         raiz.append(self._serializar_totais(manifesto.totais, retorna_string=False))

--- a/pynfe/processamento/validacao.py
+++ b/pynfe/processamento/validacao.py
@@ -64,8 +64,4 @@ class Validacao(object):
                 buffer.seek(0)
                 xml_doc = etree.parse(buffer)
 
-        return (
-            use_assert
-            and xsd_schema.assertValid(xml_doc)
-            or xsd_schema.validate(xml_doc)
-        )
+        return use_assert and xsd_schema.assertValid(xml_doc) or xsd_schema.validate(xml_doc)

--- a/pynfe/utils/__init__.py
+++ b/pynfe/utils/__init__.py
@@ -31,8 +31,8 @@ def so_numeros(texto) -> str:
 
 # @memoize
 def obter_pais_por_codigo(codigo):
-    if codigo == '1058' or codigo == '' or codigo is None:
-        return 'Brasil'
+    if codigo == "1058" or codigo == "" or codigo is None:
+        return "Brasil"
 
     pais = carregar_arquivo_pais(codigo=codigo)
     pais = pais.get(codigo)
@@ -165,13 +165,15 @@ def remover_acentos(txt):
 
 
 def carregar_arquivo_pais(codigo):
-    caminho_arquivo = os.path.join(CAMINHO_MUNICIPIOS, 'PaisIBGE.txt')
+    caminho_arquivo = os.path.join(CAMINHO_MUNICIPIOS, "PaisIBGE.txt")
 
     with open(caminho_arquivo, "r", encoding="utf-8-sig") as arquivo:
         linhas = arquivo.readlines()
 
-    return {linha.split('\t', maxsplit=1)[0].strip(): linha.split('\t', maxsplit=1)[1].strip()
-            for linha in linhas}
+    return {
+        linha.split("\t", maxsplit=1)[0].strip(): linha.split("\t", maxsplit=1)[1].strip()
+        for linha in linhas
+    }
 
 
 class CustomXMLSigner(XMLSigner):
@@ -181,13 +183,14 @@ class CustomXMLSigner(XMLSigner):
     def check_deprecated_methods(self):
         pass
 
+
 def is_empty(value):
     """
     Verifica se um valor está vazio.
-    
+
     Parameters:
     - value: O valor a ser verificado.
-    
+
     Returns:
     - True se o valor estiver vazio, False caso contrário.
     """
@@ -223,7 +226,11 @@ def arredondar_valor(value: float, decimal_places: int, suprimir_zeros: bool = F
 
 
 def ajustar_valor(
-    value: float, decimal_places: int = 2, min_decimal_places: int = 2, tipo: Literal["ROUND", "TRUNC"] = "ROUND", decimal_separator: str = "."
+    value: float,
+    decimal_places: int = 2,
+    min_decimal_places: int = 2,
+    tipo: Literal["ROUND", "TRUNC"] = "ROUND",
+    decimal_separator: str = ".",
 ):
     value = 0 if value is None else value
 

--- a/pynfe/utils/bar_code_128.py
+++ b/pynfe/utils/bar_code_128.py
@@ -542,9 +542,7 @@ class Code128:
             elif (
                 self.CharSetB in (code[c])
                 and current_charset != self.CharSetB
-                and not (
-                    self.CharSetA in (code[c]) and current_charset == self.CharSetA
-                )
+                and not (self.CharSetA in (code[c]) and current_charset == self.CharSetA)
             ):
                 # If char in chrset A = current, then just keep that
                 # Switching to Character set B
@@ -559,9 +557,7 @@ class Code128:
             elif (
                 self.CharSetA in (code[c])
                 and current_charset != self.CharSetA
-                and not (
-                    self.CharSetB in (code[c]) and current_charset == self.CharSetB
-                )
+                and not (self.CharSetB in (code[c]) and current_charset == self.CharSetB)
             ):
                 # if char in chrset B== current, then just keep that
                 # Switching to Character set A
@@ -633,9 +629,7 @@ class Code128:
         # Draw the bar codes
         for bit in range(len(bits)):
             if bits[bit] == "1":
-                draw.rectangle(
-                    ((bit + position, 0), (bit + position, height - 10)), fill=0
-                )
+                draw.rectangle(((bit + position, 0), (bit + position, height - 10)), fill=0)
 
         # Save the result image
         im.save(value + "." + lower(extension), upper(extension))

--- a/pynfe/utils/descompactar.py
+++ b/pynfe/utils/descompactar.py
@@ -1,7 +1,7 @@
 """
-    @author: Lucas Resende
+@author: Lucas Resende
 
-    classe que descompacta o gzip recebido pela consulta distribuicao
+classe que descompacta o gzip recebido pela consulta distribuicao
 
 """
 

--- a/pynfe/utils/flags.py
+++ b/pynfe/utils/flags.py
@@ -43,14 +43,14 @@ ICMS_TIPOS_TRIBUTACAO = (
     ("00", "ICMS 00 - Tributada integralmente"),
     ("02", "ICMS 02 - Tributação monofásica própria sobre combustíveis"),
     ("10", "ICMS 10 - Tributada com cobranca do ICMS por substituicao tributaria"),
-    ("15", "ICMS 15 - Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis"),
+    (
+        "15",
+        "ICMS 15 - Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis",
+    ),
     ("20", "ICMS 20 - Com reducao da base de calculo"),
     (
         "30",
-        (
-            "ICMS 30 - Isenta ou nao tributada e com cobranca do ICMS por substituicao"
-            " tributaria"
-        ),
+        ("ICMS 30 - Isenta ou nao tributada e com cobranca do ICMS por substituicao tributaria"),
     ),
     ("40", "ICMS 40 - Isenta"),
     ("41", "ICMS 41 - Nao tributada"),
@@ -61,10 +61,7 @@ ICMS_TIPOS_TRIBUTACAO = (
     ("61", "ICMS 61 - Tributação monofásica sobre combustíveis cobrada anteriormente"),
     (
         "70",
-        (
-            "ICMS 70 - Com reducao da base de calculo e cobranca do ICMS por"
-            " substituicao tributaria"
-        ),
+        ("ICMS 70 - Com reducao da base de calculo e cobranca do ICMS por substituicao tributaria"),
     ),
     ("90", "ICMS 90 - Outras"),
     ("101", "ICMS 101 - Tributação ICMS pelo Simples Nacional, CSOSN=101"),
@@ -106,10 +103,7 @@ ICMS_ORIGENS = (
     ),
     (
         5,
-        (
-            "Nacional, mercadoria ou bem com Conteúdo de Importação inferior ou igual a"
-            " 40%. "
-        ),
+        ("Nacional, mercadoria ou bem com Conteúdo de Importação inferior ou igual a 40%. "),
     ),
     (
         6,

--- a/pynfe/utils/https_nfse.py
+++ b/pynfe/utils/https_nfse.py
@@ -1,7 +1,7 @@
 """
-    @author: Junior Tada, Leonardo Tada
+@author: Junior Tada, Leonardo Tada
 
-    Classe que sobrescreve metodos da lib suds para comunicação via https com certificado digital
+Classe que sobrescreve metodos da lib suds para comunicação via https com certificado digital
 
 """
 

--- a/pynfe/utils/nfse/betha/_dsig.py
+++ b/pynfe/utils/nfse/betha/_dsig.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:770a0200-e52e-48b5-9080-7379d189705e')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:770a0200-e52e-48b5-9080-7379d189705e"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -28,10 +31,15 @@ _module_typeBindings = pyxb.utils.utility.Object()
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.w3.org/2000/09/xmldsig#', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.w3.org/2000/09/xmldsig#", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -62,7 +70,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -71,7 +81,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -84,1160 +95,1913 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}CryptoBinary
-class CryptoBinary (pyxb.binding.datatypes.base64Binary):
-
+class CryptoBinary(pyxb.binding.datatypes.base64Binary):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CryptoBinary')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 34, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "CryptoBinary")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 34, 0
+    )
     _Documentation = None
+
+
 CryptoBinary._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'CryptoBinary', CryptoBinary)
+Namespace.addCategoryObject("typeBinding", "CryptoBinary", CryptoBinary)
 _module_typeBindings.CryptoBinary = CryptoBinary
 
-# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}DigestValueType
-class DigestValueType (pyxb.binding.datatypes.base64Binary):
 
+# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}DigestValueType
+class DigestValueType(pyxb.binding.datatypes.base64Binary):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DigestValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 134, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DigestValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 134, 0
+    )
     _Documentation = None
+
+
 DigestValueType._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'DigestValueType', DigestValueType)
+Namespace.addCategoryObject("typeBinding", "DigestValueType", DigestValueType)
 _module_typeBindings.DigestValueType = DigestValueType
 
-# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}HMACOutputLengthType
-class HMACOutputLengthType (pyxb.binding.datatypes.integer):
 
+# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}HMACOutputLengthType
+class HMACOutputLengthType(pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLengthType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 281, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "HMACOutputLengthType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 281, 0
+    )
     _Documentation = None
+
+
 HMACOutputLengthType._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'HMACOutputLengthType', HMACOutputLengthType)
+Namespace.addCategoryObject("typeBinding", "HMACOutputLengthType", HMACOutputLengthType)
 _module_typeBindings.HMACOutputLengthType = HMACOutputLengthType
 
+
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureType with content type ELEMENT_ONLY
-class SignatureType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 42, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 42, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureValue uses Python identifier SignatureValue
-    __SignatureValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), 'SignatureValue', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignatureValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 52, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureValue uses Python identifier SignatureValue
+    __SignatureValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+        "SignatureValue",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignatureValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 52, 2
+        ),
+    )
+
     SignatureValue = property(__SignatureValue.value, __SignatureValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignedInfo uses Python identifier SignedInfo
-    __SignedInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), 'SignedInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignedInfo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 63, 0), )
+    __SignedInfo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+        "SignedInfo",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignedInfo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 63, 0
+        ),
+    )
 
-    
     SignedInfo = property(__SignedInfo.value, __SignedInfo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyInfo uses Python identifier KeyInfo
-    __KeyInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), 'KeyInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigKeyInfo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 142, 0), )
+    __KeyInfo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+        "KeyInfo",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigKeyInfo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 142, 0
+        ),
+    )
 
-    
     KeyInfo = property(__KeyInfo.value, __KeyInfo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Object uses Python identifier Object
-    __Object = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Object'), 'Object', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigObject', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 241, 0), )
+    __Object = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Object"),
+        "Object",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigObject",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 241, 0
+        ),
+    )
 
-    
     Object = property(__Object.value, __Object.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 49, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 49, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignatureType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 49, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 49, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __SignatureValue.name() : __SignatureValue,
-        __SignedInfo.name() : __SignedInfo,
-        __KeyInfo.name() : __KeyInfo,
-        __Object.name() : __Object
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __SignatureValue.name(): __SignatureValue,
+            __SignedInfo.name(): __SignedInfo,
+            __KeyInfo.name(): __KeyInfo,
+            __Object.name(): __Object,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignatureType = SignatureType
-Namespace.addCategoryObject('typeBinding', 'SignatureType', SignatureType)
+Namespace.addCategoryObject("typeBinding", "SignatureType", SignatureType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureValueType with content type SIMPLE
-class SignatureValueType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureValueType with content type SIMPLE"""
+
     _TypeDefinition = pyxb.binding.datatypes.base64Binary
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_SIMPLE
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 53, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 53, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.base64Binary
-    
+
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureValueType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 56, 8)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 56, 8)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignatureValueType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 56, 8
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 56, 8
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignatureValueType = SignatureValueType
-Namespace.addCategoryObject('typeBinding', 'SignatureValueType', SignatureValueType)
+Namespace.addCategoryObject("typeBinding", "SignatureValueType", SignatureValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignedInfoType with content type ELEMENT_ONLY
-class SignedInfoType (pyxb.binding.basis.complexTypeDefinition):
+class SignedInfoType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignedInfoType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignedInfoType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 64, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignedInfoType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 64, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethod uses Python identifier CanonicalizationMethod
-    __CanonicalizationMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), 'CanonicalizationMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigCanonicalizationMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 73, 2), )
+    __CanonicalizationMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+        "CanonicalizationMethod",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigCanonicalizationMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 73, 2
+        ),
+    )
 
-    
-    CanonicalizationMethod = property(__CanonicalizationMethod.value, __CanonicalizationMethod.set, None, None)
+    CanonicalizationMethod = property(
+        __CanonicalizationMethod.value, __CanonicalizationMethod.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignatureMethod uses Python identifier SignatureMethod
-    __SignatureMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), 'SignatureMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigSignatureMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 82, 2), )
+    __SignatureMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+        "SignatureMethod",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigSignatureMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 82, 2
+        ),
+    )
 
-    
     SignatureMethod = property(__SignatureMethod.value, __SignatureMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
-    __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 94, 0), )
+    __Reference = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        "Reference",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigReference",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 94, 0
+        ),
+    )
 
-    
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignedInfoType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 70, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 70, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 70, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 70, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __CanonicalizationMethod.name() : __CanonicalizationMethod,
-        __SignatureMethod.name() : __SignatureMethod,
-        __Reference.name() : __Reference
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __CanonicalizationMethod.name(): __CanonicalizationMethod,
+            __SignatureMethod.name(): __SignatureMethod,
+            __Reference.name(): __Reference,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignedInfoType = SignedInfoType
-Namespace.addCategoryObject('typeBinding', 'SignedInfoType', SignedInfoType)
+Namespace.addCategoryObject("typeBinding", "SignedInfoType", SignedInfoType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethodType with content type MIXED
-class CanonicalizationMethodType (pyxb.binding.basis.complexTypeDefinition):
+class CanonicalizationMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 74, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 74, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_CanonicalizationMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 79, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 79, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_CanonicalizationMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 79, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 79, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.CanonicalizationMethodType = CanonicalizationMethodType
-Namespace.addCategoryObject('typeBinding', 'CanonicalizationMethodType', CanonicalizationMethodType)
+Namespace.addCategoryObject("typeBinding", "CanonicalizationMethodType", CanonicalizationMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureMethodType with content type MIXED
-class SignatureMethodType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 83, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 83, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}HMACOutputLength uses Python identifier HMACOutputLength
-    __HMACOutputLength = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength'), 'HMACOutputLength', '__httpwww_w3_org200009xmldsig_SignatureMethodType_httpwww_w3_org200009xmldsigHMACOutputLength', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 85, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}HMACOutputLength uses Python identifier HMACOutputLength
+    __HMACOutputLength = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength"),
+        "HMACOutputLength",
+        "__httpwww_w3_org200009xmldsig_SignatureMethodType_httpwww_w3_org200009xmldsigHMACOutputLength",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 85, 6
+        ),
+    )
+
     HMACOutputLength = property(__HMACOutputLength.value, __HMACOutputLength.set, None, None)
 
-    
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_SignatureMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 89, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 89, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_SignatureMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 89, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 89, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __HMACOutputLength.name() : __HMACOutputLength
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({__HMACOutputLength.name(): __HMACOutputLength})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.SignatureMethodType = SignatureMethodType
-Namespace.addCategoryObject('typeBinding', 'SignatureMethodType', SignatureMethodType)
+Namespace.addCategoryObject("typeBinding", "SignatureMethodType", SignatureMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ReferenceType with content type ELEMENT_ONLY
-class ReferenceType (pyxb.binding.basis.complexTypeDefinition):
+class ReferenceType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ReferenceType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ReferenceType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 95, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ReferenceType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 95, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
-    __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 106, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
+    __Transforms = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        "Transforms",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigTransforms",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 106, 2
+        ),
+    )
+
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestMethod uses Python identifier DigestMethod
-    __DigestMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), 'DigestMethod', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 125, 0), )
+    __DigestMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+        "DigestMethod",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 125, 0
+        ),
+    )
 
-    
     DigestMethod = property(__DigestMethod.value, __DigestMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestValue uses Python identifier DigestValue
-    __DigestValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), 'DigestValue', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 133, 0), )
+    __DigestValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+        "DigestValue",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 133, 0
+        ),
+    )
 
-    
     DigestValue = property(__DigestValue.value, __DigestValue.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ReferenceType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 101, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 101, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 101, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 101, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    
     # Attribute URI uses Python identifier URI
-    __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_ReferenceType_URI', pyxb.binding.datatypes.anyURI)
-    __URI._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 102, 2)
-    __URI._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 102, 2)
-    
+    __URI = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "URI"),
+        "URI",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_URI",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __URI._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 102, 2
+    )
+    __URI._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 102, 2
+    )
+
     URI = property(__URI.value, __URI.set, None, None)
 
-    
     # Attribute Type uses Python identifier Type
-    __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_ReferenceType_Type', pyxb.binding.datatypes.anyURI)
-    __Type._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 103, 2)
-    __Type._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 103, 2)
-    
+    __Type = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Type"),
+        "Type",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_Type",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Type._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 103, 2
+    )
+    __Type._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 103, 2
+    )
+
     Type = property(__Type.value, __Type.set, None, None)
 
-    _ElementMap.update({
-        __Transforms.name() : __Transforms,
-        __DigestMethod.name() : __DigestMethod,
-        __DigestValue.name() : __DigestValue
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id,
-        __URI.name() : __URI,
-        __Type.name() : __Type
-    })
+    _ElementMap.update(
+        {
+            __Transforms.name(): __Transforms,
+            __DigestMethod.name(): __DigestMethod,
+            __DigestValue.name(): __DigestValue,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id, __URI.name(): __URI, __Type.name(): __Type})
+
+
 _module_typeBindings.ReferenceType = ReferenceType
-Namespace.addCategoryObject('typeBinding', 'ReferenceType', ReferenceType)
+Namespace.addCategoryObject("typeBinding", "ReferenceType", ReferenceType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}TransformsType with content type ELEMENT_ONLY
-class TransformsType (pyxb.binding.basis.complexTypeDefinition):
+class TransformsType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}TransformsType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TransformsType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 107, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "TransformsType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 107, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transform uses Python identifier Transform
-    __Transform = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transform'), 'Transform', '__httpwww_w3_org200009xmldsig_TransformsType_httpwww_w3_org200009xmldsigTransform', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 113, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transform uses Python identifier Transform
+    __Transform = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transform"),
+        "Transform",
+        "__httpwww_w3_org200009xmldsig_TransformsType_httpwww_w3_org200009xmldsigTransform",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 113, 2
+        ),
+    )
+
     Transform = property(__Transform.value, __Transform.set, None, None)
 
-    _ElementMap.update({
-        __Transform.name() : __Transform
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Transform.name(): __Transform})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.TransformsType = TransformsType
-Namespace.addCategoryObject('typeBinding', 'TransformsType', TransformsType)
+Namespace.addCategoryObject("typeBinding", "TransformsType", TransformsType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}TransformType with content type MIXED
-class TransformType (pyxb.binding.basis.complexTypeDefinition):
+class TransformType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}TransformType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TransformType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 114, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "TransformType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 114, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}XPath uses Python identifier XPath
-    __XPath = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'XPath'), 'XPath', '__httpwww_w3_org200009xmldsig_TransformType_httpwww_w3_org200009xmldsigXPath', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 118, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}XPath uses Python identifier XPath
+    __XPath = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "XPath"),
+        "XPath",
+        "__httpwww_w3_org200009xmldsig_TransformType_httpwww_w3_org200009xmldsigXPath",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 118, 6
+        ),
+    )
+
     XPath = property(__XPath.value, __XPath.set, None, None)
 
-    
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_TransformType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 120, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 120, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_TransformType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 120, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 120, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __XPath.name() : __XPath
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({__XPath.name(): __XPath})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.TransformType = TransformType
-Namespace.addCategoryObject('typeBinding', 'TransformType', TransformType)
+Namespace.addCategoryObject("typeBinding", "TransformType", TransformType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}DigestMethodType with content type MIXED
-class DigestMethodType (pyxb.binding.basis.complexTypeDefinition):
+class DigestMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}DigestMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DigestMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 126, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DigestMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 126, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_DigestMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 130, 2)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 130, 2)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_DigestMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 130, 2
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 130, 2
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.DigestMethodType = DigestMethodType
-Namespace.addCategoryObject('typeBinding', 'DigestMethodType', DigestMethodType)
+Namespace.addCategoryObject("typeBinding", "DigestMethodType", DigestMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}KeyInfoType with content type MIXED
-class KeyInfoType (pyxb.binding.basis.complexTypeDefinition):
+class KeyInfoType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}KeyInfoType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'KeyInfoType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 143, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "KeyInfoType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 143, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}KeyName uses Python identifier KeyName
-    __KeyName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), 'KeyName', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyName', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 158, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}KeyName uses Python identifier KeyName
+    __KeyName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+        "KeyName",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyName",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 158, 2
+        ),
+    )
+
     KeyName = property(__KeyName.value, __KeyName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}MgmtData uses Python identifier MgmtData
-    __MgmtData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), 'MgmtData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigMgmtData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 159, 2), )
+    __MgmtData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+        "MgmtData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigMgmtData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 159, 2
+        ),
+    )
 
-    
     MgmtData = property(__MgmtData.value, __MgmtData.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyValue uses Python identifier KeyValue
-    __KeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), 'KeyValue', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyValue', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 161, 2), )
+    __KeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+        "KeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyValue",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 161, 2
+        ),
+    )
 
-    
     KeyValue = property(__KeyValue.value, __KeyValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}RetrievalMethod uses Python identifier RetrievalMethod
-    __RetrievalMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), 'RetrievalMethod', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigRetrievalMethod', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 170, 2), )
+    __RetrievalMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+        "RetrievalMethod",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigRetrievalMethod",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 170, 2
+        ),
+    )
 
-    
     RetrievalMethod = property(__RetrievalMethod.value, __RetrievalMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Data uses Python identifier X509Data
-    __X509Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), 'X509Data', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigX509Data', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 181, 0), )
+    __X509Data = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+        "X509Data",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigX509Data",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 181, 0
+        ),
+    )
 
-    
     X509Data = property(__X509Data.value, __X509Data.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPData uses Python identifier PGPData
-    __PGPData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), 'PGPData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigPGPData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 206, 0), )
+    __PGPData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+        "PGPData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigPGPData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 206, 0
+        ),
+    )
 
-    
     PGPData = property(__PGPData.value, __PGPData.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SPKIData uses Python identifier SPKIData
-    __SPKIData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), 'SPKIData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigSPKIData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 227, 0), )
+    __SPKIData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+        "SPKIData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigSPKIData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 227, 0
+        ),
+    )
 
-    
     SPKIData = property(__SPKIData.value, __SPKIData.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_KeyInfoType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 155, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 155, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 155, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 155, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __KeyName.name() : __KeyName,
-        __MgmtData.name() : __MgmtData,
-        __KeyValue.name() : __KeyValue,
-        __RetrievalMethod.name() : __RetrievalMethod,
-        __X509Data.name() : __X509Data,
-        __PGPData.name() : __PGPData,
-        __SPKIData.name() : __SPKIData
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __KeyName.name(): __KeyName,
+            __MgmtData.name(): __MgmtData,
+            __KeyValue.name(): __KeyValue,
+            __RetrievalMethod.name(): __RetrievalMethod,
+            __X509Data.name(): __X509Data,
+            __PGPData.name(): __PGPData,
+            __SPKIData.name(): __SPKIData,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.KeyInfoType = KeyInfoType
-Namespace.addCategoryObject('typeBinding', 'KeyInfoType', KeyInfoType)
+Namespace.addCategoryObject("typeBinding", "KeyInfoType", KeyInfoType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}KeyValueType with content type MIXED
-class KeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class KeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}KeyValueType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'KeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 162, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "KeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 162, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}DSAKeyValue uses Python identifier DSAKeyValue
-    __DSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), 'DSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigDSAKeyValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 287, 0), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}DSAKeyValue uses Python identifier DSAKeyValue
+    __DSAKeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+        "DSAKeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigDSAKeyValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 287, 0
+        ),
+    )
+
     DSAKeyValue = property(__DSAKeyValue.value, __DSAKeyValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}RSAKeyValue uses Python identifier RSAKeyValue
-    __RSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), 'RSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigRSAKeyValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 304, 0), )
+    __RSAKeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+        "RSAKeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigRSAKeyValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 304, 0
+        ),
+    )
 
-    
     RSAKeyValue = property(__RSAKeyValue.value, __RSAKeyValue.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __DSAKeyValue.name() : __DSAKeyValue,
-        __RSAKeyValue.name() : __RSAKeyValue
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DSAKeyValue.name(): __DSAKeyValue, __RSAKeyValue.name(): __RSAKeyValue})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.KeyValueType = KeyValueType
-Namespace.addCategoryObject('typeBinding', 'KeyValueType', KeyValueType)
+Namespace.addCategoryObject("typeBinding", "KeyValueType", KeyValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}RetrievalMethodType with content type ELEMENT_ONLY
-class RetrievalMethodType (pyxb.binding.basis.complexTypeDefinition):
+class RetrievalMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}RetrievalMethodType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 171, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "RetrievalMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 171, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
-    __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 106, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
+    __Transforms = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        "Transforms",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_httpwww_w3_org200009xmldsigTransforms",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 106, 2
+        ),
+    )
+
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-    
     # Attribute URI uses Python identifier URI
-    __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_URI', pyxb.binding.datatypes.anyURI)
-    __URI._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 175, 4)
-    __URI._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 175, 4)
-    
+    __URI = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "URI"),
+        "URI",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_URI",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __URI._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 175, 4
+    )
+    __URI._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 175, 4
+    )
+
     URI = property(__URI.value, __URI.set, None, None)
 
-    
     # Attribute Type uses Python identifier Type
-    __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_Type', pyxb.binding.datatypes.anyURI)
-    __Type._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 176, 4)
-    __Type._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 176, 4)
-    
+    __Type = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Type"),
+        "Type",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_Type",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Type._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 176, 4
+    )
+    __Type._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 176, 4
+    )
+
     Type = property(__Type.value, __Type.set, None, None)
 
-    _ElementMap.update({
-        __Transforms.name() : __Transforms
-    })
-    _AttributeMap.update({
-        __URI.name() : __URI,
-        __Type.name() : __Type
-    })
+    _ElementMap.update({__Transforms.name(): __Transforms})
+    _AttributeMap.update({__URI.name(): __URI, __Type.name(): __Type})
+
+
 _module_typeBindings.RetrievalMethodType = RetrievalMethodType
-Namespace.addCategoryObject('typeBinding', 'RetrievalMethodType', RetrievalMethodType)
+Namespace.addCategoryObject("typeBinding", "RetrievalMethodType", RetrievalMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}X509DataType with content type ELEMENT_ONLY
-class X509DataType (pyxb.binding.basis.complexTypeDefinition):
+class X509DataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}X509DataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'X509DataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 182, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "X509DataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 182, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerial uses Python identifier X509IssuerSerial
-    __X509IssuerSerial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial'), 'X509IssuerSerial', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509IssuerSerial', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 185, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerial uses Python identifier X509IssuerSerial
+    __X509IssuerSerial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial"),
+        "X509IssuerSerial",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509IssuerSerial",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 185, 6
+        ),
+    )
+
     X509IssuerSerial = property(__X509IssuerSerial.value, __X509IssuerSerial.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SKI uses Python identifier X509SKI
-    __X509SKI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SKI'), 'X509SKI', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SKI', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 186, 6), )
+    __X509SKI = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SKI"),
+        "X509SKI",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SKI",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 186, 6
+        ),
+    )
 
-    
     X509SKI = property(__X509SKI.value, __X509SKI.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SubjectName uses Python identifier X509SubjectName
-    __X509SubjectName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName'), 'X509SubjectName', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SubjectName', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 187, 6), )
+    __X509SubjectName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SubjectName"),
+        "X509SubjectName",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SubjectName",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 187, 6
+        ),
+    )
 
-    
     X509SubjectName = property(__X509SubjectName.value, __X509SubjectName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Certificate uses Python identifier X509Certificate
-    __X509Certificate = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate'), 'X509Certificate', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509Certificate', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 188, 6), )
+    __X509Certificate = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509Certificate"),
+        "X509Certificate",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509Certificate",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 188, 6
+        ),
+    )
 
-    
     X509Certificate = property(__X509Certificate.value, __X509Certificate.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509CRL uses Python identifier X509CRL
-    __X509CRL = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509CRL'), 'X509CRL', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509CRL', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 189, 6), )
+    __X509CRL = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509CRL"),
+        "X509CRL",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509CRL",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 189, 6
+        ),
+    )
 
-    
     X509CRL = property(__X509CRL.value, __X509CRL.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __X509IssuerSerial.name() : __X509IssuerSerial,
-        __X509SKI.name() : __X509SKI,
-        __X509SubjectName.name() : __X509SubjectName,
-        __X509Certificate.name() : __X509Certificate,
-        __X509CRL.name() : __X509CRL
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __X509IssuerSerial.name(): __X509IssuerSerial,
+            __X509SKI.name(): __X509SKI,
+            __X509SubjectName.name(): __X509SubjectName,
+            __X509Certificate.name(): __X509Certificate,
+            __X509CRL.name(): __X509CRL,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.X509DataType = X509DataType
-Namespace.addCategoryObject('typeBinding', 'X509DataType', X509DataType)
+Namespace.addCategoryObject("typeBinding", "X509DataType", X509DataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerialType with content type ELEMENT_ONLY
-class X509IssuerSerialType (pyxb.binding.basis.complexTypeDefinition):
+class X509IssuerSerialType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerialType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerialType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 195, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerialType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 195, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerName uses Python identifier X509IssuerName
-    __X509IssuerName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName'), 'X509IssuerName', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509IssuerName', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 197, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerName uses Python identifier X509IssuerName
+    __X509IssuerName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerName"),
+        "X509IssuerName",
+        "__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509IssuerName",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 197, 4
+        ),
+    )
+
     X509IssuerName = property(__X509IssuerName.value, __X509IssuerName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SerialNumber uses Python identifier X509SerialNumber
-    __X509SerialNumber = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber'), 'X509SerialNumber', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509SerialNumber', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 198, 4), )
+    __X509SerialNumber = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber"),
+        "X509SerialNumber",
+        "__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509SerialNumber",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 198, 4
+        ),
+    )
 
-    
     X509SerialNumber = property(__X509SerialNumber.value, __X509SerialNumber.set, None, None)
 
-    _ElementMap.update({
-        __X509IssuerName.name() : __X509IssuerName,
-        __X509SerialNumber.name() : __X509SerialNumber
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__X509IssuerName.name(): __X509IssuerName, __X509SerialNumber.name(): __X509SerialNumber}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.X509IssuerSerialType = X509IssuerSerialType
-Namespace.addCategoryObject('typeBinding', 'X509IssuerSerialType', X509IssuerSerialType)
+Namespace.addCategoryObject("typeBinding", "X509IssuerSerialType", X509IssuerSerialType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}PGPDataType with content type ELEMENT_ONLY
-class PGPDataType (pyxb.binding.basis.complexTypeDefinition):
+class PGPDataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}PGPDataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'PGPDataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 207, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "PGPDataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 207, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyID uses Python identifier PGPKeyID
-    __PGPKeyID = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID'), 'PGPKeyID', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyID', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 210, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyID uses Python identifier PGPKeyID
+    __PGPKeyID = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyID"),
+        "PGPKeyID",
+        "__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyID",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 210, 6
+        ),
+    )
+
     PGPKeyID = property(__PGPKeyID.value, __PGPKeyID.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyPacket uses Python identifier PGPKeyPacket
-    __PGPKeyPacket = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket'), 'PGPKeyPacket', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyPacket', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 211, 6), )
+    __PGPKeyPacket = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket"),
+        "PGPKeyPacket",
+        "__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyPacket",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 211, 6
+        ),
+    )
 
-    
     PGPKeyPacket = property(__PGPKeyPacket.value, __PGPKeyPacket.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __PGPKeyID.name() : __PGPKeyID,
-        __PGPKeyPacket.name() : __PGPKeyPacket
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__PGPKeyID.name(): __PGPKeyID, __PGPKeyPacket.name(): __PGPKeyPacket})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.PGPDataType = PGPDataType
-Namespace.addCategoryObject('typeBinding', 'PGPDataType', PGPDataType)
+Namespace.addCategoryObject("typeBinding", "PGPDataType", PGPDataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SPKIDataType with content type ELEMENT_ONLY
-class SPKIDataType (pyxb.binding.basis.complexTypeDefinition):
+class SPKIDataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SPKIDataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SPKIDataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 228, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SPKIDataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 228, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SPKISexp uses Python identifier SPKISexp
-    __SPKISexp = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp'), 'SPKISexp', '__httpwww_w3_org200009xmldsig_SPKIDataType_httpwww_w3_org200009xmldsigSPKISexp', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 230, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SPKISexp uses Python identifier SPKISexp
+    __SPKISexp = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SPKISexp"),
+        "SPKISexp",
+        "__httpwww_w3_org200009xmldsig_SPKIDataType_httpwww_w3_org200009xmldsigSPKISexp",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 230, 4
+        ),
+    )
+
     SPKISexp = property(__SPKISexp.value, __SPKISexp.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __SPKISexp.name() : __SPKISexp
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__SPKISexp.name(): __SPKISexp})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.SPKIDataType = SPKIDataType
-Namespace.addCategoryObject('typeBinding', 'SPKIDataType', SPKIDataType)
+Namespace.addCategoryObject("typeBinding", "SPKIDataType", SPKIDataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ObjectType with content type MIXED
-class ObjectType (pyxb.binding.basis.complexTypeDefinition):
+class ObjectType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ObjectType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ObjectType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 242, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ObjectType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 242, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ObjectType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 246, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 246, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ObjectType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 246, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 246, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    
     # Attribute MimeType uses Python identifier MimeType
-    __MimeType = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'MimeType'), 'MimeType', '__httpwww_w3_org200009xmldsig_ObjectType_MimeType', pyxb.binding.datatypes.string)
-    __MimeType._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 247, 2)
-    __MimeType._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 247, 2)
-    
+    __MimeType = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "MimeType"),
+        "MimeType",
+        "__httpwww_w3_org200009xmldsig_ObjectType_MimeType",
+        pyxb.binding.datatypes.string,
+    )
+    __MimeType._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 247, 2
+    )
+    __MimeType._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 247, 2
+    )
+
     MimeType = property(__MimeType.value, __MimeType.set, None, None)
 
-    
     # Attribute Encoding uses Python identifier Encoding
-    __Encoding = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Encoding'), 'Encoding', '__httpwww_w3_org200009xmldsig_ObjectType_Encoding', pyxb.binding.datatypes.anyURI)
-    __Encoding._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 248, 2)
-    __Encoding._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 248, 2)
-    
+    __Encoding = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Encoding"),
+        "Encoding",
+        "__httpwww_w3_org200009xmldsig_ObjectType_Encoding",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Encoding._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 248, 2
+    )
+    __Encoding._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 248, 2
+    )
+
     Encoding = property(__Encoding.value, __Encoding.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id,
-        __MimeType.name() : __MimeType,
-        __Encoding.name() : __Encoding
-    })
+    _ElementMap.update({})
+    _AttributeMap.update(
+        {__Id.name(): __Id, __MimeType.name(): __MimeType, __Encoding.name(): __Encoding}
+    )
+
+
 _module_typeBindings.ObjectType = ObjectType
-Namespace.addCategoryObject('typeBinding', 'ObjectType', ObjectType)
+Namespace.addCategoryObject("typeBinding", "ObjectType", ObjectType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ManifestType with content type ELEMENT_ONLY
-class ManifestType (pyxb.binding.basis.complexTypeDefinition):
+class ManifestType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ManifestType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ManifestType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 252, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ManifestType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 252, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
-    __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_ManifestType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 94, 0), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
+    __Reference = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        "Reference",
+        "__httpwww_w3_org200009xmldsig_ManifestType_httpwww_w3_org200009xmldsigReference",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 94, 0
+        ),
+    )
+
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ManifestType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 256, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 256, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ManifestType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 256, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 256, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Reference.name() : __Reference
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__Reference.name(): __Reference})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.ManifestType = ManifestType
-Namespace.addCategoryObject('typeBinding', 'ManifestType', ManifestType)
+Namespace.addCategoryObject("typeBinding", "ManifestType", ManifestType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertiesType with content type ELEMENT_ONLY
-class SignaturePropertiesType (pyxb.binding.basis.complexTypeDefinition):
+class SignaturePropertiesType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertiesType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignaturePropertiesType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 260, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignaturePropertiesType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 260, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureProperty uses Python identifier SignatureProperty
-    __SignatureProperty = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), 'SignatureProperty', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_httpwww_w3_org200009xmldsigSignatureProperty', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 267, 3), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureProperty uses Python identifier SignatureProperty
+    __SignatureProperty = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+        "SignatureProperty",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertiesType_httpwww_w3_org200009xmldsigSignatureProperty",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 267, 3
+        ),
+    )
+
     SignatureProperty = property(__SignatureProperty.value, __SignatureProperty.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 264, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 264, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertiesType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 264, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 264, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __SignatureProperty.name() : __SignatureProperty
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__SignatureProperty.name(): __SignatureProperty})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignaturePropertiesType = SignaturePropertiesType
-Namespace.addCategoryObject('typeBinding', 'SignaturePropertiesType', SignaturePropertiesType)
+Namespace.addCategoryObject("typeBinding", "SignaturePropertiesType", SignaturePropertiesType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertyType with content type MIXED
-class SignaturePropertyType (pyxb.binding.basis.complexTypeDefinition):
+class SignaturePropertyType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertyType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignaturePropertyType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 268, 3)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignaturePropertyType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 268, 3
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Target uses Python identifier Target
-    __Target = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Target'), 'Target', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Target', pyxb.binding.datatypes.anyURI, required=True)
-    __Target._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 273, 5)
-    __Target._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 273, 5)
-    
+    __Target = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Target"),
+        "Target",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertyType_Target",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Target._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 273, 5
+    )
+    __Target._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 273, 5
+    )
+
     Target = property(__Target.value, __Target.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 274, 5)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 274, 5)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertyType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 274, 5
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 274, 5
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Target.name() : __Target,
-        __Id.name() : __Id
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Target.name(): __Target, __Id.name(): __Id})
+
+
 _module_typeBindings.SignaturePropertyType = SignaturePropertyType
-Namespace.addCategoryObject('typeBinding', 'SignaturePropertyType', SignaturePropertyType)
+Namespace.addCategoryObject("typeBinding", "SignaturePropertyType", SignaturePropertyType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}DSAKeyValueType with content type ELEMENT_ONLY
-class DSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class DSAKeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}DSAKeyValueType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 288, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DSAKeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 288, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}P uses Python identifier P
-    __P = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'P'), 'P', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigP', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 291, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}P uses Python identifier P
+    __P = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "P"),
+        "P",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigP",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 291, 6
+        ),
+    )
+
     P = property(__P.value, __P.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Q uses Python identifier Q
-    __Q = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Q'), 'Q', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigQ', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 292, 6), )
+    __Q = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Q"),
+        "Q",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigQ",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 292, 6
+        ),
+    )
 
-    
     Q = property(__Q.value, __Q.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}G uses Python identifier G
-    __G = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'G'), 'G', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigG', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 294, 4), )
+    __G = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "G"),
+        "G",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigG",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 294, 4
+        ),
+    )
 
-    
     G = property(__G.value, __G.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Y uses Python identifier Y
-    __Y = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Y'), 'Y', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigY', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 295, 4), )
+    __Y = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Y"),
+        "Y",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigY",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 295, 4
+        ),
+    )
 
-    
     Y = property(__Y.value, __Y.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}J uses Python identifier J
-    __J = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'J'), 'J', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigJ', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 296, 4), )
+    __J = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "J"),
+        "J",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigJ",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 296, 4
+        ),
+    )
 
-    
     J = property(__J.value, __J.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Seed uses Python identifier Seed
-    __Seed = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Seed'), 'Seed', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigSeed', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 298, 6), )
+    __Seed = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Seed"),
+        "Seed",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigSeed",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 298, 6
+        ),
+    )
 
-    
     Seed = property(__Seed.value, __Seed.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PgenCounter uses Python identifier PgenCounter
-    __PgenCounter = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter'), 'PgenCounter', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigPgenCounter', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 299, 6), )
+    __PgenCounter = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PgenCounter"),
+        "PgenCounter",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigPgenCounter",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 299, 6
+        ),
+    )
 
-    
     PgenCounter = property(__PgenCounter.value, __PgenCounter.set, None, None)
 
-    _ElementMap.update({
-        __P.name() : __P,
-        __Q.name() : __Q,
-        __G.name() : __G,
-        __Y.name() : __Y,
-        __J.name() : __J,
-        __Seed.name() : __Seed,
-        __PgenCounter.name() : __PgenCounter
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __P.name(): __P,
+            __Q.name(): __Q,
+            __G.name(): __G,
+            __Y.name(): __Y,
+            __J.name(): __J,
+            __Seed.name(): __Seed,
+            __PgenCounter.name(): __PgenCounter,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.DSAKeyValueType = DSAKeyValueType
-Namespace.addCategoryObject('typeBinding', 'DSAKeyValueType', DSAKeyValueType)
+Namespace.addCategoryObject("typeBinding", "DSAKeyValueType", DSAKeyValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}RSAKeyValueType with content type ELEMENT_ONLY
-class RSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class RSAKeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}RSAKeyValueType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 305, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "RSAKeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 305, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Modulus uses Python identifier Modulus
-    __Modulus = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Modulus'), 'Modulus', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigModulus', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 307, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Modulus uses Python identifier Modulus
+    __Modulus = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Modulus"),
+        "Modulus",
+        "__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigModulus",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 307, 4
+        ),
+    )
+
     Modulus = property(__Modulus.value, __Modulus.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Exponent uses Python identifier Exponent
-    __Exponent = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Exponent'), 'Exponent', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigExponent', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 308, 4), )
+    __Exponent = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Exponent"),
+        "Exponent",
+        "__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigExponent",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 308, 4
+        ),
+    )
 
-    
     Exponent = property(__Exponent.value, __Exponent.set, None, None)
 
-    _ElementMap.update({
-        __Modulus.name() : __Modulus,
-        __Exponent.name() : __Exponent
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Modulus.name(): __Modulus, __Exponent.name(): __Exponent})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.RSAKeyValueType = RSAKeyValueType
-Namespace.addCategoryObject('typeBinding', 'RSAKeyValueType', RSAKeyValueType)
+Namespace.addCategoryObject("typeBinding", "RSAKeyValueType", RSAKeyValueType)
 
 
-KeyName = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), pyxb.binding.datatypes.string, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 158, 2))
-Namespace.addCategoryObject('elementBinding', KeyName.name().localName(), KeyName)
+KeyName = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+    pyxb.binding.datatypes.string,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 158, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyName.name().localName(), KeyName)
 
-MgmtData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), pyxb.binding.datatypes.string, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 159, 2))
-Namespace.addCategoryObject('elementBinding', MgmtData.name().localName(), MgmtData)
+MgmtData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+    pyxb.binding.datatypes.string,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 159, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", MgmtData.name().localName(), MgmtData)
 
-Signature = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Signature'), SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0))
-Namespace.addCategoryObject('elementBinding', Signature.name().localName(), Signature)
+Signature = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Signature"),
+    SignatureType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Signature.name().localName(), Signature)
 
-SignatureValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), SignatureValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 52, 2))
-Namespace.addCategoryObject('elementBinding', SignatureValue.name().localName(), SignatureValue)
+SignatureValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+    SignatureValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 52, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignatureValue.name().localName(), SignatureValue)
 
-SignedInfo = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 63, 0))
-Namespace.addCategoryObject('elementBinding', SignedInfo.name().localName(), SignedInfo)
+SignedInfo = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+    SignedInfoType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 63, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignedInfo.name().localName(), SignedInfo)
 
-CanonicalizationMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), CanonicalizationMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 73, 2))
-Namespace.addCategoryObject('elementBinding', CanonicalizationMethod.name().localName(), CanonicalizationMethod)
+CanonicalizationMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+    CanonicalizationMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 73, 2
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CanonicalizationMethod.name().localName(), CanonicalizationMethod
+)
 
-SignatureMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), SignatureMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 82, 2))
-Namespace.addCategoryObject('elementBinding', SignatureMethod.name().localName(), SignatureMethod)
+SignatureMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+    SignatureMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 82, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignatureMethod.name().localName(), SignatureMethod)
 
-Reference = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 94, 0))
-Namespace.addCategoryObject('elementBinding', Reference.name().localName(), Reference)
+Reference = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Reference"),
+    ReferenceType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 94, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Reference.name().localName(), Reference)
 
-Transforms = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 106, 2))
-Namespace.addCategoryObject('elementBinding', Transforms.name().localName(), Transforms)
+Transforms = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+    TransformsType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 106, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Transforms.name().localName(), Transforms)
 
-Transform = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transform'), TransformType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 113, 2))
-Namespace.addCategoryObject('elementBinding', Transform.name().localName(), Transform)
+Transform = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Transform"),
+    TransformType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 113, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Transform.name().localName(), Transform)
 
-DigestMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), DigestMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 125, 0))
-Namespace.addCategoryObject('elementBinding', DigestMethod.name().localName(), DigestMethod)
+DigestMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+    DigestMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 125, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DigestMethod.name().localName(), DigestMethod)
 
-DigestValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), DigestValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 133, 0))
-Namespace.addCategoryObject('elementBinding', DigestValue.name().localName(), DigestValue)
+DigestValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+    DigestValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 133, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DigestValue.name().localName(), DigestValue)
 
-KeyInfo = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 142, 0))
-Namespace.addCategoryObject('elementBinding', KeyInfo.name().localName(), KeyInfo)
+KeyInfo = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+    KeyInfoType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 142, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyInfo.name().localName(), KeyInfo)
 
-KeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 161, 2))
-Namespace.addCategoryObject('elementBinding', KeyValue.name().localName(), KeyValue)
+KeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+    KeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 161, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyValue.name().localName(), KeyValue)
 
-RetrievalMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), RetrievalMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 170, 2))
-Namespace.addCategoryObject('elementBinding', RetrievalMethod.name().localName(), RetrievalMethod)
+RetrievalMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+    RetrievalMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 170, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", RetrievalMethod.name().localName(), RetrievalMethod)
 
-X509Data = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 181, 0))
-Namespace.addCategoryObject('elementBinding', X509Data.name().localName(), X509Data)
+X509Data = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+    X509DataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 181, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", X509Data.name().localName(), X509Data)
 
-PGPData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 206, 0))
-Namespace.addCategoryObject('elementBinding', PGPData.name().localName(), PGPData)
+PGPData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+    PGPDataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 206, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", PGPData.name().localName(), PGPData)
 
-SPKIData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), SPKIDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 227, 0))
-Namespace.addCategoryObject('elementBinding', SPKIData.name().localName(), SPKIData)
+SPKIData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+    SPKIDataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 227, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SPKIData.name().localName(), SPKIData)
 
-Object = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Object'), ObjectType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 241, 0))
-Namespace.addCategoryObject('elementBinding', Object.name().localName(), Object)
+Object = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Object"),
+    ObjectType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 241, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Object.name().localName(), Object)
 
-Manifest = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Manifest'), ManifestType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 251, 0))
-Namespace.addCategoryObject('elementBinding', Manifest.name().localName(), Manifest)
+Manifest = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Manifest"),
+    ManifestType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 251, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Manifest.name().localName(), Manifest)
 
-SignatureProperties = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperties'), SignaturePropertiesType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 259, 0))
-Namespace.addCategoryObject('elementBinding', SignatureProperties.name().localName(), SignatureProperties)
+SignatureProperties = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureProperties"),
+    SignaturePropertiesType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 259, 0
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SignatureProperties.name().localName(), SignatureProperties
+)
 
-SignatureProperty = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), SignaturePropertyType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 267, 3))
-Namespace.addCategoryObject('elementBinding', SignatureProperty.name().localName(), SignatureProperty)
+SignatureProperty = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+    SignaturePropertyType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 267, 3
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SignatureProperty.name().localName(), SignatureProperty
+)
 
-DSAKeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 287, 0))
-Namespace.addCategoryObject('elementBinding', DSAKeyValue.name().localName(), DSAKeyValue)
+DSAKeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+    DSAKeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 287, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DSAKeyValue.name().localName(), DSAKeyValue)
 
-RSAKeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 304, 0))
-Namespace.addCategoryObject('elementBinding', RSAKeyValue.name().localName(), RSAKeyValue)
+RSAKeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+    RSAKeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 304, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", RSAKeyValue.name().localName(), RSAKeyValue)
 
 
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+        SignatureValueType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 52, 2
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), SignatureValueType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 52, 2)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+        SignedInfoType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 63, 0
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), SignedInfoType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 63, 0)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+        KeyInfoType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 142, 0
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), KeyInfoType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 142, 0)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Object"),
+        ObjectType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 241, 0
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Object'), ObjectType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 241, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 46, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 46, 4
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 47, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 47, 4
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 44, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignedInfo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 44, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 45, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignatureValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 45, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 46, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyInfo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 46, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Object')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 47, 4))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Object")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 47, 4
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, True)]))
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignatureType._Automaton = _BuildAutomaton()
 
 
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+        CanonicalizationMethodType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 73, 2
+        ),
+    )
+)
+
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+        SignatureMethodType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 82, 2
+        ),
+    )
+)
+
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        ReferenceType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 94, 0
+        ),
+    )
+)
 
 
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), CanonicalizationMethodType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 73, 2)))
-
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), SignatureMethodType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 82, 2)))
-
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 94, 0)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
@@ -1246,149 +2010,283 @@ def _BuildAutomaton_ ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 66, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 66, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 67, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignatureMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 67, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Reference')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 68, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Reference")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 68, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignedInfoType._Automaton = _BuildAutomaton_()
 
 
-
-
-def _BuildAutomaton_2 ():
+def _BuildAutomaton_2():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_2
     del _BuildAutomaton_2
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 76, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 76, 6
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_strict, namespace_constraint=pyxb.binding.content.Wildcard.NC_any), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 76, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_strict,
+            namespace_constraint=pyxb.binding.content.Wildcard.NC_any,
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 76, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 CanonicalizationMethodType._Automaton = _BuildAutomaton_2()
 
 
+SignatureMethodType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength"),
+        HMACOutputLengthType,
+        scope=SignatureMethodType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 85, 6
+        ),
+    )
+)
 
 
-SignatureMethodType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength'), HMACOutputLengthType, scope=SignatureMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 85, 6)))
-
-def _BuildAutomaton_3 ():
+def _BuildAutomaton_3():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_3
     del _BuildAutomaton_3
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 85, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 85, 6
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 86, 6))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 86, 6
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 85, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 85, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_strict, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 86, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_strict,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 86, 6
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 SignatureMethodType._Automaton = _BuildAutomaton_3()
 
 
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        TransformsType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 106, 2
+        ),
+    )
+)
+
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+        DigestMethodType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 125, 0
+        ),
+    )
+)
+
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+        DigestValueType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 133, 0
+        ),
+    )
+)
 
 
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 106, 2)))
-
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), DigestMethodType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 125, 0)))
-
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), DigestValueType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 133, 0)))
-
-def _BuildAutomaton_4 ():
+def _BuildAutomaton_4():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_4
     del _BuildAutomaton_4
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 97, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 97, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transforms')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 97, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transforms")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 97, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 98, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DigestMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 98, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DigestValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 99, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DigestValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 99, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 ReferenceType._Automaton = _BuildAutomaton_4()
 
 
+TransformsType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transform"),
+        TransformType,
+        scope=TransformsType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 113, 2
+        ),
+    )
+)
 
 
-TransformsType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transform'), TransformType, scope=TransformsType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 113, 2)))
-
-def _BuildAutomaton_5 ():
+def _BuildAutomaton_5():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_5
     del _BuildAutomaton_5
@@ -1397,99 +2295,219 @@ def _BuildAutomaton_5 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(TransformsType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transform')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 109, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        TransformsType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transform")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 109, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 TransformsType._Automaton = _BuildAutomaton_5()
 
 
+TransformType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "XPath"),
+        pyxb.binding.datatypes.string,
+        scope=TransformType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 118, 6
+        ),
+    )
+)
 
 
-TransformType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'XPath'), pyxb.binding.datatypes.string, scope=TransformType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 118, 6)))
-
-def _BuildAutomaton_6 ():
+def _BuildAutomaton_6():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_6
     del _BuildAutomaton_6
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 115, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 115, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 116, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 116, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(TransformType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'XPath')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 118, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        TransformType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "XPath")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 118, 6
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 TransformType._Automaton = _BuildAutomaton_6()
 
 
-
-
-def _BuildAutomaton_7 ():
+def _BuildAutomaton_7():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_7
     del _BuildAutomaton_7
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 128, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 128, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 128, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 128, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 DigestMethodType._Automaton = _BuildAutomaton_7()
 
 
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+        pyxb.binding.datatypes.string,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 158, 2
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+        pyxb.binding.datatypes.string,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 159, 2
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+        KeyValueType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 161, 2
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+        RetrievalMethodType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 170, 2
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+        X509DataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 181, 0
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+        PGPDataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 206, 0
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+        SPKIDataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 227, 0
+        ),
+    )
+)
 
 
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), pyxb.binding.datatypes.string, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 158, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), pyxb.binding.datatypes.string, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 159, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), KeyValueType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 161, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), RetrievalMethodType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 170, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), X509DataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 181, 0)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), PGPDataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 206, 0)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), SPKIDataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 227, 0)))
-
-def _BuildAutomaton_8 ():
+def _BuildAutomaton_8():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_8
     del _BuildAutomaton_8
@@ -1498,192 +2516,209 @@ def _BuildAutomaton_8 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 145, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 145, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 146, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 146, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 147, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 147, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509Data')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 148, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509Data")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 148, 4
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 149, 4))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 149, 4
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SPKIData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 150, 4))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SPKIData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 150, 4
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MgmtData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 151, 4))
-    st_6 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MgmtData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 151, 4
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 152, 4))
-    st_7 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 152, 4
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_7._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 KeyInfoType._Automaton = _BuildAutomaton_8()
 
 
+KeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+        DSAKeyValueType,
+        scope=KeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 287, 0
+        ),
+    )
+)
+
+KeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+        RSAKeyValueType,
+        scope=KeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 304, 0
+        ),
+    )
+)
 
 
-KeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), DSAKeyValueType, scope=KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 287, 0)))
-
-KeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), RSAKeyValueType, scope=KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 304, 0)))
-
-def _BuildAutomaton_9 ():
+def _BuildAutomaton_9():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_9
     del _BuildAutomaton_9
@@ -1692,16 +2727,43 @@ def _BuildAutomaton_9 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 164, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 164, 5
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 165, 5))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 165, 5
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 166, 5))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 166, 5
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
     st_0._set_transitionSet(transitions)
@@ -1710,49 +2772,117 @@ def _BuildAutomaton_9 ():
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 KeyValueType._Automaton = _BuildAutomaton_9()
 
 
+RetrievalMethodType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        TransformsType,
+        scope=RetrievalMethodType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 106, 2
+        ),
+    )
+)
 
 
-RetrievalMethodType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, scope=RetrievalMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 106, 2)))
-
-def _BuildAutomaton_10 ():
+def _BuildAutomaton_10():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_10
     del _BuildAutomaton_10
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 173, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 173, 6
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(RetrievalMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transforms')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 173, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RetrievalMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transforms")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 173, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 RetrievalMethodType._Automaton = _BuildAutomaton_10()
 
 
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial"),
+        X509IssuerSerialType,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 185, 6
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SKI"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 186, 6
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SubjectName"),
+        pyxb.binding.datatypes.string,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 187, 6
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509Certificate"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 188, 6
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509CRL"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 189, 6
+        ),
+    )
+)
 
 
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial'), X509IssuerSerialType, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 185, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SKI'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 186, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName'), pyxb.binding.datatypes.string, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 187, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 188, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509CRL'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 189, 6)))
-
-def _BuildAutomaton_11 ():
+def _BuildAutomaton_11():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_11
     del _BuildAutomaton_11
@@ -1761,124 +2891,155 @@ def _BuildAutomaton_11 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 185, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 185, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SKI')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 186, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SKI")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 186, 6
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 187, 6))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SubjectName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 187, 6
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 188, 6))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509Certificate")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 188, 6
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509CRL')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 189, 6))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509CRL")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 189, 6
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 190, 6))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 190, 6
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_5._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 X509DataType._Automaton = _BuildAutomaton_11()
 
 
+X509IssuerSerialType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerName"),
+        pyxb.binding.datatypes.string,
+        scope=X509IssuerSerialType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 197, 4
+        ),
+    )
+)
+
+X509IssuerSerialType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber"),
+        pyxb.binding.datatypes.integer,
+        scope=X509IssuerSerialType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 198, 4
+        ),
+    )
+)
 
 
-X509IssuerSerialType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName'), pyxb.binding.datatypes.string, scope=X509IssuerSerialType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 197, 4)))
-
-X509IssuerSerialType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber'), pyxb.binding.datatypes.integer, scope=X509IssuerSerialType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 198, 4)))
-
-def _BuildAutomaton_12 ():
+def _BuildAutomaton_12():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_12
     del _BuildAutomaton_12
@@ -1887,163 +3048,310 @@ def _BuildAutomaton_12 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 197, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509IssuerName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 197, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 198, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 198, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 X509IssuerSerialType._Automaton = _BuildAutomaton_12()
 
 
+PGPDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyID"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=PGPDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 210, 6
+        ),
+    )
+)
+
+PGPDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=PGPDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 211, 6
+        ),
+    )
+)
 
 
-PGPDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID'), pyxb.binding.datatypes.base64Binary, scope=PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 210, 6)))
-
-PGPDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket'), pyxb.binding.datatypes.base64Binary, scope=PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 211, 6)))
-
-def _BuildAutomaton_13 ():
+def _BuildAutomaton_13():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_13
     del _BuildAutomaton_13
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 211, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 211, 6
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 212, 6))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 212, 6
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 217, 6))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 217, 6
+        ),
+    )
     counters.add(cc_2)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 210, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyID")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 210, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 211, 6))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 211, 6
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 212, 6))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 212, 6
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 216, 6))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 216, 6
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 217, 6))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 217, 6
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, True) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, True)]))
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 PGPDataType._Automaton = _BuildAutomaton_13()
 
 
+SPKIDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SPKISexp"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=SPKIDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 230, 4
+        ),
+    )
+)
 
 
-SPKIDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp'), pyxb.binding.datatypes.base64Binary, scope=SPKIDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 230, 4)))
-
-def _BuildAutomaton_14 ():
+def _BuildAutomaton_14():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_14
     del _BuildAutomaton_14
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 231, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 231, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SPKIDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 230, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SPKIDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SPKISexp")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 230, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 231, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 231, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SPKIDataType._Automaton = _BuildAutomaton_14()
 
 
-
-
-def _BuildAutomaton_15 ():
+def _BuildAutomaton_15():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_15
     del _BuildAutomaton_15
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 243, 2))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 243, 2
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=pyxb.binding.content.Wildcard.NC_any), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 244, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=pyxb.binding.content.Wildcard.NC_any,
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 244, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 ObjectType._Automaton = _BuildAutomaton_15()
 
 
+ManifestType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        ReferenceType,
+        scope=ManifestType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 94, 0
+        ),
+    )
+)
 
 
-ManifestType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, scope=ManifestType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 94, 0)))
-
-def _BuildAutomaton_16 ():
+def _BuildAutomaton_16():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_16
     del _BuildAutomaton_16
@@ -2052,22 +3360,38 @@ def _BuildAutomaton_16 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(ManifestType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Reference')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 254, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ManifestType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Reference")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 254, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 ManifestType._Automaton = _BuildAutomaton_16()
 
 
+SignaturePropertiesType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+        SignaturePropertyType,
+        scope=SignaturePropertiesType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 267, 3
+        ),
+    )
+)
 
 
-SignaturePropertiesType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), SignaturePropertyType, scope=SignaturePropertiesType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 267, 3)))
-
-def _BuildAutomaton_17 ():
+def _BuildAutomaton_17():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_17
     del _BuildAutomaton_17
@@ -2076,20 +3400,28 @@ def _BuildAutomaton_17 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignaturePropertiesType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 262, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignaturePropertiesType._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "SignatureProperty")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 262, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignaturePropertiesType._Automaton = _BuildAutomaton_17()
 
 
-
-
-def _BuildAutomaton_18 ():
+def _BuildAutomaton_18():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_18
     del _BuildAutomaton_18
@@ -2098,128 +3430,284 @@ def _BuildAutomaton_18 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 270, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 270, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignaturePropertyType._Automaton = _BuildAutomaton_18()
 
 
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "P"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 291, 6
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Q"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 292, 6
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "G"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 294, 4
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Y"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 295, 4
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "J"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 296, 4
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Seed"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 298, 6
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PgenCounter"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 299, 6
+        ),
+    )
+)
 
 
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'P'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 291, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Q'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 292, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'G'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 294, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Y'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 295, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'J'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 296, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Seed'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 298, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 299, 6)))
-
-def _BuildAutomaton_19 ():
+def _BuildAutomaton_19():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_19
     del _BuildAutomaton_19
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 290, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 290, 4
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 294, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 294, 4
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 296, 4))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 296, 4
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 297, 4))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 297, 4
+        ),
+    )
     counters.add(cc_3)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'P')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 291, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "P")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 291, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Q')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 292, 6))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Q")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 292, 6
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'G')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 294, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "G")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 294, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Y')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 295, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Y")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 295, 4
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'J')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 296, 4))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "J")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 296, 4
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Seed')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 298, 6))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Seed")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 298, 6
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 299, 6))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PgenCounter")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 299, 6
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-         ]))
+    transitions.append(fac.Transition(st_6, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, True) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, True)]))
     st_6._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 DSAKeyValueType._Automaton = _BuildAutomaton_19()
 
 
+RSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Modulus"),
+        CryptoBinary,
+        scope=RSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 307, 4
+        ),
+    )
+)
+
+RSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Exponent"),
+        CryptoBinary,
+        scope=RSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 308, 4
+        ),
+    )
+)
 
 
-RSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Modulus'), CryptoBinary, scope=RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 307, 4)))
-
-RSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Exponent'), CryptoBinary, scope=RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 308, 4)))
-
-def _BuildAutomaton_20 ():
+def _BuildAutomaton_20():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_20
     del _BuildAutomaton_20
@@ -2228,19 +3716,33 @@ def _BuildAutomaton_20 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Modulus')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 307, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Modulus")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 307, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Exponent')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 308, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Exponent")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 308, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-RSAKeyValueType._Automaton = _BuildAutomaton_20()
 
+
+RSAKeyValueType._Automaton = _BuildAutomaton_20()

--- a/pynfe/utils/nfse/betha/nfse_v202.py
+++ b/pynfe/utils/nfse/betha/nfse_v202.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:770a0200-e52e-48b5-9080-7379d189705e')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:770a0200-e52e-48b5-9080-7379d189705e"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.betha import _dsig as _ImportedBinding__dsig
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.betha.com.br/e-nota-contribuinte-ws', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.betha.com.br/e-nota-contribuinte-ws", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,4041 +98,6343 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroNfse
-class tsNumeroNfse (pyxb.binding.datatypes.nonNegativeInteger):
-
+class tsNumeroNfse(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 10, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 10, 1
+    )
     _Documentation = None
-tsNumeroNfse._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
+
+
+tsNumeroNfse._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
 tsNumeroNfse._InitializeFacetMap(tsNumeroNfse._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroNfse', tsNumeroNfse)
+Namespace.addCategoryObject("typeBinding", "tsNumeroNfse", tsNumeroNfse)
 _module_typeBindings.tsNumeroNfse = tsNumeroNfse
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoVerificacao
-class tsCodigoVerificacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoVerificacao
+class tsCodigoVerificacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoVerificacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 15, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoVerificacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 15, 1
+    )
     _Documentation = None
-tsCodigoVerificacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(9))
-tsCodigoVerificacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoVerificacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoVerificacao._InitializeFacetMap(tsCodigoVerificacao._CF_maxLength,
-   tsCodigoVerificacao._CF_minLength,
-   tsCodigoVerificacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoVerificacao', tsCodigoVerificacao)
+
+
+tsCodigoVerificacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(9)
+)
+tsCodigoVerificacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoVerificacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoVerificacao._InitializeFacetMap(
+    tsCodigoVerificacao._CF_maxLength,
+    tsCodigoVerificacao._CF_minLength,
+    tsCodigoVerificacao._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoVerificacao", tsCodigoVerificacao)
 _module_typeBindings.tsCodigoVerificacao = tsCodigoVerificacao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsStatusRps
-class tsStatusRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsStatusRps
+class tsStatusRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsStatusRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 22, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsStatusRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 22, 1
+    )
     _Documentation = None
+
+
 tsStatusRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsStatusRps._CF_pattern.addPattern(pattern='1|2')
+tsStatusRps._CF_pattern.addPattern(pattern="1|2")
 tsStatusRps._InitializeFacetMap(tsStatusRps._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsStatusRps', tsStatusRps)
+Namespace.addCategoryObject("typeBinding", "tsStatusRps", tsStatusRps)
 _module_typeBindings.tsStatusRps = tsStatusRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsStatusNfse
-class tsStatusNfse (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsStatusNfse
+class tsStatusNfse(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsStatusNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 27, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsStatusNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 27, 1
+    )
     _Documentation = None
+
+
 tsStatusNfse._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsStatusNfse._CF_pattern.addPattern(pattern='1|2')
+tsStatusNfse._CF_pattern.addPattern(pattern="1|2")
 tsStatusNfse._InitializeFacetMap(tsStatusNfse._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsStatusNfse', tsStatusNfse)
+Namespace.addCategoryObject("typeBinding", "tsStatusNfse", tsStatusNfse)
 _module_typeBindings.tsStatusNfse = tsStatusNfse
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsExigibilidadeISS
-class tsExigibilidadeISS (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsExigibilidadeISS
+class tsExigibilidadeISS(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsExigibilidadeISS')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 32, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsExigibilidadeISS")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 32, 1
+    )
     _Documentation = None
+
+
 tsExigibilidadeISS._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsExigibilidadeISS._CF_pattern.addPattern(pattern='1|2|3|4|5|6|7')
+tsExigibilidadeISS._CF_pattern.addPattern(pattern="1|2|3|4|5|6|7")
 tsExigibilidadeISS._InitializeFacetMap(tsExigibilidadeISS._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsExigibilidadeISS', tsExigibilidadeISS)
+Namespace.addCategoryObject("typeBinding", "tsExigibilidadeISS", tsExigibilidadeISS)
 _module_typeBindings.tsExigibilidadeISS = tsExigibilidadeISS
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroProcesso
-class tsNumeroProcesso (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroProcesso
+class tsNumeroProcesso(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroProcesso')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 37, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroProcesso")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 37, 1
+    )
     _Documentation = None
-tsNumeroProcesso._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(30))
-tsNumeroProcesso._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsNumeroProcesso._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroProcesso._InitializeFacetMap(tsNumeroProcesso._CF_maxLength,
-   tsNumeroProcesso._CF_minLength,
-   tsNumeroProcesso._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroProcesso', tsNumeroProcesso)
+
+
+tsNumeroProcesso._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(30)
+)
+tsNumeroProcesso._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsNumeroProcesso._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroProcesso._InitializeFacetMap(
+    tsNumeroProcesso._CF_maxLength, tsNumeroProcesso._CF_minLength, tsNumeroProcesso._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNumeroProcesso", tsNumeroProcesso)
 _module_typeBindings.tsNumeroProcesso = tsNumeroProcesso
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsRegimeEspecialTributacao
-class tsRegimeEspecialTributacao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsRegimeEspecialTributacao
+class tsRegimeEspecialTributacao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsRegimeEspecialTributacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 44, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsRegimeEspecialTributacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 44, 1
+    )
     _Documentation = None
+
+
 tsRegimeEspecialTributacao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsRegimeEspecialTributacao._CF_pattern.addPattern(pattern='1|2|3|4|5|6')
+tsRegimeEspecialTributacao._CF_pattern.addPattern(pattern="1|2|3|4|5|6")
 tsRegimeEspecialTributacao._InitializeFacetMap(tsRegimeEspecialTributacao._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsRegimeEspecialTributacao', tsRegimeEspecialTributacao)
+Namespace.addCategoryObject("typeBinding", "tsRegimeEspecialTributacao", tsRegimeEspecialTributacao)
 _module_typeBindings.tsRegimeEspecialTributacao = tsRegimeEspecialTributacao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSimNao
-class tsSimNao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSimNao
+class tsSimNao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSimNao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 49, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSimNao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 49, 1
+    )
     _Documentation = None
+
+
 tsSimNao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsSimNao._CF_pattern.addPattern(pattern='1|2')
+tsSimNao._CF_pattern.addPattern(pattern="1|2")
 tsSimNao._InitializeFacetMap(tsSimNao._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsSimNao', tsSimNao)
+Namespace.addCategoryObject("typeBinding", "tsSimNao", tsSimNao)
 _module_typeBindings.tsSimNao = tsSimNao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsResponsavelRetencao
-class tsResponsavelRetencao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsResponsavelRetencao
+class tsResponsavelRetencao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsResponsavelRetencao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 54, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsResponsavelRetencao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 54, 1
+    )
     _Documentation = None
+
+
 tsResponsavelRetencao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsResponsavelRetencao._CF_pattern.addPattern(pattern='1|2')
+tsResponsavelRetencao._CF_pattern.addPattern(pattern="1|2")
 tsResponsavelRetencao._InitializeFacetMap(tsResponsavelRetencao._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsResponsavelRetencao', tsResponsavelRetencao)
+Namespace.addCategoryObject("typeBinding", "tsResponsavelRetencao", tsResponsavelRetencao)
 _module_typeBindings.tsResponsavelRetencao = tsResponsavelRetencao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsPagina
-class tsPagina (pyxb.binding.datatypes.nonNegativeInteger):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsPagina
+class tsPagina(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsPagina')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 59, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsPagina")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 59, 1
+    )
     _Documentation = None
-tsPagina._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value=pyxb.binding.datatypes.nonNegativeInteger(999999), value_datatype=tsPagina)
-tsPagina._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value=pyxb.binding.datatypes.nonNegativeInteger(1), value_datatype=tsPagina)
-tsPagina._InitializeFacetMap(tsPagina._CF_maxInclusive,
-   tsPagina._CF_minInclusive)
-Namespace.addCategoryObject('typeBinding', 'tsPagina', tsPagina)
+
+
+tsPagina._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(
+    value=pyxb.binding.datatypes.nonNegativeInteger(999999), value_datatype=tsPagina
+)
+tsPagina._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1), value_datatype=tsPagina
+)
+tsPagina._InitializeFacetMap(tsPagina._CF_maxInclusive, tsPagina._CF_minInclusive)
+Namespace.addCategoryObject("typeBinding", "tsPagina", tsPagina)
 _module_typeBindings.tsPagina = tsPagina
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroRps
-class tsNumeroRps (pyxb.binding.datatypes.nonNegativeInteger):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroRps
+class tsNumeroRps(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 65, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 65, 1
+    )
     _Documentation = None
-tsNumeroRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
+
+
+tsNumeroRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
 tsNumeroRps._InitializeFacetMap(tsNumeroRps._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroRps', tsNumeroRps)
+Namespace.addCategoryObject("typeBinding", "tsNumeroRps", tsNumeroRps)
 _module_typeBindings.tsNumeroRps = tsNumeroRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSerieRps
-class tsSerieRps (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSerieRps
+class tsSerieRps(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSerieRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 70, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSerieRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 70, 1
+    )
     _Documentation = None
-tsSerieRps._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(5))
-tsSerieRps._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsSerieRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsSerieRps._InitializeFacetMap(tsSerieRps._CF_maxLength,
-   tsSerieRps._CF_minLength,
-   tsSerieRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsSerieRps', tsSerieRps)
+
+
+tsSerieRps._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(5)
+)
+tsSerieRps._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsSerieRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsSerieRps._InitializeFacetMap(
+    tsSerieRps._CF_maxLength, tsSerieRps._CF_minLength, tsSerieRps._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsSerieRps", tsSerieRps)
 _module_typeBindings.tsSerieRps = tsSerieRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsTipoRps
-class tsTipoRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsTipoRps
+class tsTipoRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsTipoRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 77, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsTipoRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 77, 1
+    )
     _Documentation = None
+
+
 tsTipoRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsTipoRps._CF_pattern.addPattern(pattern='1|2|3')
+tsTipoRps._CF_pattern.addPattern(pattern="1|2|3")
 tsTipoRps._InitializeFacetMap(tsTipoRps._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsTipoRps', tsTipoRps)
+Namespace.addCategoryObject("typeBinding", "tsTipoRps", tsTipoRps)
 _module_typeBindings.tsTipoRps = tsTipoRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsOutrasInformacoes
-class tsOutrasInformacoes (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsOutrasInformacoes
+class tsOutrasInformacoes(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsOutrasInformacoes')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 82, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsOutrasInformacoes")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 82, 1
+    )
     _Documentation = None
-tsOutrasInformacoes._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(255))
-tsOutrasInformacoes._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsOutrasInformacoes._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsOutrasInformacoes._InitializeFacetMap(tsOutrasInformacoes._CF_maxLength,
-   tsOutrasInformacoes._CF_minLength,
-   tsOutrasInformacoes._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsOutrasInformacoes', tsOutrasInformacoes)
+
+
+tsOutrasInformacoes._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(255)
+)
+tsOutrasInformacoes._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsOutrasInformacoes._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsOutrasInformacoes._InitializeFacetMap(
+    tsOutrasInformacoes._CF_maxLength,
+    tsOutrasInformacoes._CF_minLength,
+    tsOutrasInformacoes._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsOutrasInformacoes", tsOutrasInformacoes)
 _module_typeBindings.tsOutrasInformacoes = tsOutrasInformacoes
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsValor
-class tsValor (pyxb.binding.datatypes.decimal):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsValor
+class tsValor(pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsValor')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 89, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsValor")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 89, 1
+    )
     _Documentation = None
-tsValor._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(value=pyxb.binding.datatypes.nonNegativeInteger(2))
-tsValor._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value=pyxb.binding.datatypes.decimal('0.0'), value_datatype=tsValor)
-tsValor._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
-tsValor._InitializeFacetMap(tsValor._CF_fractionDigits,
-   tsValor._CF_minInclusive,
-   tsValor._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsValor', tsValor)
+
+
+tsValor._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(
+    value=pyxb.binding.datatypes.nonNegativeInteger(2)
+)
+tsValor._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(
+    value=pyxb.binding.datatypes.decimal("0.0"), value_datatype=tsValor
+)
+tsValor._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
+tsValor._InitializeFacetMap(
+    tsValor._CF_fractionDigits, tsValor._CF_minInclusive, tsValor._CF_totalDigits
+)
+Namespace.addCategoryObject("typeBinding", "tsValor", tsValor)
 _module_typeBindings.tsValor = tsValor
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsItemListaServico
-class tsItemListaServico (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsItemListaServico
+class tsItemListaServico(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsItemListaServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 96, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsItemListaServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 96, 1
+    )
     _Documentation = None
-tsItemListaServico._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(5))
-tsItemListaServico._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsItemListaServico._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsItemListaServico._InitializeFacetMap(tsItemListaServico._CF_maxLength,
-   tsItemListaServico._CF_minLength,
-   tsItemListaServico._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsItemListaServico', tsItemListaServico)
+
+
+tsItemListaServico._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(5)
+)
+tsItemListaServico._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsItemListaServico._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsItemListaServico._InitializeFacetMap(
+    tsItemListaServico._CF_maxLength,
+    tsItemListaServico._CF_minLength,
+    tsItemListaServico._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsItemListaServico", tsItemListaServico)
 _module_typeBindings.tsItemListaServico = tsItemListaServico
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoCnae
-class tsCodigoCnae (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoCnae
+class tsCodigoCnae(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoCnae')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 103, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoCnae")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 103, 1
+    )
     _Documentation = None
-tsCodigoCnae._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(7))
+
+
+tsCodigoCnae._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(7)
+)
 tsCodigoCnae._InitializeFacetMap(tsCodigoCnae._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoCnae', tsCodigoCnae)
+Namespace.addCategoryObject("typeBinding", "tsCodigoCnae", tsCodigoCnae)
 _module_typeBindings.tsCodigoCnae = tsCodigoCnae
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoTributacao
-class tsCodigoTributacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoTributacao
+class tsCodigoTributacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoTributacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 108, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoTributacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 108, 1
+    )
     _Documentation = None
-tsCodigoTributacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(20))
-tsCodigoTributacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoTributacao._InitializeFacetMap(tsCodigoTributacao._CF_maxLength,
-   tsCodigoTributacao._CF_minLength,
-   tsCodigoTributacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoTributacao', tsCodigoTributacao)
+
+
+tsCodigoTributacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(20)
+)
+tsCodigoTributacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoTributacao._InitializeFacetMap(
+    tsCodigoTributacao._CF_maxLength,
+    tsCodigoTributacao._CF_minLength,
+    tsCodigoTributacao._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoTributacao", tsCodigoTributacao)
 _module_typeBindings.tsCodigoTributacao = tsCodigoTributacao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsAliquota
-class tsAliquota (pyxb.binding.datatypes.decimal):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsAliquota
+class tsAliquota(pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsAliquota')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 115, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsAliquota")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 115, 1
+    )
     _Documentation = None
-tsAliquota._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsAliquota._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value=pyxb.binding.datatypes.decimal('0.0'), value_datatype=tsAliquota)
-tsAliquota._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(6))
-tsAliquota._InitializeFacetMap(tsAliquota._CF_fractionDigits,
-   tsAliquota._CF_minInclusive,
-   tsAliquota._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsAliquota', tsAliquota)
+
+
+tsAliquota._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsAliquota._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(
+    value=pyxb.binding.datatypes.decimal("0.0"), value_datatype=tsAliquota
+)
+tsAliquota._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(6)
+)
+tsAliquota._InitializeFacetMap(
+    tsAliquota._CF_fractionDigits, tsAliquota._CF_minInclusive, tsAliquota._CF_totalDigits
+)
+Namespace.addCategoryObject("typeBinding", "tsAliquota", tsAliquota)
 _module_typeBindings.tsAliquota = tsAliquota
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsDiscriminacao
-class tsDiscriminacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsDiscriminacao
+class tsDiscriminacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsDiscriminacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 122, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsDiscriminacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 122, 1
+    )
     _Documentation = None
-tsDiscriminacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(2000))
-tsDiscriminacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsDiscriminacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsDiscriminacao._InitializeFacetMap(tsDiscriminacao._CF_maxLength,
-   tsDiscriminacao._CF_minLength,
-   tsDiscriminacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsDiscriminacao', tsDiscriminacao)
+
+
+tsDiscriminacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(2000)
+)
+tsDiscriminacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsDiscriminacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsDiscriminacao._InitializeFacetMap(
+    tsDiscriminacao._CF_maxLength, tsDiscriminacao._CF_minLength, tsDiscriminacao._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsDiscriminacao", tsDiscriminacao)
 _module_typeBindings.tsDiscriminacao = tsDiscriminacao
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoMunicipioIbge
-class tsCodigoMunicipioIbge (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoMunicipioIbge
+class tsCodigoMunicipioIbge(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoMunicipioIbge')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 129, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoMunicipioIbge")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 129, 1
+    )
     _Documentation = None
-tsCodigoMunicipioIbge._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(7))
+
+
+tsCodigoMunicipioIbge._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(7)
+)
 tsCodigoMunicipioIbge._InitializeFacetMap(tsCodigoMunicipioIbge._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoMunicipioIbge', tsCodigoMunicipioIbge)
+Namespace.addCategoryObject("typeBinding", "tsCodigoMunicipioIbge", tsCodigoMunicipioIbge)
 _module_typeBindings.tsCodigoMunicipioIbge = tsCodigoMunicipioIbge
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsInscricaoMunicipal
-class tsInscricaoMunicipal (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsInscricaoMunicipal
+class tsInscricaoMunicipal(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsInscricaoMunicipal')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 134, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsInscricaoMunicipal")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 134, 1
+    )
     _Documentation = None
-tsInscricaoMunicipal._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsInscricaoMunicipal._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsInscricaoMunicipal._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsInscricaoMunicipal._InitializeFacetMap(tsInscricaoMunicipal._CF_maxLength,
-   tsInscricaoMunicipal._CF_minLength,
-   tsInscricaoMunicipal._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsInscricaoMunicipal', tsInscricaoMunicipal)
+
+
+tsInscricaoMunicipal._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsInscricaoMunicipal._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsInscricaoMunicipal._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsInscricaoMunicipal._InitializeFacetMap(
+    tsInscricaoMunicipal._CF_maxLength,
+    tsInscricaoMunicipal._CF_minLength,
+    tsInscricaoMunicipal._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsInscricaoMunicipal", tsInscricaoMunicipal)
 _module_typeBindings.tsInscricaoMunicipal = tsInscricaoMunicipal
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsRazaoSocial
-class tsRazaoSocial (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsRazaoSocial
+class tsRazaoSocial(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsRazaoSocial')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 141, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsRazaoSocial")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 141, 1
+    )
     _Documentation = None
-tsRazaoSocial._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(150))
-tsRazaoSocial._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsRazaoSocial._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsRazaoSocial._InitializeFacetMap(tsRazaoSocial._CF_maxLength,
-   tsRazaoSocial._CF_minLength,
-   tsRazaoSocial._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsRazaoSocial', tsRazaoSocial)
+
+
+tsRazaoSocial._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(150)
+)
+tsRazaoSocial._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsRazaoSocial._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsRazaoSocial._InitializeFacetMap(
+    tsRazaoSocial._CF_maxLength, tsRazaoSocial._CF_minLength, tsRazaoSocial._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsRazaoSocial", tsRazaoSocial)
 _module_typeBindings.tsRazaoSocial = tsRazaoSocial
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNomeFantasia
-class tsNomeFantasia (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNomeFantasia
+class tsNomeFantasia(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNomeFantasia')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 148, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNomeFantasia")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 148, 1
+    )
     _Documentation = None
-tsNomeFantasia._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsNomeFantasia._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsNomeFantasia._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNomeFantasia._InitializeFacetMap(tsNomeFantasia._CF_maxLength,
-   tsNomeFantasia._CF_minLength,
-   tsNomeFantasia._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNomeFantasia', tsNomeFantasia)
+
+
+tsNomeFantasia._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsNomeFantasia._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsNomeFantasia._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNomeFantasia._InitializeFacetMap(
+    tsNomeFantasia._CF_maxLength, tsNomeFantasia._CF_minLength, tsNomeFantasia._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNomeFantasia", tsNomeFantasia)
 _module_typeBindings.tsNomeFantasia = tsNomeFantasia
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCnpj
-class tsCnpj (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCnpj
+class tsCnpj(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCnpj')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 155, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCnpj")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 155, 1
+    )
     _Documentation = None
-tsCnpj._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(14))
-tsCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCnpj._InitializeFacetMap(tsCnpj._CF_length,
-   tsCnpj._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCnpj', tsCnpj)
+
+
+tsCnpj._CF_length = pyxb.binding.facets.CF_length(
+    value=pyxb.binding.datatypes.nonNegativeInteger(14)
+)
+tsCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCnpj._InitializeFacetMap(tsCnpj._CF_length, tsCnpj._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsCnpj", tsCnpj)
 _module_typeBindings.tsCnpj = tsCnpj
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsEndereco
-class tsEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsEndereco
+class tsEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 161, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 161, 1
+    )
     _Documentation = None
-tsEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(125))
-tsEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsEndereco._InitializeFacetMap(tsEndereco._CF_maxLength,
-   tsEndereco._CF_minLength,
-   tsEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsEndereco', tsEndereco)
+
+
+tsEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(125)
+)
+tsEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsEndereco._InitializeFacetMap(
+    tsEndereco._CF_maxLength, tsEndereco._CF_minLength, tsEndereco._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsEndereco", tsEndereco)
 _module_typeBindings.tsEndereco = tsEndereco
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroEndereco
-class tsNumeroEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroEndereco
+class tsNumeroEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 168, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 168, 1
+    )
     _Documentation = None
-tsNumeroEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(10))
-tsNumeroEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsNumeroEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroEndereco._InitializeFacetMap(tsNumeroEndereco._CF_maxLength,
-   tsNumeroEndereco._CF_minLength,
-   tsNumeroEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroEndereco', tsNumeroEndereco)
+
+
+tsNumeroEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(10)
+)
+tsNumeroEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsNumeroEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroEndereco._InitializeFacetMap(
+    tsNumeroEndereco._CF_maxLength, tsNumeroEndereco._CF_minLength, tsNumeroEndereco._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNumeroEndereco", tsNumeroEndereco)
 _module_typeBindings.tsNumeroEndereco = tsNumeroEndereco
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsComplementoEndereco
-class tsComplementoEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsComplementoEndereco
+class tsComplementoEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsComplementoEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 175, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsComplementoEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 175, 1
+    )
     _Documentation = None
-tsComplementoEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsComplementoEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsComplementoEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsComplementoEndereco._InitializeFacetMap(tsComplementoEndereco._CF_maxLength,
-   tsComplementoEndereco._CF_minLength,
-   tsComplementoEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsComplementoEndereco', tsComplementoEndereco)
+
+
+tsComplementoEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsComplementoEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsComplementoEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsComplementoEndereco._InitializeFacetMap(
+    tsComplementoEndereco._CF_maxLength,
+    tsComplementoEndereco._CF_minLength,
+    tsComplementoEndereco._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsComplementoEndereco", tsComplementoEndereco)
 _module_typeBindings.tsComplementoEndereco = tsComplementoEndereco
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsBairro
-class tsBairro (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsBairro
+class tsBairro(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsBairro')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 182, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsBairro")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 182, 1
+    )
     _Documentation = None
-tsBairro._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsBairro._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsBairro._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsBairro._InitializeFacetMap(tsBairro._CF_maxLength,
-   tsBairro._CF_minLength,
-   tsBairro._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsBairro', tsBairro)
+
+
+tsBairro._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsBairro._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsBairro._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsBairro._InitializeFacetMap(
+    tsBairro._CF_maxLength, tsBairro._CF_minLength, tsBairro._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsBairro", tsBairro)
 _module_typeBindings.tsBairro = tsBairro
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsUf
-class tsUf (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsUf
+class tsUf(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsUf')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 189, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsUf")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 189, 1
+    )
     _Documentation = None
+
+
 tsUf._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 tsUf._InitializeFacetMap(tsUf._CF_length)
-Namespace.addCategoryObject('typeBinding', 'tsUf', tsUf)
+Namespace.addCategoryObject("typeBinding", "tsUf", tsUf)
 _module_typeBindings.tsUf = tsUf
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoPaisBacen
-class tsCodigoPaisBacen (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoPaisBacen
+class tsCodigoPaisBacen(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoPaisBacen')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 194, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoPaisBacen")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 194, 1
+    )
     _Documentation = None
-tsCodigoPaisBacen._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsCodigoPaisBacen._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoPaisBacen._InitializeFacetMap(tsCodigoPaisBacen._CF_length,
-   tsCodigoPaisBacen._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoPaisBacen', tsCodigoPaisBacen)
+
+
+tsCodigoPaisBacen._CF_length = pyxb.binding.facets.CF_length(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsCodigoPaisBacen._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoPaisBacen._InitializeFacetMap(
+    tsCodigoPaisBacen._CF_length, tsCodigoPaisBacen._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoPaisBacen", tsCodigoPaisBacen)
 _module_typeBindings.tsCodigoPaisBacen = tsCodigoPaisBacen
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCep
-class tsCep (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCep
+class tsCep(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCep')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 200, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCep")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 200, 1
+    )
     _Documentation = None
+
+
 tsCep._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(8))
 tsCep._InitializeFacetMap(tsCep._CF_length)
-Namespace.addCategoryObject('typeBinding', 'tsCep', tsCep)
+Namespace.addCategoryObject("typeBinding", "tsCep", tsCep)
 _module_typeBindings.tsCep = tsCep
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsEmail
-class tsEmail (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsEmail
+class tsEmail(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsEmail')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 205, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsEmail")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 205, 1
+    )
     _Documentation = None
-tsEmail._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(80))
-tsEmail._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsEmail._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsEmail._InitializeFacetMap(tsEmail._CF_maxLength,
-   tsEmail._CF_minLength,
-   tsEmail._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsEmail', tsEmail)
+
+
+tsEmail._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(80)
+)
+tsEmail._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsEmail._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsEmail._InitializeFacetMap(tsEmail._CF_maxLength, tsEmail._CF_minLength, tsEmail._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsEmail", tsEmail)
 _module_typeBindings.tsEmail = tsEmail
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsTelefone
-class tsTelefone (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsTelefone
+class tsTelefone(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsTelefone')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 212, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsTelefone")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 212, 1
+    )
     _Documentation = None
-tsTelefone._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(20))
-tsTelefone._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsTelefone._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsTelefone._InitializeFacetMap(tsTelefone._CF_maxLength,
-   tsTelefone._CF_minLength,
-   tsTelefone._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsTelefone', tsTelefone)
+
+
+tsTelefone._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(20)
+)
+tsTelefone._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsTelefone._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsTelefone._InitializeFacetMap(
+    tsTelefone._CF_maxLength, tsTelefone._CF_minLength, tsTelefone._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsTelefone", tsTelefone)
 _module_typeBindings.tsTelefone = tsTelefone
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCpf
-class tsCpf (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCpf
+class tsCpf(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCpf')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 219, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCpf")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 219, 1
+    )
     _Documentation = None
-tsCpf._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(11))
+
+
+tsCpf._CF_length = pyxb.binding.facets.CF_length(
+    value=pyxb.binding.datatypes.nonNegativeInteger(11)
+)
 tsCpf._InitializeFacetMap(tsCpf._CF_length)
-Namespace.addCategoryObject('typeBinding', 'tsCpf', tsCpf)
+Namespace.addCategoryObject("typeBinding", "tsCpf", tsCpf)
 _module_typeBindings.tsCpf = tsCpf
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoObra
-class tsCodigoObra (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoObra
+class tsCodigoObra(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoObra')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 224, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoObra")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 224, 1
+    )
     _Documentation = None
-tsCodigoObra._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsCodigoObra._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoObra._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoObra._InitializeFacetMap(tsCodigoObra._CF_maxLength,
-   tsCodigoObra._CF_minLength,
-   tsCodigoObra._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoObra', tsCodigoObra)
+
+
+tsCodigoObra._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsCodigoObra._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoObra._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoObra._InitializeFacetMap(
+    tsCodigoObra._CF_maxLength, tsCodigoObra._CF_minLength, tsCodigoObra._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoObra", tsCodigoObra)
 _module_typeBindings.tsCodigoObra = tsCodigoObra
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsArt
-class tsArt (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsArt
+class tsArt(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsArt')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 231, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsArt")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 231, 1
+    )
     _Documentation = None
-tsArt._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsArt._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsArt._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsArt._InitializeFacetMap(tsArt._CF_maxLength,
-   tsArt._CF_minLength,
-   tsArt._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsArt', tsArt)
+
+
+tsArt._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsArt._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsArt._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsArt._InitializeFacetMap(tsArt._CF_maxLength, tsArt._CF_minLength, tsArt._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsArt", tsArt)
 _module_typeBindings.tsArt = tsArt
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroLote
-class tsNumeroLote (pyxb.binding.datatypes.nonNegativeInteger):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroLote
+class tsNumeroLote(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroLote')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 238, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroLote")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 238, 1
+    )
     _Documentation = None
-tsNumeroLote._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
+
+
+tsNumeroLote._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
 tsNumeroLote._InitializeFacetMap(tsNumeroLote._CF_totalDigits)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroLote', tsNumeroLote)
+Namespace.addCategoryObject("typeBinding", "tsNumeroLote", tsNumeroLote)
 _module_typeBindings.tsNumeroLote = tsNumeroLote
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroProtocolo
-class tsNumeroProtocolo (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsNumeroProtocolo
+class tsNumeroProtocolo(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroProtocolo')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 243, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroProtocolo")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 243, 1
+    )
     _Documentation = None
-tsNumeroProtocolo._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(50))
+
+
+tsNumeroProtocolo._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(50)
+)
 tsNumeroProtocolo._InitializeFacetMap(tsNumeroProtocolo._CF_maxLength)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroProtocolo', tsNumeroProtocolo)
+Namespace.addCategoryObject("typeBinding", "tsNumeroProtocolo", tsNumeroProtocolo)
 _module_typeBindings.tsNumeroProtocolo = tsNumeroProtocolo
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSituacaoLoteRps
-class tsSituacaoLoteRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsSituacaoLoteRps
+class tsSituacaoLoteRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSituacaoLoteRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 248, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSituacaoLoteRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 248, 1
+    )
     _Documentation = None
+
+
 tsSituacaoLoteRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsSituacaoLoteRps._CF_pattern.addPattern(pattern='1|2|3|4')
+tsSituacaoLoteRps._CF_pattern.addPattern(pattern="1|2|3|4")
 tsSituacaoLoteRps._InitializeFacetMap(tsSituacaoLoteRps._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsSituacaoLoteRps', tsSituacaoLoteRps)
+Namespace.addCategoryObject("typeBinding", "tsSituacaoLoteRps", tsSituacaoLoteRps)
 _module_typeBindings.tsSituacaoLoteRps = tsSituacaoLoteRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsQuantidadeRps
-class tsQuantidadeRps (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsQuantidadeRps
+class tsQuantidadeRps(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsQuantidadeRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 253, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsQuantidadeRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 253, 1
+    )
     _Documentation = None
+
+
 tsQuantidadeRps._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'tsQuantidadeRps', tsQuantidadeRps)
+Namespace.addCategoryObject("typeBinding", "tsQuantidadeRps", tsQuantidadeRps)
 _module_typeBindings.tsQuantidadeRps = tsQuantidadeRps
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoMensagemAlerta
-class tsCodigoMensagemAlerta (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoMensagemAlerta
+class tsCodigoMensagemAlerta(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoMensagemAlerta')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 257, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoMensagemAlerta")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 257, 1
+    )
     _Documentation = None
-tsCodigoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsCodigoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoMensagemAlerta._InitializeFacetMap(tsCodigoMensagemAlerta._CF_maxLength,
-   tsCodigoMensagemAlerta._CF_minLength,
-   tsCodigoMensagemAlerta._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoMensagemAlerta', tsCodigoMensagemAlerta)
+
+
+tsCodigoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsCodigoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoMensagemAlerta._InitializeFacetMap(
+    tsCodigoMensagemAlerta._CF_maxLength,
+    tsCodigoMensagemAlerta._CF_minLength,
+    tsCodigoMensagemAlerta._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoMensagemAlerta", tsCodigoMensagemAlerta)
 _module_typeBindings.tsCodigoMensagemAlerta = tsCodigoMensagemAlerta
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsDescricaoMensagemAlerta
-class tsDescricaoMensagemAlerta (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsDescricaoMensagemAlerta
+class tsDescricaoMensagemAlerta(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsDescricaoMensagemAlerta')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 264, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsDescricaoMensagemAlerta")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 264, 1
+    )
     _Documentation = None
-tsDescricaoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(200))
-tsDescricaoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsDescricaoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsDescricaoMensagemAlerta._InitializeFacetMap(tsDescricaoMensagemAlerta._CF_maxLength,
-   tsDescricaoMensagemAlerta._CF_minLength,
-   tsDescricaoMensagemAlerta._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsDescricaoMensagemAlerta', tsDescricaoMensagemAlerta)
+
+
+tsDescricaoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(200)
+)
+tsDescricaoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsDescricaoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsDescricaoMensagemAlerta._InitializeFacetMap(
+    tsDescricaoMensagemAlerta._CF_maxLength,
+    tsDescricaoMensagemAlerta._CF_minLength,
+    tsDescricaoMensagemAlerta._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsDescricaoMensagemAlerta", tsDescricaoMensagemAlerta)
 _module_typeBindings.tsDescricaoMensagemAlerta = tsDescricaoMensagemAlerta
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoCancelamentoNfse
-class tsCodigoCancelamentoNfse (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsCodigoCancelamentoNfse
+class tsCodigoCancelamentoNfse(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoCancelamentoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 271, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoCancelamentoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 271, 1
+    )
     _Documentation = None
+
+
 tsCodigoCancelamentoNfse._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsCodigoCancelamentoNfse._CF_pattern.addPattern(pattern='1|2|3|4|5')
+tsCodigoCancelamentoNfse._CF_pattern.addPattern(pattern="1|2|3|4|5")
 tsCodigoCancelamentoNfse._InitializeFacetMap(tsCodigoCancelamentoNfse._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoCancelamentoNfse', tsCodigoCancelamentoNfse)
+Namespace.addCategoryObject("typeBinding", "tsCodigoCancelamentoNfse", tsCodigoCancelamentoNfse)
 _module_typeBindings.tsCodigoCancelamentoNfse = tsCodigoCancelamentoNfse
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsIdTag
-class tsIdTag (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsIdTag
+class tsIdTag(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsIdTag')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 276, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsIdTag")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 276, 1
+    )
     _Documentation = None
-tsIdTag._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(255))
+
+
+tsIdTag._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(255)
+)
 tsIdTag._InitializeFacetMap(tsIdTag._CF_maxLength)
-Namespace.addCategoryObject('typeBinding', 'tsIdTag', tsIdTag)
+Namespace.addCategoryObject("typeBinding", "tsIdTag", tsIdTag)
 _module_typeBindings.tsIdTag = tsIdTag
 
-# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsVersao
-class tsVersao (pyxb.binding.datatypes.token):
 
+# Atomic simple type: {http://www.betha.com.br/e-nota-contribuinte-ws}tsVersao
+class tsVersao(pyxb.binding.datatypes.token):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsVersao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 282, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsVersao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 282, 1
+    )
     _Documentation = None
+
+
 tsVersao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsVersao._CF_pattern.addPattern(pattern='[1-9]{1}[0-9]{0,1}\\.[0-9]{2}')
+tsVersao._CF_pattern.addPattern(pattern="[1-9]{1}[0-9]{0,1}\\.[0-9]{2}")
 tsVersao._InitializeFacetMap(tsVersao._CF_pattern)
-Namespace.addCategoryObject('typeBinding', 'tsVersao', tsVersao)
+Namespace.addCategoryObject("typeBinding", "tsVersao", tsVersao)
 _module_typeBindings.tsVersao = tsVersao
 
+
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCpfCnpj with content type ELEMENT_ONLY
-class tcCpfCnpj (pyxb.binding.basis.complexTypeDefinition):
+class tcCpfCnpj(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCpfCnpj with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCpfCnpj')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 289, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCpfCnpj")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 289, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Cpf uses Python identifier Cpf
-    __Cpf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cpf'), 'Cpf', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCpfCnpj_httpwww_betha_com_bre_nota_contribuinte_wsCpf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 291, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Cpf uses Python identifier Cpf
+    __Cpf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cpf"),
+        "Cpf",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCpfCnpj_httpwww_betha_com_bre_nota_contribuinte_wsCpf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 291, 3
+        ),
+    )
+
     Cpf = property(__Cpf.value, __Cpf.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Cnpj uses Python identifier Cnpj
-    __Cnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), 'Cnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCpfCnpj_httpwww_betha_com_bre_nota_contribuinte_wsCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 293, 3), )
+    __Cnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        "Cnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCpfCnpj_httpwww_betha_com_bre_nota_contribuinte_wsCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 293, 3
+        ),
+    )
 
-    
     Cnpj = property(__Cnpj.value, __Cnpj.set, None, None)
 
-    _ElementMap.update({
-        __Cpf.name() : __Cpf,
-        __Cnpj.name() : __Cnpj
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Cpf.name(): __Cpf, __Cnpj.name(): __Cnpj})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcCpfCnpj = tcCpfCnpj
-Namespace.addCategoryObject('typeBinding', 'tcCpfCnpj', tcCpfCnpj)
+Namespace.addCategoryObject("typeBinding", "tcCpfCnpj", tcCpfCnpj)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcEndereco with content type ELEMENT_ONLY
-class tcEndereco (pyxb.binding.basis.complexTypeDefinition):
+class tcEndereco(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcEndereco with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 298, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 298, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 300, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Endereco uses Python identifier Endereco
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 300, 3
+        ),
+    )
+
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 302, 3), )
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 302, 3
+        ),
+    )
 
-    
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Complemento uses Python identifier Complemento
-    __Complemento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Complemento'), 'Complemento', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsComplemento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 304, 3), )
+    __Complemento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Complemento"),
+        "Complemento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsComplemento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 304, 3
+        ),
+    )
 
-    
     Complemento = property(__Complemento.value, __Complemento.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Bairro uses Python identifier Bairro
-    __Bairro = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Bairro'), 'Bairro', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsBairro', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 306, 3), )
+    __Bairro = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Bairro"),
+        "Bairro",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsBairro",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 306, 3
+        ),
+    )
 
-    
     Bairro = property(__Bairro.value, __Bairro.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 308, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 308, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Uf uses Python identifier Uf
-    __Uf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Uf'), 'Uf', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsUf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 310, 3), )
+    __Uf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        "Uf",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsUf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 310, 3
+        ),
+    )
 
-    
     Uf = property(__Uf.value, __Uf.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoPais uses Python identifier CodigoPais
-    __CodigoPais = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais'), 'CodigoPais', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCodigoPais', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 312, 3), )
+    __CodigoPais = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoPais"),
+        "CodigoPais",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCodigoPais",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 312, 3
+        ),
+    )
 
-    
     CodigoPais = property(__CodigoPais.value, __CodigoPais.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Cep uses Python identifier Cep
-    __Cep = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cep'), 'Cep', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCep', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 314, 3), )
+    __Cep = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cep"),
+        "Cep",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcEndereco_httpwww_betha_com_bre_nota_contribuinte_wsCep",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 314, 3
+        ),
+    )
 
-    
     Cep = property(__Cep.value, __Cep.set, None, None)
 
-    _ElementMap.update({
-        __Endereco.name() : __Endereco,
-        __Numero.name() : __Numero,
-        __Complemento.name() : __Complemento,
-        __Bairro.name() : __Bairro,
-        __CodigoMunicipio.name() : __CodigoMunicipio,
-        __Uf.name() : __Uf,
-        __CodigoPais.name() : __CodigoPais,
-        __Cep.name() : __Cep
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Endereco.name(): __Endereco,
+            __Numero.name(): __Numero,
+            __Complemento.name(): __Complemento,
+            __Bairro.name(): __Bairro,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+            __Uf.name(): __Uf,
+            __CodigoPais.name(): __CodigoPais,
+            __Cep.name(): __Cep,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcEndereco = tcEndereco
-Namespace.addCategoryObject('typeBinding', 'tcEndereco', tcEndereco)
+Namespace.addCategoryObject("typeBinding", "tcEndereco", tcEndereco)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcContato with content type ELEMENT_ONLY
-class tcContato (pyxb.binding.basis.complexTypeDefinition):
+class tcContato(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcContato with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcContato')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 319, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcContato")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 319, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Telefone uses Python identifier Telefone
-    __Telefone = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Telefone'), 'Telefone', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcContato_httpwww_betha_com_bre_nota_contribuinte_wsTelefone', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 321, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Telefone uses Python identifier Telefone
+    __Telefone = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Telefone"),
+        "Telefone",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcContato_httpwww_betha_com_bre_nota_contribuinte_wsTelefone",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 321, 3
+        ),
+    )
+
     Telefone = property(__Telefone.value, __Telefone.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Email uses Python identifier Email
-    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Email'), 'Email', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcContato_httpwww_betha_com_bre_nota_contribuinte_wsEmail', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 323, 3), )
+    __Email = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Email"),
+        "Email",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcContato_httpwww_betha_com_bre_nota_contribuinte_wsEmail",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 323, 3
+        ),
+    )
 
-    
     Email = property(__Email.value, __Email.set, None, None)
 
-    _ElementMap.update({
-        __Telefone.name() : __Telefone,
-        __Email.name() : __Email
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Telefone.name(): __Telefone, __Email.name(): __Email})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcContato = tcContato
-Namespace.addCategoryObject('typeBinding', 'tcContato', tcContato)
+Namespace.addCategoryObject("typeBinding", "tcContato", tcContato)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoOrgaoGerador with content type ELEMENT_ONLY
-class tcIdentificacaoOrgaoGerador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoOrgaoGerador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoOrgaoGerador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoOrgaoGerador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 328, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoOrgaoGerador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 328, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoOrgaoGerador_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 330, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoMunicipio uses Python identifier CodigoMunicipio
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoOrgaoGerador_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 330, 3
+        ),
+    )
+
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Uf uses Python identifier Uf
-    __Uf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Uf'), 'Uf', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoOrgaoGerador_httpwww_betha_com_bre_nota_contribuinte_wsUf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 332, 3), )
+    __Uf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        "Uf",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoOrgaoGerador_httpwww_betha_com_bre_nota_contribuinte_wsUf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 332, 3
+        ),
+    )
 
-    
     Uf = property(__Uf.value, __Uf.set, None, None)
 
-    _ElementMap.update({
-        __CodigoMunicipio.name() : __CodigoMunicipio,
-        __Uf.name() : __Uf
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CodigoMunicipio.name(): __CodigoMunicipio, __Uf.name(): __Uf})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoOrgaoGerador = tcIdentificacaoOrgaoGerador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoOrgaoGerador', tcIdentificacaoOrgaoGerador)
+Namespace.addCategoryObject(
+    "typeBinding", "tcIdentificacaoOrgaoGerador", tcIdentificacaoOrgaoGerador
+)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoRps with content type ELEMENT_ONLY
-class tcIdentificacaoRps (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 337, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 337, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 339, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 339, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Serie uses Python identifier Serie
-    __Serie = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Serie'), 'Serie', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsSerie', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 341, 3), )
+    __Serie = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Serie"),
+        "Serie",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsSerie",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 341, 3
+        ),
+    )
 
-    
     Serie = property(__Serie.value, __Serie.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Tipo uses Python identifier Tipo
-    __Tipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tipo'), 'Tipo', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsTipo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 343, 3), )
+    __Tipo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tipo"),
+        "Tipo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoRps_httpwww_betha_com_bre_nota_contribuinte_wsTipo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 343, 3
+        ),
+    )
 
-    
     Tipo = property(__Tipo.value, __Tipo.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __Serie.name() : __Serie,
-        __Tipo.name() : __Tipo
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Numero.name(): __Numero, __Serie.name(): __Serie, __Tipo.name(): __Tipo})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoRps = tcIdentificacaoRps
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoRps', tcIdentificacaoRps)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoRps", tcIdentificacaoRps)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoPrestador with content type ELEMENT_ONLY
-class tcIdentificacaoPrestador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoPrestador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoPrestador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoPrestador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 348, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoPrestador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 348, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoPrestador_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 350, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoPrestador_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 350, 3
+        ),
+    )
+
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoPrestador_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 352, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoPrestador_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 352, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CpfCnpj.name(): __CpfCnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoPrestador = tcIdentificacaoPrestador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoPrestador', tcIdentificacaoPrestador)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoPrestador", tcIdentificacaoPrestador)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoTomador with content type ELEMENT_ONLY
-class tcIdentificacaoTomador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoTomador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoTomador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoTomador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 357, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoTomador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 357, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoTomador_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 359, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoTomador_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 359, 3
+        ),
+    )
+
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoTomador_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 361, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoTomador_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 361, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CpfCnpj.name(): __CpfCnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoTomador = tcIdentificacaoTomador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoTomador', tcIdentificacaoTomador)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoTomador", tcIdentificacaoTomador)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoConsulente with content type ELEMENT_ONLY
-class tcIdentificacaoConsulente (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoConsulente(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoConsulente with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoConsulente')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 366, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoConsulente")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 366, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoConsulente_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 368, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoConsulente_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 368, 3
+        ),
+    )
+
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoConsulente_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 370, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoConsulente_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 370, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CpfCnpj.name(): __CpfCnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoConsulente = tcIdentificacaoConsulente
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoConsulente', tcIdentificacaoConsulente)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoConsulente", tcIdentificacaoConsulente)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoIntermediario with content type ELEMENT_ONLY
-class tcIdentificacaoIntermediario (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoIntermediario(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoIntermediario with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoIntermediario')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 375, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoIntermediario")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 375, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 377, 15), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 377, 15
+        ),
+    )
+
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 378, 14), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 378, 14
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CpfCnpj.name(): __CpfCnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoIntermediario = tcIdentificacaoIntermediario
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoIntermediario', tcIdentificacaoIntermediario)
+Namespace.addCategoryObject(
+    "typeBinding", "tcIdentificacaoIntermediario", tcIdentificacaoIntermediario
+)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosTomador with content type ELEMENT_ONLY
-class tcDadosTomador (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosTomador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosTomador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosTomador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 382, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosTomador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 382, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoTomador uses Python identifier IdentificacaoTomador
-    __IdentificacaoTomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador'), 'IdentificacaoTomador', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 384, 3), )
+    __IdentificacaoTomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador"),
+        "IdentificacaoTomador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 384, 3
+        ),
+    )
 
-    
-    IdentificacaoTomador = property(__IdentificacaoTomador.value, __IdentificacaoTomador.set, None, None)
+    IdentificacaoTomador = property(
+        __IdentificacaoTomador.value, __IdentificacaoTomador.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 386, 3), )
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 386, 3
+        ),
+    )
 
-    
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 388, 3), )
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 388, 3
+        ),
+    )
 
-    
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Contato uses Python identifier Contato
-    __Contato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Contato'), 'Contato', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsContato', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 390, 3), )
+    __Contato = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        "Contato",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosTomador_httpwww_betha_com_bre_nota_contribuinte_wsContato",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 390, 3
+        ),
+    )
 
-    
     Contato = property(__Contato.value, __Contato.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoTomador.name() : __IdentificacaoTomador,
-        __RazaoSocial.name() : __RazaoSocial,
-        __Endereco.name() : __Endereco,
-        __Contato.name() : __Contato
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoTomador.name(): __IdentificacaoTomador,
+            __RazaoSocial.name(): __RazaoSocial,
+            __Endereco.name(): __Endereco,
+            __Contato.name(): __Contato,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosTomador = tcDadosTomador
-Namespace.addCategoryObject('typeBinding', 'tcDadosTomador', tcDadosTomador)
+Namespace.addCategoryObject("typeBinding", "tcDadosTomador", tcDadosTomador)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosIntermediario with content type ELEMENT_ONLY
-class tcDadosIntermediario (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosIntermediario(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosIntermediario with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosIntermediario')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 395, 4)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosIntermediario")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 395, 4
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoIntermediario uses Python identifier IdentificacaoIntermediario
-    __IdentificacaoIntermediario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoIntermediario'), 'IdentificacaoIntermediario', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoIntermediario', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 397, 12), )
+    __IdentificacaoIntermediario = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoIntermediario"),
+        "IdentificacaoIntermediario",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoIntermediario",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 397, 12
+        ),
+    )
 
-    
-    IdentificacaoIntermediario = property(__IdentificacaoIntermediario.value, __IdentificacaoIntermediario.set, None, None)
+    IdentificacaoIntermediario = property(
+        __IdentificacaoIntermediario.value, __IdentificacaoIntermediario.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 398, 12), )
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosIntermediario_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 398, 12
+        ),
+    )
 
-    
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoIntermediario.name() : __IdentificacaoIntermediario,
-        __RazaoSocial.name() : __RazaoSocial
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoIntermediario.name(): __IdentificacaoIntermediario,
+            __RazaoSocial.name(): __RazaoSocial,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosIntermediario = tcDadosIntermediario
-Namespace.addCategoryObject('typeBinding', 'tcDadosIntermediario', tcDadosIntermediario)
+Namespace.addCategoryObject("typeBinding", "tcDadosIntermediario", tcDadosIntermediario)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcValoresDeclaracaoServico with content type ELEMENT_ONLY
-class tcValoresDeclaracaoServico (pyxb.binding.basis.complexTypeDefinition):
+class tcValoresDeclaracaoServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcValoresDeclaracaoServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcValoresDeclaracaoServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 402, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcValoresDeclaracaoServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 402, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorServicos uses Python identifier ValorServicos
-    __ValorServicos = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos'), 'ValorServicos', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorServicos', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 404, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorServicos uses Python identifier ValorServicos
+    __ValorServicos = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorServicos"),
+        "ValorServicos",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorServicos",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 404, 3
+        ),
+    )
+
     ValorServicos = property(__ValorServicos.value, __ValorServicos.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorDeducoes uses Python identifier ValorDeducoes
-    __ValorDeducoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes'), 'ValorDeducoes', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorDeducoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 406, 3), )
+    __ValorDeducoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes"),
+        "ValorDeducoes",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorDeducoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 406, 3
+        ),
+    )
 
-    
     ValorDeducoes = property(__ValorDeducoes.value, __ValorDeducoes.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorPis uses Python identifier ValorPis
-    __ValorPis = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorPis'), 'ValorPis', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorPis', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 408, 3), )
+    __ValorPis = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorPis"),
+        "ValorPis",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorPis",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 408, 3
+        ),
+    )
 
-    
     ValorPis = property(__ValorPis.value, __ValorPis.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorCofins uses Python identifier ValorCofins
-    __ValorCofins = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins'), 'ValorCofins', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorCofins', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 410, 3), )
+    __ValorCofins = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCofins"),
+        "ValorCofins",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorCofins",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 410, 3
+        ),
+    )
 
-    
     ValorCofins = property(__ValorCofins.value, __ValorCofins.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorInss uses Python identifier ValorInss
-    __ValorInss = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorInss'), 'ValorInss', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorInss', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 412, 3), )
+    __ValorInss = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorInss"),
+        "ValorInss",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorInss",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 412, 3
+        ),
+    )
 
-    
     ValorInss = property(__ValorInss.value, __ValorInss.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorIr uses Python identifier ValorIr
-    __ValorIr = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIr'), 'ValorIr', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorIr', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 414, 3), )
+    __ValorIr = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIr"),
+        "ValorIr",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorIr",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 414, 3
+        ),
+    )
 
-    
     ValorIr = property(__ValorIr.value, __ValorIr.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorCsll uses Python identifier ValorCsll
-    __ValorCsll = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll'), 'ValorCsll', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorCsll', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 416, 3), )
+    __ValorCsll = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCsll"),
+        "ValorCsll",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorCsll",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 416, 3
+        ),
+    )
 
-    
     ValorCsll = property(__ValorCsll.value, __ValorCsll.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}OutrasRetencoes uses Python identifier OutrasRetencoes
-    __OutrasRetencoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes'), 'OutrasRetencoes', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsOutrasRetencoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 418, 3), )
+    __OutrasRetencoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes"),
+        "OutrasRetencoes",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsOutrasRetencoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 418, 3
+        ),
+    )
 
-    
     OutrasRetencoes = property(__OutrasRetencoes.value, __OutrasRetencoes.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorIss uses Python identifier ValorIss
-    __ValorIss = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), 'ValorIss', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorIss', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 420, 3), )
+    __ValorIss = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        "ValorIss",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsValorIss",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 420, 3
+        ),
+    )
 
-    
     ValorIss = property(__ValorIss.value, __ValorIss.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Aliquota uses Python identifier Aliquota
-    __Aliquota = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), 'Aliquota', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsAliquota', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 422, 3), )
+    __Aliquota = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        "Aliquota",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsAliquota",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 422, 3
+        ),
+    )
 
-    
     Aliquota = property(__Aliquota.value, __Aliquota.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DescontoIncondicionado uses Python identifier DescontoIncondicionado
-    __DescontoIncondicionado = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado'), 'DescontoIncondicionado', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsDescontoIncondicionado', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 424, 3), )
+    __DescontoIncondicionado = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado"),
+        "DescontoIncondicionado",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsDescontoIncondicionado",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 424, 3
+        ),
+    )
 
-    
-    DescontoIncondicionado = property(__DescontoIncondicionado.value, __DescontoIncondicionado.set, None, None)
+    DescontoIncondicionado = property(
+        __DescontoIncondicionado.value, __DescontoIncondicionado.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DescontoCondicionado uses Python identifier DescontoCondicionado
-    __DescontoCondicionado = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado'), 'DescontoCondicionado', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsDescontoCondicionado', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 426, 3), )
+    __DescontoCondicionado = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado"),
+        "DescontoCondicionado",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresDeclaracaoServico_httpwww_betha_com_bre_nota_contribuinte_wsDescontoCondicionado",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 426, 3
+        ),
+    )
 
-    
-    DescontoCondicionado = property(__DescontoCondicionado.value, __DescontoCondicionado.set, None, None)
+    DescontoCondicionado = property(
+        __DescontoCondicionado.value, __DescontoCondicionado.set, None, None
+    )
 
-    _ElementMap.update({
-        __ValorServicos.name() : __ValorServicos,
-        __ValorDeducoes.name() : __ValorDeducoes,
-        __ValorPis.name() : __ValorPis,
-        __ValorCofins.name() : __ValorCofins,
-        __ValorInss.name() : __ValorInss,
-        __ValorIr.name() : __ValorIr,
-        __ValorCsll.name() : __ValorCsll,
-        __OutrasRetencoes.name() : __OutrasRetencoes,
-        __ValorIss.name() : __ValorIss,
-        __Aliquota.name() : __Aliquota,
-        __DescontoIncondicionado.name() : __DescontoIncondicionado,
-        __DescontoCondicionado.name() : __DescontoCondicionado
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ValorServicos.name(): __ValorServicos,
+            __ValorDeducoes.name(): __ValorDeducoes,
+            __ValorPis.name(): __ValorPis,
+            __ValorCofins.name(): __ValorCofins,
+            __ValorInss.name(): __ValorInss,
+            __ValorIr.name(): __ValorIr,
+            __ValorCsll.name(): __ValorCsll,
+            __OutrasRetencoes.name(): __OutrasRetencoes,
+            __ValorIss.name(): __ValorIss,
+            __Aliquota.name(): __Aliquota,
+            __DescontoIncondicionado.name(): __DescontoIncondicionado,
+            __DescontoCondicionado.name(): __DescontoCondicionado,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcValoresDeclaracaoServico = tcValoresDeclaracaoServico
-Namespace.addCategoryObject('typeBinding', 'tcValoresDeclaracaoServico', tcValoresDeclaracaoServico)
+Namespace.addCategoryObject("typeBinding", "tcValoresDeclaracaoServico", tcValoresDeclaracaoServico)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcValoresNfse with content type ELEMENT_ONLY
-class tcValoresNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcValoresNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcValoresNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcValoresNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 431, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcValoresNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 431, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}BaseCalculo uses Python identifier BaseCalculo
-    __BaseCalculo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo'), 'BaseCalculo', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsBaseCalculo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 433, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}BaseCalculo uses Python identifier BaseCalculo
+    __BaseCalculo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "BaseCalculo"),
+        "BaseCalculo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsBaseCalculo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 433, 3
+        ),
+    )
+
     BaseCalculo = property(__BaseCalculo.value, __BaseCalculo.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Aliquota uses Python identifier Aliquota
-    __Aliquota = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), 'Aliquota', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsAliquota', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 435, 3), )
+    __Aliquota = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        "Aliquota",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsAliquota",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 435, 3
+        ),
+    )
 
-    
     Aliquota = property(__Aliquota.value, __Aliquota.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorIss uses Python identifier ValorIss
-    __ValorIss = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), 'ValorIss', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorIss', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 437, 3), )
+    __ValorIss = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        "ValorIss",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorIss",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 437, 3
+        ),
+    )
 
-    
     ValorIss = property(__ValorIss.value, __ValorIss.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorLiquidoNfse uses Python identifier ValorLiquidoNfse
-    __ValorLiquidoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse'), 'ValorLiquidoNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorLiquidoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 439, 3), )
+    __ValorLiquidoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse"),
+        "ValorLiquidoNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcValoresNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorLiquidoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 439, 3
+        ),
+    )
 
-    
     ValorLiquidoNfse = property(__ValorLiquidoNfse.value, __ValorLiquidoNfse.set, None, None)
 
-    _ElementMap.update({
-        __BaseCalculo.name() : __BaseCalculo,
-        __Aliquota.name() : __Aliquota,
-        __ValorIss.name() : __ValorIss,
-        __ValorLiquidoNfse.name() : __ValorLiquidoNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __BaseCalculo.name(): __BaseCalculo,
+            __Aliquota.name(): __Aliquota,
+            __ValorIss.name(): __ValorIss,
+            __ValorLiquidoNfse.name(): __ValorLiquidoNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcValoresNfse = tcValoresNfse
-Namespace.addCategoryObject('typeBinding', 'tcValoresNfse', tcValoresNfse)
+Namespace.addCategoryObject("typeBinding", "tcValoresNfse", tcValoresNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosServico with content type ELEMENT_ONLY
-class tcDadosServico (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 444, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 444, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Valores uses Python identifier Valores
-    __Valores = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Valores'), 'Valores', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsValores', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 446, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Valores uses Python identifier Valores
+    __Valores = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Valores"),
+        "Valores",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsValores",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 446, 3
+        ),
+    )
+
     Valores = property(__Valores.value, __Valores.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IssRetido uses Python identifier IssRetido
-    __IssRetido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IssRetido'), 'IssRetido', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsIssRetido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 448, 3), )
+    __IssRetido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IssRetido"),
+        "IssRetido",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsIssRetido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 448, 3
+        ),
+    )
 
-    
     IssRetido = property(__IssRetido.value, __IssRetido.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ResponsavelRetencao uses Python identifier ResponsavelRetencao
-    __ResponsavelRetencao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ResponsavelRetencao'), 'ResponsavelRetencao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsResponsavelRetencao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 450, 3), )
+    __ResponsavelRetencao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ResponsavelRetencao"),
+        "ResponsavelRetencao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsResponsavelRetencao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 450, 3
+        ),
+    )
 
-    
-    ResponsavelRetencao = property(__ResponsavelRetencao.value, __ResponsavelRetencao.set, None, None)
+    ResponsavelRetencao = property(
+        __ResponsavelRetencao.value, __ResponsavelRetencao.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ItemListaServico uses Python identifier ItemListaServico
-    __ItemListaServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico'), 'ItemListaServico', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsItemListaServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 452, 3), )
+    __ItemListaServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ItemListaServico"),
+        "ItemListaServico",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsItemListaServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 452, 3
+        ),
+    )
 
-    
     ItemListaServico = property(__ItemListaServico.value, __ItemListaServico.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoCnae uses Python identifier CodigoCnae
-    __CodigoCnae = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae'), 'CodigoCnae', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoCnae', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 454, 3), )
+    __CodigoCnae = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCnae"),
+        "CodigoCnae",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoCnae",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 454, 3
+        ),
+    )
 
-    
     CodigoCnae = property(__CodigoCnae.value, __CodigoCnae.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoTributacaoMunicipio uses Python identifier CodigoTributacaoMunicipio
-    __CodigoTributacaoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio'), 'CodigoTributacaoMunicipio', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoTributacaoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 456, 3), )
+    __CodigoTributacaoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio"),
+        "CodigoTributacaoMunicipio",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoTributacaoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 456, 3
+        ),
+    )
 
-    
-    CodigoTributacaoMunicipio = property(__CodigoTributacaoMunicipio.value, __CodigoTributacaoMunicipio.set, None, None)
+    CodigoTributacaoMunicipio = property(
+        __CodigoTributacaoMunicipio.value, __CodigoTributacaoMunicipio.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Discriminacao uses Python identifier Discriminacao
-    __Discriminacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao'), 'Discriminacao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsDiscriminacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 458, 3), )
+    __Discriminacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Discriminacao"),
+        "Discriminacao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsDiscriminacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 458, 3
+        ),
+    )
 
-    
     Discriminacao = property(__Discriminacao.value, __Discriminacao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 460, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 460, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoPais uses Python identifier CodigoPais
-    __CodigoPais = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais'), 'CodigoPais', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoPais', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 462, 3), )
+    __CodigoPais = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoPais"),
+        "CodigoPais",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsCodigoPais",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 462, 3
+        ),
+    )
 
-    
     CodigoPais = property(__CodigoPais.value, __CodigoPais.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ExigibilidadeISS uses Python identifier ExigibilidadeISS
-    __ExigibilidadeISS = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ExigibilidadeISS'), 'ExigibilidadeISS', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsExigibilidadeISS', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 464, 3), )
+    __ExigibilidadeISS = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ExigibilidadeISS"),
+        "ExigibilidadeISS",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsExigibilidadeISS",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 464, 3
+        ),
+    )
 
-    
     ExigibilidadeISS = property(__ExigibilidadeISS.value, __ExigibilidadeISS.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MunicipioIncidencia uses Python identifier MunicipioIncidencia
-    __MunicipioIncidencia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MunicipioIncidencia'), 'MunicipioIncidencia', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsMunicipioIncidencia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 466, 3), )
+    __MunicipioIncidencia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MunicipioIncidencia"),
+        "MunicipioIncidencia",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsMunicipioIncidencia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 466, 3
+        ),
+    )
 
-    
-    MunicipioIncidencia = property(__MunicipioIncidencia.value, __MunicipioIncidencia.set, None, None)
+    MunicipioIncidencia = property(
+        __MunicipioIncidencia.value, __MunicipioIncidencia.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroProcesso uses Python identifier NumeroProcesso
-    __NumeroProcesso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroProcesso'), 'NumeroProcesso', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsNumeroProcesso', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 468, 3), )
+    __NumeroProcesso = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroProcesso"),
+        "NumeroProcesso",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosServico_httpwww_betha_com_bre_nota_contribuinte_wsNumeroProcesso",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 468, 3
+        ),
+    )
 
-    
     NumeroProcesso = property(__NumeroProcesso.value, __NumeroProcesso.set, None, None)
 
-    _ElementMap.update({
-        __Valores.name() : __Valores,
-        __IssRetido.name() : __IssRetido,
-        __ResponsavelRetencao.name() : __ResponsavelRetencao,
-        __ItemListaServico.name() : __ItemListaServico,
-        __CodigoCnae.name() : __CodigoCnae,
-        __CodigoTributacaoMunicipio.name() : __CodigoTributacaoMunicipio,
-        __Discriminacao.name() : __Discriminacao,
-        __CodigoMunicipio.name() : __CodigoMunicipio,
-        __CodigoPais.name() : __CodigoPais,
-        __ExigibilidadeISS.name() : __ExigibilidadeISS,
-        __MunicipioIncidencia.name() : __MunicipioIncidencia,
-        __NumeroProcesso.name() : __NumeroProcesso
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Valores.name(): __Valores,
+            __IssRetido.name(): __IssRetido,
+            __ResponsavelRetencao.name(): __ResponsavelRetencao,
+            __ItemListaServico.name(): __ItemListaServico,
+            __CodigoCnae.name(): __CodigoCnae,
+            __CodigoTributacaoMunicipio.name(): __CodigoTributacaoMunicipio,
+            __Discriminacao.name(): __Discriminacao,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+            __CodigoPais.name(): __CodigoPais,
+            __ExigibilidadeISS.name(): __ExigibilidadeISS,
+            __MunicipioIncidencia.name(): __MunicipioIncidencia,
+            __NumeroProcesso.name(): __NumeroProcesso,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosServico = tcDadosServico
-Namespace.addCategoryObject('typeBinding', 'tcDadosServico', tcDadosServico)
+Namespace.addCategoryObject("typeBinding", "tcDadosServico", tcDadosServico)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosConstrucaoCivil with content type ELEMENT_ONLY
-class tcDadosConstrucaoCivil (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosConstrucaoCivil(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosConstrucaoCivil with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosConstrucaoCivil')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 474, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosConstrucaoCivil")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 474, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoObra uses Python identifier CodigoObra
-    __CodigoObra = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra'), 'CodigoObra', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosConstrucaoCivil_httpwww_betha_com_bre_nota_contribuinte_wsCodigoObra', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 476, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoObra uses Python identifier CodigoObra
+    __CodigoObra = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoObra"),
+        "CodigoObra",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosConstrucaoCivil_httpwww_betha_com_bre_nota_contribuinte_wsCodigoObra",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 476, 3
+        ),
+    )
+
     CodigoObra = property(__CodigoObra.value, __CodigoObra.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Art uses Python identifier Art
-    __Art = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Art'), 'Art', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosConstrucaoCivil_httpwww_betha_com_bre_nota_contribuinte_wsArt', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 478, 3), )
+    __Art = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Art"),
+        "Art",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosConstrucaoCivil_httpwww_betha_com_bre_nota_contribuinte_wsArt",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 478, 3
+        ),
+    )
 
-    
     Art = property(__Art.value, __Art.set, None, None)
 
-    _ElementMap.update({
-        __CodigoObra.name() : __CodigoObra,
-        __Art.name() : __Art
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CodigoObra.name(): __CodigoObra, __Art.name(): __Art})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosConstrucaoCivil = tcDadosConstrucaoCivil
-Namespace.addCategoryObject('typeBinding', 'tcDadosConstrucaoCivil', tcDadosConstrucaoCivil)
+Namespace.addCategoryObject("typeBinding", "tcDadosConstrucaoCivil", tcDadosConstrucaoCivil)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosPrestador with content type ELEMENT_ONLY
-class tcDadosPrestador (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosPrestador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDadosPrestador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosPrestador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 483, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosPrestador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 483, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoPrestador uses Python identifier IdentificacaoPrestador
-    __IdentificacaoPrestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador'), 'IdentificacaoPrestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 485, 3), )
+    __IdentificacaoPrestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador"),
+        "IdentificacaoPrestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 485, 3
+        ),
+    )
 
-    
-    IdentificacaoPrestador = property(__IdentificacaoPrestador.value, __IdentificacaoPrestador.set, None, None)
+    IdentificacaoPrestador = property(
+        __IdentificacaoPrestador.value, __IdentificacaoPrestador.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 487, 3), )
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 487, 3
+        ),
+    )
 
-    
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NomeFantasia uses Python identifier NomeFantasia
-    __NomeFantasia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia'), 'NomeFantasia', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsNomeFantasia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 489, 3), )
+    __NomeFantasia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NomeFantasia"),
+        "NomeFantasia",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsNomeFantasia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 489, 3
+        ),
+    )
 
-    
     NomeFantasia = property(__NomeFantasia.value, __NomeFantasia.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 491, 3), )
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 491, 3
+        ),
+    )
 
-    
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Contato uses Python identifier Contato
-    __Contato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Contato'), 'Contato', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsContato', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 493, 3), )
+    __Contato = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        "Contato",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDadosPrestador_httpwww_betha_com_bre_nota_contribuinte_wsContato",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 493, 3
+        ),
+    )
 
-    
     Contato = property(__Contato.value, __Contato.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoPrestador.name() : __IdentificacaoPrestador,
-        __RazaoSocial.name() : __RazaoSocial,
-        __NomeFantasia.name() : __NomeFantasia,
-        __Endereco.name() : __Endereco,
-        __Contato.name() : __Contato
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoPrestador.name(): __IdentificacaoPrestador,
+            __RazaoSocial.name(): __RazaoSocial,
+            __NomeFantasia.name(): __NomeFantasia,
+            __Endereco.name(): __Endereco,
+            __Contato.name(): __Contato,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosPrestador = tcDadosPrestador
-Namespace.addCategoryObject('typeBinding', 'tcDadosPrestador', tcDadosPrestador)
+Namespace.addCategoryObject("typeBinding", "tcDadosPrestador", tcDadosPrestador)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDeclaracaoPrestacaoServico with content type ELEMENT_ONLY
-class tcDeclaracaoPrestacaoServico (pyxb.binding.basis.complexTypeDefinition):
+class tcDeclaracaoPrestacaoServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcDeclaracaoPrestacaoServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDeclaracaoPrestacaoServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 538, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDeclaracaoPrestacaoServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 538, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InfDeclaracaoPrestacaoServico uses Python identifier InfDeclaracaoPrestacaoServico
-    __InfDeclaracaoPrestacaoServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfDeclaracaoPrestacaoServico'), 'InfDeclaracaoPrestacaoServico', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsInfDeclaracaoPrestacaoServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 540, 3), )
+    __InfDeclaracaoPrestacaoServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfDeclaracaoPrestacaoServico"),
+        "InfDeclaracaoPrestacaoServico",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsInfDeclaracaoPrestacaoServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 540, 3
+        ),
+    )
 
-    
-    InfDeclaracaoPrestacaoServico = property(__InfDeclaracaoPrestacaoServico.value, __InfDeclaracaoPrestacaoServico.set, None, None)
+    InfDeclaracaoPrestacaoServico = property(
+        __InfDeclaracaoPrestacaoServico.value, __InfDeclaracaoPrestacaoServico.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcDeclaracaoPrestacaoServico_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcDeclaracaoPrestacaoServico_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __InfDeclaracaoPrestacaoServico.name() : __InfDeclaracaoPrestacaoServico,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __InfDeclaracaoPrestacaoServico.name(): __InfDeclaracaoPrestacaoServico,
+            __Signature.name(): __Signature,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDeclaracaoPrestacaoServico = tcDeclaracaoPrestacaoServico
-Namespace.addCategoryObject('typeBinding', 'tcDeclaracaoPrestacaoServico', tcDeclaracaoPrestacaoServico)
+Namespace.addCategoryObject(
+    "typeBinding", "tcDeclaracaoPrestacaoServico", tcDeclaracaoPrestacaoServico
+)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoNfse with content type ELEMENT_ONLY
-class tcIdentificacaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcIdentificacaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 547, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 547, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 549, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 549, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 551, 3), )
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 551, 3
+        ),
+    )
 
-    
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 553, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 553, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 555, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcIdentificacaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 555, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal,
-        __CodigoMunicipio.name() : __CodigoMunicipio
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Numero.name(): __Numero,
+            __CpfCnpj.name(): __CpfCnpj,
+            __InscricaoMunicipal.name(): __InscricaoMunicipal,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoNfse = tcIdentificacaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoNfse', tcIdentificacaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoNfse", tcIdentificacaoNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcPedidoCancelamento with content type ELEMENT_ONLY
-class tcPedidoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcPedidoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcPedidoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcPedidoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 605, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcPedidoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 605, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InfPedidoCancelamento uses Python identifier InfPedidoCancelamento
-    __InfPedidoCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento'), 'InfPedidoCancelamento', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsInfPedidoCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 607, 3), )
+    __InfPedidoCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento"),
+        "InfPedidoCancelamento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsInfPedidoCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 607, 3
+        ),
+    )
 
-    
-    InfPedidoCancelamento = property(__InfPedidoCancelamento.value, __InfPedidoCancelamento.set, None, None)
+    InfPedidoCancelamento = property(
+        __InfPedidoCancelamento.value, __InfPedidoCancelamento.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcPedidoCancelamento_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcPedidoCancelamento_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __InfPedidoCancelamento.name() : __InfPedidoCancelamento,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__InfPedidoCancelamento.name(): __InfPedidoCancelamento, __Signature.name(): __Signature}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcPedidoCancelamento = tcPedidoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcPedidoCancelamento', tcPedidoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcPedidoCancelamento", tcPedidoCancelamento)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcRetCancelamento with content type ELEMENT_ONLY
-class tcRetCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcRetCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcRetCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcRetCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 634, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcRetCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 634, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseCancelamento uses Python identifier NfseCancelamento
-    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), 'NfseCancelamento', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcRetCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsNfseCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 636, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseCancelamento uses Python identifier NfseCancelamento
+    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        "NfseCancelamento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcRetCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsNfseCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 636, 3
+        ),
+    )
+
     NfseCancelamento = property(__NfseCancelamento.value, __NfseCancelamento.set, None, None)
 
-    _ElementMap.update({
-        __NfseCancelamento.name() : __NfseCancelamento
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__NfseCancelamento.name(): __NfseCancelamento})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcRetCancelamento = tcRetCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcRetCancelamento', tcRetCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcRetCancelamento", tcRetCancelamento)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCompNfse with content type ELEMENT_ONLY
-class tcCompNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcCompNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCompNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCompNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 660, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCompNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 660, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Nfse uses Python identifier Nfse
-    __Nfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Nfse'), 'Nfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 662, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Nfse uses Python identifier Nfse
+    __Nfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Nfse"),
+        "Nfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 662, 3
+        ),
+    )
+
     Nfse = property(__Nfse.value, __Nfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseCancelamento uses Python identifier NfseCancelamento
-    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), 'NfseCancelamento', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 664, 3), )
+    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        "NfseCancelamento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 664, 3
+        ),
+    )
 
-    
     NfseCancelamento = property(__NfseCancelamento.value, __NfseCancelamento.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituicao uses Python identifier NfseSubstituicao
-    __NfseSubstituicao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao'), 'NfseSubstituicao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituicao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 666, 3), )
+    __NfseSubstituicao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao"),
+        "NfseSubstituicao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCompNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituicao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 666, 3
+        ),
+    )
 
-    
     NfseSubstituicao = property(__NfseSubstituicao.value, __NfseSubstituicao.set, None, None)
 
-    _ElementMap.update({
-        __Nfse.name() : __Nfse,
-        __NfseCancelamento.name() : __NfseCancelamento,
-        __NfseSubstituicao.name() : __NfseSubstituicao
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Nfse.name(): __Nfse,
+            __NfseCancelamento.name(): __NfseCancelamento,
+            __NfseSubstituicao.name(): __NfseSubstituicao,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcCompNfse = tcCompNfse
-Namespace.addCategoryObject('typeBinding', 'tcCompNfse', tcCompNfse)
+Namespace.addCategoryObject("typeBinding", "tcCompNfse", tcCompNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcMensagemRetorno with content type ELEMENT_ONLY
-class tcMensagemRetorno (pyxb.binding.basis.complexTypeDefinition):
+class tcMensagemRetorno(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcMensagemRetorno with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcMensagemRetorno')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 671, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcMensagemRetorno")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 671, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Codigo uses Python identifier Codigo
-    __Codigo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), 'Codigo', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsCodigo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 673, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Codigo uses Python identifier Codigo
+    __Codigo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        "Codigo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsCodigo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 673, 3
+        ),
+    )
+
     Codigo = property(__Codigo.value, __Codigo.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Mensagem uses Python identifier Mensagem
-    __Mensagem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), 'Mensagem', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsMensagem', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 675, 3), )
+    __Mensagem = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        "Mensagem",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsMensagem",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 675, 3
+        ),
+    )
 
-    
     Mensagem = property(__Mensagem.value, __Mensagem.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Correcao uses Python identifier Correcao
-    __Correcao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Correcao'), 'Correcao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsCorrecao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 677, 3), )
+    __Correcao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Correcao"),
+        "Correcao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetorno_httpwww_betha_com_bre_nota_contribuinte_wsCorrecao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 677, 3
+        ),
+    )
 
-    
     Correcao = property(__Correcao.value, __Correcao.set, None, None)
 
-    _ElementMap.update({
-        __Codigo.name() : __Codigo,
-        __Mensagem.name() : __Mensagem,
-        __Correcao.name() : __Correcao
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__Codigo.name(): __Codigo, __Mensagem.name(): __Mensagem, __Correcao.name(): __Correcao}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcMensagemRetorno = tcMensagemRetorno
-Namespace.addCategoryObject('typeBinding', 'tcMensagemRetorno', tcMensagemRetorno)
+Namespace.addCategoryObject("typeBinding", "tcMensagemRetorno", tcMensagemRetorno)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcMensagemRetornoLote with content type ELEMENT_ONLY
-class tcMensagemRetornoLote (pyxb.binding.basis.complexTypeDefinition):
+class tcMensagemRetornoLote(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcMensagemRetornoLote with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcMensagemRetornoLote')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 682, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcMensagemRetornoLote")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 682, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 684, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 684, 3
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Codigo uses Python identifier Codigo
-    __Codigo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), 'Codigo', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsCodigo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 686, 3), )
+    __Codigo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        "Codigo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsCodigo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 686, 3
+        ),
+    )
 
-    
     Codigo = property(__Codigo.value, __Codigo.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Mensagem uses Python identifier Mensagem
-    __Mensagem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), 'Mensagem', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsMensagem', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 688, 3), )
+    __Mensagem = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        "Mensagem",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcMensagemRetornoLote_httpwww_betha_com_bre_nota_contribuinte_wsMensagem",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 688, 3
+        ),
+    )
 
-    
     Mensagem = property(__Mensagem.value, __Mensagem.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __Codigo.name() : __Codigo,
-        __Mensagem.name() : __Mensagem
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __Codigo.name(): __Codigo,
+            __Mensagem.name(): __Mensagem,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcMensagemRetornoLote = tcMensagemRetornoLote
-Namespace.addCategoryObject('typeBinding', 'tcMensagemRetornoLote', tcMensagemRetornoLote)
+Namespace.addCategoryObject("typeBinding", "tcMensagemRetornoLote", tcMensagemRetornoLote)
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 704, 4)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 704, 4
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
-    __Rps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Rps'), 'Rps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_httpwww_betha_com_bre_nota_contribuinte_wsRps', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 706, 6), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
+    __Rps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        "Rps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_httpwww_betha_com_bre_nota_contribuinte_wsRps",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 706, 6
+        ),
+    )
+
     Rps = property(__Rps.value, __Rps.set, None, None)
 
-    _ElementMap.update({
-        __Rps.name() : __Rps
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Rps.name(): __Rps})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_ (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 718, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 718, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
-    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), 'MensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON__httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 720, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
+    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        "MensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON__httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 720, 4
+        ),
+    )
+
     MensagemRetorno = property(__MensagemRetorno.value, __MensagemRetorno.set, None, None)
 
-    _ElementMap.update({
-        __MensagemRetorno.name() : __MensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__MensagemRetorno.name(): __MensagemRetorno})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_ = CTD_ANON_
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_2 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_2(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 727, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 727, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
-    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), 'MensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_2_httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 729, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
+    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        "MensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_2_httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 729, 4
+        ),
+    )
+
     MensagemRetorno = property(__MensagemRetorno.value, __MensagemRetorno.set, None, None)
 
-    _ElementMap.update({
-        __MensagemRetorno.name() : __MensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__MensagemRetorno.name(): __MensagemRetorno})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_2 = CTD_ANON_2
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_3 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_3(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 736, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 736, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
-    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), 'MensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_3_httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 738, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}MensagemRetorno uses Python identifier MensagemRetorno
+    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        "MensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_3_httpwww_betha_com_bre_nota_contribuinte_wsMensagemRetorno",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 738, 4
+        ),
+    )
+
     MensagemRetorno = property(__MensagemRetorno.value, __MensagemRetorno.set, None, None)
 
-    _ElementMap.update({
-        __MensagemRetorno.name() : __MensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__MensagemRetorno.name(): __MensagemRetorno})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_3 = CTD_ANON_3
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_4 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_4(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 757, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 757, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}LoteRps uses Python identifier LoteRps
-    __LoteRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), 'LoteRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_4_httpwww_betha_com_bre_nota_contribuinte_wsLoteRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 759, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}LoteRps uses Python identifier LoteRps
+    __LoteRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        "LoteRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_4_httpwww_betha_com_bre_nota_contribuinte_wsLoteRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 759, 4
+        ),
+    )
+
     LoteRps = property(__LoteRps.value, __LoteRps.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_4_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_4_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __LoteRps.name() : __LoteRps,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__LoteRps.name(): __LoteRps, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_4 = CTD_ANON_4
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_5 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_5(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 767, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 767, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 770, 5), )
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 770, 5
+        ),
+    )
 
-    
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataRecebimento uses Python identifier DataRecebimento
-    __DataRecebimento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), 'DataRecebimento', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsDataRecebimento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 772, 5), )
+    __DataRecebimento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        "DataRecebimento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsDataRecebimento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 772, 5
+        ),
+    )
 
-    
     DataRecebimento = property(__DataRecebimento.value, __DataRecebimento.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 774, 5), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_5_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 774, 5
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __NumeroLote.name() : __NumeroLote,
-        __DataRecebimento.name() : __DataRecebimento,
-        __Protocolo.name() : __Protocolo
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+            __NumeroLote.name(): __NumeroLote,
+            __DataRecebimento.name(): __DataRecebimento,
+            __Protocolo.name(): __Protocolo,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_5 = CTD_ANON_5
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_6 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_6(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 784, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 784, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}LoteRps uses Python identifier LoteRps
-    __LoteRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), 'LoteRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_6_httpwww_betha_com_bre_nota_contribuinte_wsLoteRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 786, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}LoteRps uses Python identifier LoteRps
+    __LoteRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        "LoteRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_6_httpwww_betha_com_bre_nota_contribuinte_wsLoteRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 786, 4
+        ),
+    )
+
     LoteRps = property(__LoteRps.value, __LoteRps.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_6_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_6_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __LoteRps.name() : __LoteRps,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__LoteRps.name(): __LoteRps, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_6 = CTD_ANON_6
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_7 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_7(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 795, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 795, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetornoLote uses Python identifier ListaMensagemRetornoLote
-    __ListaMensagemRetornoLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote'), 'ListaMensagemRetornoLote', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetornoLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 717, 2), )
+    __ListaMensagemRetornoLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote"),
+        "ListaMensagemRetornoLote",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetornoLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 717, 2
+        ),
+    )
 
-    
-    ListaMensagemRetornoLote = property(__ListaMensagemRetornoLote.value, __ListaMensagemRetornoLote.set, None, None)
+    ListaMensagemRetornoLote = property(
+        __ListaMensagemRetornoLote.value, __ListaMensagemRetornoLote.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 797, 4), )
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 797, 4
+        ),
+    )
 
-    
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataRecebimento uses Python identifier DataRecebimento
-    __DataRecebimento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), 'DataRecebimento', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsDataRecebimento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 799, 4), )
+    __DataRecebimento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        "DataRecebimento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsDataRecebimento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 799, 4
+        ),
+    )
 
-    
     DataRecebimento = property(__DataRecebimento.value, __DataRecebimento.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 801, 4), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 801, 4
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 804, 5), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_7_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 804, 5
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetornoLote.name() : __ListaMensagemRetornoLote,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __NumeroLote.name() : __NumeroLote,
-        __DataRecebimento.name() : __DataRecebimento,
-        __Protocolo.name() : __Protocolo,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemRetornoLote.name(): __ListaMensagemRetornoLote,
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+            __NumeroLote.name(): __NumeroLote,
+            __DataRecebimento.name(): __DataRecebimento,
+            __Protocolo.name(): __Protocolo,
+            __ListaNfse.name(): __ListaNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_7 = CTD_ANON_7
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_8 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_8(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 805, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 805, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemAlertaRetorno uses Python identifier ListaMensagemAlertaRetorno
-    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), 'ListaMensagemAlertaRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_8_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1), )
+    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        "ListaMensagemAlertaRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_8_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
 
-    
-    ListaMensagemAlertaRetorno = property(__ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None)
+    ListaMensagemAlertaRetorno = property(
+        __ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_8_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_8_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
 
-    
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemAlertaRetorno.name() : __ListaMensagemAlertaRetorno,
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemAlertaRetorno.name(): __ListaMensagemAlertaRetorno,
+            __CompNfse.name(): __CompNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_8 = CTD_ANON_8
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_9 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_9(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 823, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 823, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
-    __Rps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Rps'), 'Rps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_9_httpwww_betha_com_bre_nota_contribuinte_wsRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 825, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
+    __Rps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        "Rps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_9_httpwww_betha_com_bre_nota_contribuinte_wsRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 825, 4
+        ),
+    )
+
     Rps = property(__Rps.value, __Rps.set, None, None)
 
-    _ElementMap.update({
-        __Rps.name() : __Rps
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Rps.name(): __Rps})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_9 = CTD_ANON_9
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_10 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_10(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 831, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 831, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_10_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_10_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_10_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 834, 5), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_10_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 834, 5
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaMensagemRetorno.name(): __ListaMensagemRetorno, __ListaNfse.name(): __ListaNfse}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_10 = CTD_ANON_10
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_11 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_11(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 835, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 835, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemAlertaRetorno uses Python identifier ListaMensagemAlertaRetorno
-    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), 'ListaMensagemAlertaRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_11_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1), )
+    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        "ListaMensagemAlertaRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_11_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
 
-    
-    ListaMensagemAlertaRetorno = property(__ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None)
+    ListaMensagemAlertaRetorno = property(
+        __ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_11_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_11_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
 
-    
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemAlertaRetorno.name() : __ListaMensagemAlertaRetorno,
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemAlertaRetorno.name(): __ListaMensagemAlertaRetorno,
+            __CompNfse.name(): __CompNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_11 = CTD_ANON_11
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_12 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_12(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 851, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 851, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
-    __Pedido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), 'Pedido', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_12_httpwww_betha_com_bre_nota_contribuinte_wsPedido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 853, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
+    __Pedido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        "Pedido",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_12_httpwww_betha_com_bre_nota_contribuinte_wsPedido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 853, 4
+        ),
+    )
+
     Pedido = property(__Pedido.value, __Pedido.set, None, None)
 
-    _ElementMap.update({
-        __Pedido.name() : __Pedido
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Pedido.name(): __Pedido})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_12 = CTD_ANON_12
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_13 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_13(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 859, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 859, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_13_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_13_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RetCancelamento uses Python identifier RetCancelamento
-    __RetCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RetCancelamento'), 'RetCancelamento', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_13_httpwww_betha_com_bre_nota_contribuinte_wsRetCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 861, 4), )
+    __RetCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RetCancelamento"),
+        "RetCancelamento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_13_httpwww_betha_com_bre_nota_contribuinte_wsRetCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 861, 4
+        ),
+    )
 
-    
     RetCancelamento = property(__RetCancelamento.value, __RetCancelamento.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __RetCancelamento.name() : __RetCancelamento
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+            __RetCancelamento.name(): __RetCancelamento,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_13 = CTD_ANON_13
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_14 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_14(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 868, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 868, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}SubstituicaoNfse uses Python identifier SubstituicaoNfse
-    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), 'SubstituicaoNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_14_httpwww_betha_com_bre_nota_contribuinte_wsSubstituicaoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 870, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}SubstituicaoNfse uses Python identifier SubstituicaoNfse
+    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        "SubstituicaoNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_14_httpwww_betha_com_bre_nota_contribuinte_wsSubstituicaoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 870, 4
+        ),
+    )
+
     SubstituicaoNfse = property(__SubstituicaoNfse.value, __SubstituicaoNfse.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_14_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_14_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __SubstituicaoNfse.name() : __SubstituicaoNfse,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__SubstituicaoNfse.name(): __SubstituicaoNfse, __Signature.name(): __Signature}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_14 = CTD_ANON_14
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_15 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_15(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 887, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 887, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_15_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_15_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RetSubstituicao uses Python identifier RetSubstituicao
-    __RetSubstituicao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RetSubstituicao'), 'RetSubstituicao', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_15_httpwww_betha_com_bre_nota_contribuinte_wsRetSubstituicao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 889, 5), )
+    __RetSubstituicao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RetSubstituicao"),
+        "RetSubstituicao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_15_httpwww_betha_com_bre_nota_contribuinte_wsRetSubstituicao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 889, 5
+        ),
+    )
 
-    
     RetSubstituicao = property(__RetSubstituicao.value, __RetSubstituicao.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __RetSubstituicao.name() : __RetSubstituicao
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+            __RetSubstituicao.name(): __RetSubstituicao,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_15 = CTD_ANON_15
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_16 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_16(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 890, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 890, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituida uses Python identifier NfseSubstituida
-    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), 'NfseSubstituida', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_16_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituida', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 892, 8), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituida uses Python identifier NfseSubstituida
+    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        "NfseSubstituida",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_16_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituida",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 892, 8
+        ),
+    )
+
     NfseSubstituida = property(__NfseSubstituida.value, __NfseSubstituida.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituidora uses Python identifier NfseSubstituidora
-    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), 'NfseSubstituidora', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_16_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituidora', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 901, 8), )
+    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        "NfseSubstituidora",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_16_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituidora",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 901, 8
+        ),
+    )
 
-    
     NfseSubstituidora = property(__NfseSubstituidora.value, __NfseSubstituidora.set, None, None)
 
-    _ElementMap.update({
-        __NfseSubstituida.name() : __NfseSubstituida,
-        __NfseSubstituidora.name() : __NfseSubstituidora
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __NfseSubstituida.name(): __NfseSubstituida,
+            __NfseSubstituidora.name(): __NfseSubstituidora,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_16 = CTD_ANON_16
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_17 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_17(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 893, 9)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 893, 9
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemAlertaRetorno uses Python identifier ListaMensagemAlertaRetorno
-    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), 'ListaMensagemAlertaRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_17_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1), )
+    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        "ListaMensagemAlertaRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_17_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
 
-    
-    ListaMensagemAlertaRetorno = property(__ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None)
+    ListaMensagemAlertaRetorno = property(
+        __ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_17_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_17_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
 
-    
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemAlertaRetorno.name() : __ListaMensagemAlertaRetorno,
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemAlertaRetorno.name(): __ListaMensagemAlertaRetorno,
+            __CompNfse.name(): __CompNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_17 = CTD_ANON_17
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_18 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_18(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 902, 9)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 902, 9
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_18_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_18_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_18 = CTD_ANON_18
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_19 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_19(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 918, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 918, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_19_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 920, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_19_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 920, 4
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_19_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 922, 4), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_19_httpwww_betha_com_bre_nota_contribuinte_wsProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 922, 4
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __Protocolo.name() : __Protocolo
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Prestador.name(): __Prestador, __Protocolo.name(): __Protocolo})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_19 = CTD_ANON_19
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_20 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_20(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 929, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 929, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetornoLote uses Python identifier ListaMensagemRetornoLote
-    __ListaMensagemRetornoLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote'), 'ListaMensagemRetornoLote', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetornoLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 717, 2), )
+    __ListaMensagemRetornoLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote"),
+        "ListaMensagemRetornoLote",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetornoLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 717, 2
+        ),
+    )
 
-    
-    ListaMensagemRetornoLote = property(__ListaMensagemRetornoLote.value, __ListaMensagemRetornoLote.set, None, None)
+    ListaMensagemRetornoLote = property(
+        __ListaMensagemRetornoLote.value, __ListaMensagemRetornoLote.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Situacao uses Python identifier Situacao
-    __Situacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Situacao'), 'Situacao', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsSituacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 931, 11), )
+    __Situacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Situacao"),
+        "Situacao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsSituacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 931, 11
+        ),
+    )
 
-    
     Situacao = property(__Situacao.value, __Situacao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 933, 4), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_20_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 933, 4
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetornoLote.name() : __ListaMensagemRetornoLote,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __Situacao.name() : __Situacao,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemRetornoLote.name(): __ListaMensagemRetornoLote,
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+            __Situacao.name(): __Situacao,
+            __ListaNfse.name(): __ListaNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_20 = CTD_ANON_20
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_21 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_21(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 934, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 934, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemAlertaRetorno uses Python identifier ListaMensagemAlertaRetorno
-    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), 'ListaMensagemAlertaRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_21_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1), )
+    __ListaMensagemAlertaRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        "ListaMensagemAlertaRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_21_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemAlertaRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
 
-    
-    ListaMensagemAlertaRetorno = property(__ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None)
+    ListaMensagemAlertaRetorno = property(
+        __ListaMensagemAlertaRetorno.value, __ListaMensagemAlertaRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_21_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_21_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
 
-    
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemAlertaRetorno.name() : __ListaMensagemAlertaRetorno,
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ListaMensagemAlertaRetorno.name(): __ListaMensagemAlertaRetorno,
+            __CompNfse.name(): __CompNfse,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_21 = CTD_ANON_21
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_22 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_22(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 952, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 952, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_22_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 954, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_22_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 954, 4
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_22_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 956, 4), )
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_22_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 956, 4
+        ),
+    )
 
-    
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __Prestador.name() : __Prestador
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__IdentificacaoRps.name(): __IdentificacaoRps, __Prestador.name(): __Prestador}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_22 = CTD_ANON_22
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_23 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_23(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 963, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 963, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_23_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_23_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_23_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_23_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
 
-    
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaMensagemRetorno.name(): __ListaMensagemRetorno, __CompNfse.name(): __CompNfse}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_23 = CTD_ANON_23
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_24 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_24(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 973, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 973, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 975, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 975, 4
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroNfse uses Python identifier NumeroNfse
-    __NumeroNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), 'NumeroNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 977, 4), )
+    __NumeroNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        "NumeroNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 977, 4
+        ),
+    )
 
-    
     NumeroNfse = property(__NumeroNfse.value, __NumeroNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}PeriodoEmissao uses Python identifier PeriodoEmissao
-    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), 'PeriodoEmissao', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 980, 5), )
+    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        "PeriodoEmissao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 980, 5
+        ),
+    )
 
-    
     PeriodoEmissao = property(__PeriodoEmissao.value, __PeriodoEmissao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}PeriodoCompetencia uses Python identifier PeriodoCompetencia
-    __PeriodoCompetencia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia'), 'PeriodoCompetencia', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoCompetencia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 991, 5), )
+    __PeriodoCompetencia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia"),
+        "PeriodoCompetencia",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoCompetencia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 991, 5
+        ),
+    )
 
-    
     PeriodoCompetencia = property(__PeriodoCompetencia.value, __PeriodoCompetencia.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Tomador uses Python identifier Tomador
-    __Tomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), 'Tomador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1003, 4), )
+    __Tomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        "Tomador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1003, 4
+        ),
+    )
 
-    
     Tomador = property(__Tomador.value, __Tomador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Intermediario uses Python identifier Intermediario
-    __Intermediario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), 'Intermediario', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1005, 4), )
+    __Intermediario = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        "Intermediario",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1005, 4
+        ),
+    )
 
-    
     Intermediario = property(__Intermediario.value, __Intermediario.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pagina uses Python identifier Pagina
-    __Pagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), 'Pagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1007, 4), )
+    __Pagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        "Pagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_24_httpwww_betha_com_bre_nota_contribuinte_wsPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1007, 4
+        ),
+    )
 
-    
     Pagina = property(__Pagina.value, __Pagina.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __NumeroNfse.name() : __NumeroNfse,
-        __PeriodoEmissao.name() : __PeriodoEmissao,
-        __PeriodoCompetencia.name() : __PeriodoCompetencia,
-        __Tomador.name() : __Tomador,
-        __Intermediario.name() : __Intermediario,
-        __Pagina.name() : __Pagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Prestador.name(): __Prestador,
+            __NumeroNfse.name(): __NumeroNfse,
+            __PeriodoEmissao.name(): __PeriodoEmissao,
+            __PeriodoCompetencia.name(): __PeriodoCompetencia,
+            __Tomador.name(): __Tomador,
+            __Intermediario.name(): __Intermediario,
+            __Pagina.name(): __Pagina,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_24 = CTD_ANON_24
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_25 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_25(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 982, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 982, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
-    __DataInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), 'DataInicial', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_25_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 984, 8), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
+    __DataInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        "DataInicial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_25_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 984, 8
+        ),
+    )
+
     DataInicial = property(__DataInicial.value, __DataInicial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataFinal uses Python identifier DataFinal
-    __DataFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), 'DataFinal', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_25_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 986, 8), )
+    __DataFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        "DataFinal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_25_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 986, 8
+        ),
+    )
 
-    
     DataFinal = property(__DataFinal.value, __DataFinal.set, None, None)
 
-    _ElementMap.update({
-        __DataInicial.name() : __DataInicial,
-        __DataFinal.name() : __DataFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DataInicial.name(): __DataInicial, __DataFinal.name(): __DataFinal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_25 = CTD_ANON_25
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_26 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_26(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 993, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 993, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
-    __DataInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), 'DataInicial', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_26_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 995, 8), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
+    __DataInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        "DataInicial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_26_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 995, 8
+        ),
+    )
+
     DataInicial = property(__DataInicial.value, __DataInicial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataFinal uses Python identifier DataFinal
-    __DataFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), 'DataFinal', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_26_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 997, 8), )
+    __DataFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        "DataFinal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_26_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 997, 8
+        ),
+    )
 
-    
     DataFinal = property(__DataFinal.value, __DataFinal.set, None, None)
 
-    _ElementMap.update({
-        __DataInicial.name() : __DataInicial,
-        __DataFinal.name() : __DataFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DataInicial.name(): __DataInicial, __DataFinal.name(): __DataFinal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_26 = CTD_ANON_26
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_27 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_27(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1013, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1013, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_27_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_27_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_27_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1015, 4), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_27_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1015, 4
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaMensagemRetorno.name(): __ListaMensagemRetorno, __ListaNfse.name(): __ListaNfse}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_27 = CTD_ANON_27
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_28 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_28(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1016, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1016, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_28_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_28_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ProximaPagina uses Python identifier ProximaPagina
-    __ProximaPagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), 'ProximaPagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_28_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1019, 7), )
+    __ProximaPagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        "ProximaPagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_28_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1019, 7
+        ),
+    )
 
-    
     ProximaPagina = property(__ProximaPagina.value, __ProximaPagina.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse,
-        __ProximaPagina.name() : __ProximaPagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse, __ProximaPagina.name(): __ProximaPagina})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_28 = CTD_ANON_28
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_29 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_29(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1030, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1030, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Consulente uses Python identifier Consulente
-    __Consulente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Consulente'), 'Consulente', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsConsulente', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1032, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Consulente uses Python identifier Consulente
+    __Consulente = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Consulente"),
+        "Consulente",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsConsulente",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1032, 4
+        ),
+    )
+
     Consulente = property(__Consulente.value, __Consulente.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroNfse uses Python identifier NumeroNfse
-    __NumeroNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), 'NumeroNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1034, 4), )
+    __NumeroNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        "NumeroNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1034, 4
+        ),
+    )
 
-    
     NumeroNfse = property(__NumeroNfse.value, __NumeroNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}PeriodoEmissao uses Python identifier PeriodoEmissao
-    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), 'PeriodoEmissao', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1037, 5), )
+    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        "PeriodoEmissao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1037, 5
+        ),
+    )
 
-    
     PeriodoEmissao = property(__PeriodoEmissao.value, __PeriodoEmissao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}PeriodoCompetencia uses Python identifier PeriodoCompetencia
-    __PeriodoCompetencia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia'), 'PeriodoCompetencia', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoCompetencia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1048, 5), )
+    __PeriodoCompetencia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia"),
+        "PeriodoCompetencia",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPeriodoCompetencia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1048, 5
+        ),
+    )
 
-    
     PeriodoCompetencia = property(__PeriodoCompetencia.value, __PeriodoCompetencia.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1060, 4), )
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1060, 4
+        ),
+    )
 
-    
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Tomador uses Python identifier Tomador
-    __Tomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), 'Tomador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1062, 4), )
+    __Tomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        "Tomador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1062, 4
+        ),
+    )
 
-    
     Tomador = property(__Tomador.value, __Tomador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Intermediario uses Python identifier Intermediario
-    __Intermediario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), 'Intermediario', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1064, 4), )
+    __Intermediario = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        "Intermediario",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1064, 4
+        ),
+    )
 
-    
     Intermediario = property(__Intermediario.value, __Intermediario.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pagina uses Python identifier Pagina
-    __Pagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), 'Pagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1066, 4), )
+    __Pagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        "Pagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_29_httpwww_betha_com_bre_nota_contribuinte_wsPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1066, 4
+        ),
+    )
 
-    
     Pagina = property(__Pagina.value, __Pagina.set, None, None)
 
-    _ElementMap.update({
-        __Consulente.name() : __Consulente,
-        __NumeroNfse.name() : __NumeroNfse,
-        __PeriodoEmissao.name() : __PeriodoEmissao,
-        __PeriodoCompetencia.name() : __PeriodoCompetencia,
-        __Prestador.name() : __Prestador,
-        __Tomador.name() : __Tomador,
-        __Intermediario.name() : __Intermediario,
-        __Pagina.name() : __Pagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Consulente.name(): __Consulente,
+            __NumeroNfse.name(): __NumeroNfse,
+            __PeriodoEmissao.name(): __PeriodoEmissao,
+            __PeriodoCompetencia.name(): __PeriodoCompetencia,
+            __Prestador.name(): __Prestador,
+            __Tomador.name(): __Tomador,
+            __Intermediario.name(): __Intermediario,
+            __Pagina.name(): __Pagina,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_29 = CTD_ANON_29
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_30 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_30(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1039, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1039, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
-    __DataInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), 'DataInicial', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_30_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1041, 8), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
+    __DataInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        "DataInicial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_30_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1041, 8
+        ),
+    )
+
     DataInicial = property(__DataInicial.value, __DataInicial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataFinal uses Python identifier DataFinal
-    __DataFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), 'DataFinal', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_30_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1043, 8), )
+    __DataFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        "DataFinal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_30_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1043, 8
+        ),
+    )
 
-    
     DataFinal = property(__DataFinal.value, __DataFinal.set, None, None)
 
-    _ElementMap.update({
-        __DataInicial.name() : __DataInicial,
-        __DataFinal.name() : __DataFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DataInicial.name(): __DataInicial, __DataFinal.name(): __DataFinal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_30 = CTD_ANON_30
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_31 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_31(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1050, 6)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1050, 6
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
-    __DataInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), 'DataInicial', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_31_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1052, 8), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataInicial uses Python identifier DataInicial
+    __DataInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        "DataInicial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_31_httpwww_betha_com_bre_nota_contribuinte_wsDataInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1052, 8
+        ),
+    )
+
     DataInicial = property(__DataInicial.value, __DataInicial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataFinal uses Python identifier DataFinal
-    __DataFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), 'DataFinal', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_31_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1054, 8), )
+    __DataFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        "DataFinal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_31_httpwww_betha_com_bre_nota_contribuinte_wsDataFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1054, 8
+        ),
+    )
 
-    
     DataFinal = property(__DataFinal.value, __DataFinal.set, None, None)
 
-    _ElementMap.update({
-        __DataInicial.name() : __DataInicial,
-        __DataFinal.name() : __DataFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DataInicial.name(): __DataInicial, __DataFinal.name(): __DataFinal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_31 = CTD_ANON_31
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_32 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_32(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1072, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1072, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_32_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_32_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_32_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1074, 4), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_32_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1074, 4
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaMensagemRetorno.name(): __ListaMensagemRetorno, __ListaNfse.name(): __ListaNfse}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_32 = CTD_ANON_32
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_33 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_33(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1075, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1075, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_33_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_33_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ProximaPagina uses Python identifier ProximaPagina
-    __ProximaPagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), 'ProximaPagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_33_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1078, 7), )
+    __ProximaPagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        "ProximaPagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_33_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1078, 7
+        ),
+    )
 
-    
     ProximaPagina = property(__ProximaPagina.value, __ProximaPagina.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse,
-        __ProximaPagina.name() : __ProximaPagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse, __ProximaPagina.name(): __ProximaPagina})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_33 = CTD_ANON_33
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_34 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_34(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1089, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1089, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1091, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1091, 4
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Faixa uses Python identifier Faixa
-    __Faixa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Faixa'), 'Faixa', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsFaixa', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1093, 4), )
+    __Faixa = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Faixa"),
+        "Faixa",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsFaixa",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1093, 4
+        ),
+    )
 
-    
     Faixa = property(__Faixa.value, __Faixa.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pagina uses Python identifier Pagina
-    __Pagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), 'Pagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1103, 4), )
+    __Pagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        "Pagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_34_httpwww_betha_com_bre_nota_contribuinte_wsPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1103, 4
+        ),
+    )
 
-    
     Pagina = property(__Pagina.value, __Pagina.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __Faixa.name() : __Faixa,
-        __Pagina.name() : __Pagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__Prestador.name(): __Prestador, __Faixa.name(): __Faixa, __Pagina.name(): __Pagina}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_34 = CTD_ANON_34
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_35 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_35(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1094, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1094, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroNfseInicial uses Python identifier NumeroNfseInicial
-    __NumeroNfseInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseInicial'), 'NumeroNfseInicial', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_35_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfseInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1096, 7), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroNfseInicial uses Python identifier NumeroNfseInicial
+    __NumeroNfseInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfseInicial"),
+        "NumeroNfseInicial",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_35_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfseInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1096, 7
+        ),
+    )
+
     NumeroNfseInicial = property(__NumeroNfseInicial.value, __NumeroNfseInicial.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroNfseFinal uses Python identifier NumeroNfseFinal
-    __NumeroNfseFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseFinal'), 'NumeroNfseFinal', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_35_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfseFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1098, 7), )
+    __NumeroNfseFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfseFinal"),
+        "NumeroNfseFinal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_35_httpwww_betha_com_bre_nota_contribuinte_wsNumeroNfseFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1098, 7
+        ),
+    )
 
-    
     NumeroNfseFinal = property(__NumeroNfseFinal.value, __NumeroNfseFinal.set, None, None)
 
-    _ElementMap.update({
-        __NumeroNfseInicial.name() : __NumeroNfseInicial,
-        __NumeroNfseFinal.name() : __NumeroNfseFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __NumeroNfseInicial.name(): __NumeroNfseInicial,
+            __NumeroNfseFinal.name(): __NumeroNfseFinal,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_35 = CTD_ANON_35
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_36 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_36(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1109, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1109, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_36_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_36_httpwww_betha_com_bre_nota_contribuinte_wsListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_36_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1111, 4), )
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_36_httpwww_betha_com_bre_nota_contribuinte_wsListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1111, 4
+        ),
+    )
 
-    
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    _ElementMap.update({
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno,
-        __ListaNfse.name() : __ListaNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaMensagemRetorno.name(): __ListaMensagemRetorno, __ListaNfse.name(): __ListaNfse}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_36 = CTD_ANON_36
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_37 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_37(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1112, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1112, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_37_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_37_httpwww_betha_com_bre_nota_contribuinte_wsCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ProximaPagina uses Python identifier ProximaPagina
-    __ProximaPagina = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), 'ProximaPagina', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_37_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1115, 7), )
+    __ProximaPagina = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        "ProximaPagina",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_37_httpwww_betha_com_bre_nota_contribuinte_wsProximaPagina",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1115, 7
+        ),
+    )
 
-    
     ProximaPagina = property(__ProximaPagina.value, __ProximaPagina.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse,
-        __ProximaPagina.name() : __ProximaPagina
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse, __ProximaPagina.name(): __ProximaPagina})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_37 = CTD_ANON_37
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfRps with content type ELEMENT_ONLY
-class tcInfRps (pyxb.binding.basis.complexTypeDefinition):
+class tcInfRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 498, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 498, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 500, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 500, 3
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataEmissao uses Python identifier DataEmissao
-    __DataEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), 'DataEmissao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsDataEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 502, 3), )
+    __DataEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        "DataEmissao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsDataEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 502, 3
+        ),
+    )
 
-    
     DataEmissao = property(__DataEmissao.value, __DataEmissao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Status uses Python identifier Status
-    __Status = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Status'), 'Status', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsStatus', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 504, 3), )
+    __Status = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Status"),
+        "Status",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsStatus",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 504, 3
+        ),
+    )
 
-    
     Status = property(__Status.value, __Status.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RpsSubstituido uses Python identifier RpsSubstituido
-    __RpsSubstituido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido'), 'RpsSubstituido', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsRpsSubstituido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 506, 3), )
+    __RpsSubstituido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido"),
+        "RpsSubstituido",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_httpwww_betha_com_bre_nota_contribuinte_wsRpsSubstituido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 506, 3
+        ),
+    )
 
-    
     RpsSubstituido = property(__RpsSubstituido.value, __RpsSubstituido.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 509, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 509, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfRps_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 509, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 509, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __DataEmissao.name() : __DataEmissao,
-        __Status.name() : __Status,
-        __RpsSubstituido.name() : __RpsSubstituido
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __DataEmissao.name(): __DataEmissao,
+            __Status.name(): __Status,
+            __RpsSubstituido.name(): __RpsSubstituido,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfRps = tcInfRps
-Namespace.addCategoryObject('typeBinding', 'tcInfRps', tcInfRps)
+Namespace.addCategoryObject("typeBinding", "tcInfRps", tcInfRps)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfDeclaracaoPrestacaoServico with content type ELEMENT_ONLY
-class tcInfDeclaracaoPrestacaoServico (pyxb.binding.basis.complexTypeDefinition):
+class tcInfDeclaracaoPrestacaoServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfDeclaracaoPrestacaoServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfDeclaracaoPrestacaoServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 512, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfDeclaracaoPrestacaoServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 512, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
-    __Rps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Rps'), 'Rps', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 514, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
+    __Rps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        "Rps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 514, 3
+        ),
+    )
+
     Rps = property(__Rps.value, __Rps.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Competencia uses Python identifier Competencia
-    __Competencia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Competencia'), 'Competencia', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsCompetencia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 516, 3), )
+    __Competencia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Competencia"),
+        "Competencia",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsCompetencia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 516, 3
+        ),
+    )
 
-    
     Competencia = property(__Competencia.value, __Competencia.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Servico uses Python identifier Servico
-    __Servico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Servico'), 'Servico', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 518, 3), )
+    __Servico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        "Servico",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 518, 3
+        ),
+    )
 
-    
     Servico = property(__Servico.value, __Servico.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 520, 3), )
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 520, 3
+        ),
+    )
 
-    
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Tomador uses Python identifier Tomador
-    __Tomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), 'Tomador', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 522, 3), )
+    __Tomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        "Tomador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 522, 3
+        ),
+    )
 
-    
     Tomador = property(__Tomador.value, __Tomador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Intermediario uses Python identifier Intermediario
-    __Intermediario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), 'Intermediario', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 524, 3), )
+    __Intermediario = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        "Intermediario",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsIntermediario",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 524, 3
+        ),
+    )
 
-    
     Intermediario = property(__Intermediario.value, __Intermediario.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ConstrucaoCivil uses Python identifier ConstrucaoCivil
-    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), 'ConstrucaoCivil', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsConstrucaoCivil', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 526, 3), )
+    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        "ConstrucaoCivil",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsConstrucaoCivil",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 526, 3
+        ),
+    )
 
-    
     ConstrucaoCivil = property(__ConstrucaoCivil.value, __ConstrucaoCivil.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}RegimeEspecialTributacao uses Python identifier RegimeEspecialTributacao
-    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), 'RegimeEspecialTributacao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsRegimeEspecialTributacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 528, 3), )
+    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        "RegimeEspecialTributacao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsRegimeEspecialTributacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 528, 3
+        ),
+    )
 
-    
-    RegimeEspecialTributacao = property(__RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None)
+    RegimeEspecialTributacao = property(
+        __RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}OptanteSimplesNacional uses Python identifier OptanteSimplesNacional
-    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), 'OptanteSimplesNacional', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsOptanteSimplesNacional', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 530, 3), )
+    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        "OptanteSimplesNacional",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsOptanteSimplesNacional",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 530, 3
+        ),
+    )
 
-    
-    OptanteSimplesNacional = property(__OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None)
+    OptanteSimplesNacional = property(
+        __OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None
+    )
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IncentivoFiscal uses Python identifier IncentivoFiscal
-    __IncentivoFiscal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IncentivoFiscal'), 'IncentivoFiscal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsIncentivoFiscal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 532, 3), )
+    __IncentivoFiscal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivoFiscal"),
+        "IncentivoFiscal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_httpwww_betha_com_bre_nota_contribuinte_wsIncentivoFiscal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 532, 3
+        ),
+    )
 
-    
     IncentivoFiscal = property(__IncentivoFiscal.value, __IncentivoFiscal.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 535, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 535, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfDeclaracaoPrestacaoServico_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 535, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 535, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Rps.name() : __Rps,
-        __Competencia.name() : __Competencia,
-        __Servico.name() : __Servico,
-        __Prestador.name() : __Prestador,
-        __Tomador.name() : __Tomador,
-        __Intermediario.name() : __Intermediario,
-        __ConstrucaoCivil.name() : __ConstrucaoCivil,
-        __RegimeEspecialTributacao.name() : __RegimeEspecialTributacao,
-        __OptanteSimplesNacional.name() : __OptanteSimplesNacional,
-        __IncentivoFiscal.name() : __IncentivoFiscal
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __Rps.name(): __Rps,
+            __Competencia.name(): __Competencia,
+            __Servico.name(): __Servico,
+            __Prestador.name(): __Prestador,
+            __Tomador.name(): __Tomador,
+            __Intermediario.name(): __Intermediario,
+            __ConstrucaoCivil.name(): __ConstrucaoCivil,
+            __RegimeEspecialTributacao.name(): __RegimeEspecialTributacao,
+            __OptanteSimplesNacional.name(): __OptanteSimplesNacional,
+            __IncentivoFiscal.name(): __IncentivoFiscal,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfDeclaracaoPrestacaoServico = tcInfDeclaracaoPrestacaoServico
-Namespace.addCategoryObject('typeBinding', 'tcInfDeclaracaoPrestacaoServico', tcInfDeclaracaoPrestacaoServico)
+Namespace.addCategoryObject(
+    "typeBinding", "tcInfDeclaracaoPrestacaoServico", tcInfDeclaracaoPrestacaoServico
+)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfNfse with content type ELEMENT_ONLY
-class tcInfNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcInfNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 560, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 560, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 562, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 562, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoVerificacao uses Python identifier CodigoVerificacao
-    __CodigoVerificacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao'), 'CodigoVerificacao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsCodigoVerificacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 564, 3), )
+    __CodigoVerificacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao"),
+        "CodigoVerificacao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsCodigoVerificacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 564, 3
+        ),
+    )
 
-    
     CodigoVerificacao = property(__CodigoVerificacao.value, __CodigoVerificacao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataEmissao uses Python identifier DataEmissao
-    __DataEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), 'DataEmissao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsDataEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 566, 3), )
+    __DataEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        "DataEmissao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsDataEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 566, 3
+        ),
+    )
 
-    
     DataEmissao = property(__DataEmissao.value, __DataEmissao.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituida uses Python identifier NfseSubstituida
-    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), 'NfseSubstituida', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituida', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 568, 3), )
+    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        "NfseSubstituida",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituida",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 568, 3
+        ),
+    )
 
-    
     NfseSubstituida = property(__NfseSubstituida.value, __NfseSubstituida.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}OutrasInformacoes uses Python identifier OutrasInformacoes
-    __OutrasInformacoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes'), 'OutrasInformacoes', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsOutrasInformacoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 570, 3), )
+    __OutrasInformacoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes"),
+        "OutrasInformacoes",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsOutrasInformacoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 570, 3
+        ),
+    )
 
-    
     OutrasInformacoes = property(__OutrasInformacoes.value, __OutrasInformacoes.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValoresNfse uses Python identifier ValoresNfse
-    __ValoresNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValoresNfse'), 'ValoresNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsValoresNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 572, 3), )
+    __ValoresNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValoresNfse"),
+        "ValoresNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsValoresNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 572, 3
+        ),
+    )
 
-    
     ValoresNfse = property(__ValoresNfse.value, __ValoresNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ValorCredito uses Python identifier ValorCredito
-    __ValorCredito = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito'), 'ValorCredito', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorCredito', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 574, 3), )
+    __ValorCredito = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCredito"),
+        "ValorCredito",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsValorCredito",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 574, 3
+        ),
+    )
 
-    
     ValorCredito = property(__ValorCredito.value, __ValorCredito.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}PrestadorServico uses Python identifier PrestadorServico
-    __PrestadorServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico'), 'PrestadorServico', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsPrestadorServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 576, 3), )
+    __PrestadorServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PrestadorServico"),
+        "PrestadorServico",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsPrestadorServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 576, 3
+        ),
+    )
 
-    
     PrestadorServico = property(__PrestadorServico.value, __PrestadorServico.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}OrgaoGerador uses Python identifier OrgaoGerador
-    __OrgaoGerador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador'), 'OrgaoGerador', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsOrgaoGerador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 578, 3), )
+    __OrgaoGerador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador"),
+        "OrgaoGerador",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsOrgaoGerador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 578, 3
+        ),
+    )
 
-    
     OrgaoGerador = property(__OrgaoGerador.value, __OrgaoGerador.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DeclaracaoPrestacaoServico uses Python identifier DeclaracaoPrestacaoServico
-    __DeclaracaoPrestacaoServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DeclaracaoPrestacaoServico'), 'DeclaracaoPrestacaoServico', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsDeclaracaoPrestacaoServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 580, 3), )
+    __DeclaracaoPrestacaoServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DeclaracaoPrestacaoServico"),
+        "DeclaracaoPrestacaoServico",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_httpwww_betha_com_bre_nota_contribuinte_wsDeclaracaoPrestacaoServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 580, 3
+        ),
+    )
 
-    
-    DeclaracaoPrestacaoServico = property(__DeclaracaoPrestacaoServico.value, __DeclaracaoPrestacaoServico.set, None, None)
+    DeclaracaoPrestacaoServico = property(
+        __DeclaracaoPrestacaoServico.value, __DeclaracaoPrestacaoServico.set, None, None
+    )
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 582, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 582, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfNfse_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 582, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 582, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __CodigoVerificacao.name() : __CodigoVerificacao,
-        __DataEmissao.name() : __DataEmissao,
-        __NfseSubstituida.name() : __NfseSubstituida,
-        __OutrasInformacoes.name() : __OutrasInformacoes,
-        __ValoresNfse.name() : __ValoresNfse,
-        __ValorCredito.name() : __ValorCredito,
-        __PrestadorServico.name() : __PrestadorServico,
-        __OrgaoGerador.name() : __OrgaoGerador,
-        __DeclaracaoPrestacaoServico.name() : __DeclaracaoPrestacaoServico
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __Numero.name(): __Numero,
+            __CodigoVerificacao.name(): __CodigoVerificacao,
+            __DataEmissao.name(): __DataEmissao,
+            __NfseSubstituida.name(): __NfseSubstituida,
+            __OutrasInformacoes.name(): __OutrasInformacoes,
+            __ValoresNfse.name(): __ValoresNfse,
+            __ValorCredito.name(): __ValorCredito,
+            __PrestadorServico.name(): __PrestadorServico,
+            __OrgaoGerador.name(): __OrgaoGerador,
+            __DeclaracaoPrestacaoServico.name(): __DeclaracaoPrestacaoServico,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfNfse = tcInfNfse
-Namespace.addCategoryObject('typeBinding', 'tcInfNfse', tcInfNfse)
+Namespace.addCategoryObject("typeBinding", "tcInfNfse", tcInfNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcNfse with content type ELEMENT_ONLY
-class tcNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 585, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 585, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InfNfse uses Python identifier InfNfse
-    __InfNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfNfse'), 'InfNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_httpwww_betha_com_bre_nota_contribuinte_wsInfNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 587, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InfNfse uses Python identifier InfNfse
+    __InfNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfNfse"),
+        "InfNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_httpwww_betha_com_bre_nota_contribuinte_wsInfNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 587, 3
+        ),
+    )
+
     InfNfse = property(__InfNfse.value, __InfNfse.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_versao', _module_typeBindings.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 592, 2)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 592, 2)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcNfse_versao",
+        _module_typeBindings.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 592, 2
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 592, 2
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __InfNfse.name() : __InfNfse,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        __versao.name() : __versao
-    })
+    _ElementMap.update({__InfNfse.name(): __InfNfse, __Signature.name(): __Signature})
+    _AttributeMap.update({__versao.name(): __versao})
+
+
 _module_typeBindings.tcNfse = tcNfse
-Namespace.addCategoryObject('typeBinding', 'tcNfse', tcNfse)
+Namespace.addCategoryObject("typeBinding", "tcNfse", tcNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfPedidoCancelamento with content type ELEMENT_ONLY
-class tcInfPedidoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcInfPedidoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfPedidoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfPedidoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 595, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfPedidoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 595, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoNfse uses Python identifier IdentificacaoNfse
-    __IdentificacaoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse'), 'IdentificacaoNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 597, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}IdentificacaoNfse uses Python identifier IdentificacaoNfse
+    __IdentificacaoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse"),
+        "IdentificacaoNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsIdentificacaoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 597, 3
+        ),
+    )
+
     IdentificacaoNfse = property(__IdentificacaoNfse.value, __IdentificacaoNfse.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CodigoCancelamento uses Python identifier CodigoCancelamento
-    __CodigoCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento'), 'CodigoCancelamento', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsCodigoCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 599, 3), )
+    __CodigoCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento"),
+        "CodigoCancelamento",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsCodigoCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 599, 3
+        ),
+    )
 
-    
     CodigoCancelamento = property(__CodigoCancelamento.value, __CodigoCancelamento.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 602, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 602, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfPedidoCancelamento_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 602, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 602, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoNfse.name() : __IdentificacaoNfse,
-        __CodigoCancelamento.name() : __CodigoCancelamento
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoNfse.name(): __IdentificacaoNfse,
+            __CodigoCancelamento.name(): __CodigoCancelamento,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfPedidoCancelamento = tcInfPedidoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcInfPedidoCancelamento', tcInfPedidoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcInfPedidoCancelamento", tcInfPedidoCancelamento)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcConfirmacaoCancelamento with content type ELEMENT_ONLY
-class tcConfirmacaoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcConfirmacaoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcConfirmacaoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcConfirmacaoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 614, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcConfirmacaoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 614, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
-    __Pedido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), 'Pedido', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsPedido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 616, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
+    __Pedido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        "Pedido",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsPedido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 616, 3
+        ),
+    )
+
     Pedido = property(__Pedido.value, __Pedido.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}DataHora uses Python identifier DataHora
-    __DataHora = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataHora'), 'DataHora', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsDataHora', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 618, 3), )
+    __DataHora = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataHora"),
+        "DataHora",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_httpwww_betha_com_bre_nota_contribuinte_wsDataHora",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 618, 3
+        ),
+    )
 
-    
     DataHora = property(__DataHora.value, __DataHora.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 621, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 621, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcConfirmacaoCancelamento_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 621, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 621, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Pedido.name() : __Pedido,
-        __DataHora.name() : __DataHora
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__Pedido.name(): __Pedido, __DataHora.name(): __DataHora})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcConfirmacaoCancelamento = tcConfirmacaoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcConfirmacaoCancelamento', tcConfirmacaoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcConfirmacaoCancelamento", tcConfirmacaoCancelamento)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCancelamentoNfse with content type ELEMENT_ONLY
-class tcCancelamentoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcCancelamentoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcCancelamentoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCancelamentoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 624, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCancelamentoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 624, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Confirmacao uses Python identifier Confirmacao
-    __Confirmacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao'), 'Confirmacao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_httpwww_betha_com_bre_nota_contribuinte_wsConfirmacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 626, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Confirmacao uses Python identifier Confirmacao
+    __Confirmacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Confirmacao"),
+        "Confirmacao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_httpwww_betha_com_bre_nota_contribuinte_wsConfirmacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 626, 3
+        ),
+    )
+
     Confirmacao = property(__Confirmacao.value, __Confirmacao.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_versao', _module_typeBindings.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 631, 2)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 631, 2)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcCancelamentoNfse_versao",
+        _module_typeBindings.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 631, 2
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 631, 2
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __Confirmacao.name() : __Confirmacao,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        __versao.name() : __versao
-    })
+    _ElementMap.update({__Confirmacao.name(): __Confirmacao, __Signature.name(): __Signature})
+    _AttributeMap.update({__versao.name(): __versao})
+
+
 _module_typeBindings.tcCancelamentoNfse = tcCancelamentoNfse
-Namespace.addCategoryObject('typeBinding', 'tcCancelamentoNfse', tcCancelamentoNfse)
+Namespace.addCategoryObject("typeBinding", "tcCancelamentoNfse", tcCancelamentoNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfSubstituicaoNfse with content type ELEMENT_ONLY
-class tcInfSubstituicaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcInfSubstituicaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcInfSubstituicaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfSubstituicaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 642, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfSubstituicaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 642, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituidora uses Python identifier NfseSubstituidora
-    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), 'NfseSubstituidora', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfSubstituicaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituidora', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 644, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NfseSubstituidora uses Python identifier NfseSubstituidora
+    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        "NfseSubstituidora",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfSubstituicaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsNfseSubstituidora",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 644, 3
+        ),
+    )
+
     NfseSubstituidora = property(__NfseSubstituidora.value, __NfseSubstituidora.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfSubstituicaoNfse_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 647, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 647, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcInfSubstituicaoNfse_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 647, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 647, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __NfseSubstituidora.name() : __NfseSubstituidora
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__NfseSubstituidora.name(): __NfseSubstituidora})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfSubstituicaoNfse = tcInfSubstituicaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcInfSubstituicaoNfse', tcInfSubstituicaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcInfSubstituicaoNfse", tcInfSubstituicaoNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcSubstituicaoNfse with content type ELEMENT_ONLY
-class tcSubstituicaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcSubstituicaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcSubstituicaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcSubstituicaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 650, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcSubstituicaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 650, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}SubstituicaoNfse uses Python identifier SubstituicaoNfse
-    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), 'SubstituicaoNfse', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsSubstituicaoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 652, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}SubstituicaoNfse uses Python identifier SubstituicaoNfse
+    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        "SubstituicaoNfse",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_httpwww_betha_com_bre_nota_contribuinte_wsSubstituicaoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 652, 3
+        ),
+    )
+
     SubstituicaoNfse = property(__SubstituicaoNfse.value, __SubstituicaoNfse.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_httpwww_w3_org200009xmldsigSignature', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_httpwww_w3_org200009xmldsigSignature",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_versao', _module_typeBindings.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 657, 2)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 657, 2)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcSubstituicaoNfse_versao",
+        _module_typeBindings.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 657, 2
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 657, 2
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __SubstituicaoNfse.name() : __SubstituicaoNfse,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        __versao.name() : __versao
-    })
+    _ElementMap.update(
+        {__SubstituicaoNfse.name(): __SubstituicaoNfse, __Signature.name(): __Signature}
+    )
+    _AttributeMap.update({__versao.name(): __versao})
+
+
 _module_typeBindings.tcSubstituicaoNfse = tcSubstituicaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcSubstituicaoNfse', tcSubstituicaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcSubstituicaoNfse", tcSubstituicaoNfse)
 
 
 # Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcLoteRps with content type ELEMENT_ONLY
-class tcLoteRps (pyxb.binding.basis.complexTypeDefinition):
+class tcLoteRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.betha.com.br/e-nota-contribuinte-ws}tcLoteRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcLoteRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 693, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcLoteRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 693, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 695, 3), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}NumeroLote uses Python identifier NumeroLote
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 695, 3
+        ),
+    )
+
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 697, 3), )
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 697, 3
+        ),
+    )
 
-    
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 699, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 699, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}QuantidadeRps uses Python identifier QuantidadeRps
-    __QuantidadeRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps'), 'QuantidadeRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsQuantidadeRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 701, 3), )
+    __QuantidadeRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps"),
+        "QuantidadeRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsQuantidadeRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 701, 3
+        ),
+    )
 
-    
     QuantidadeRps = property(__QuantidadeRps.value, __QuantidadeRps.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}ListaRps uses Python identifier ListaRps
-    __ListaRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaRps'), 'ListaRps', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsListaRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 703, 3), )
+    __ListaRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaRps"),
+        "ListaRps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_httpwww_betha_com_bre_nota_contribuinte_wsListaRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 703, 3
+        ),
+    )
 
-    
     ListaRps = property(__ListaRps.value, __ListaRps.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 713, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 713, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 713, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 713, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_versao', _module_typeBindings.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 714, 2)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 714, 2)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_tcLoteRps_versao",
+        _module_typeBindings.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 714, 2
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 714, 2
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __NumeroLote.name() : __NumeroLote,
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal,
-        __QuantidadeRps.name() : __QuantidadeRps,
-        __ListaRps.name() : __ListaRps
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id,
-        __versao.name() : __versao
-    })
+    _ElementMap.update(
+        {
+            __NumeroLote.name(): __NumeroLote,
+            __CpfCnpj.name(): __CpfCnpj,
+            __InscricaoMunicipal.name(): __InscricaoMunicipal,
+            __QuantidadeRps.name(): __QuantidadeRps,
+            __ListaRps.name(): __ListaRps,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id, __versao.name(): __versao})
+
+
 _module_typeBindings.tcLoteRps = tcLoteRps
-Namespace.addCategoryObject('typeBinding', 'tcLoteRps', tcLoteRps)
+Namespace.addCategoryObject("typeBinding", "tcLoteRps", tcLoteRps)
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_38 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_38(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 745, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 745, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}versaoDados uses Python identifier versaoDados
-    __versaoDados = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'versaoDados'), 'versaoDados', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_38_httpwww_betha_com_bre_nota_contribuinte_wsversaoDados', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 747, 4), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}versaoDados uses Python identifier versaoDados
+    __versaoDados = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "versaoDados"),
+        "versaoDados",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_38_httpwww_betha_com_bre_nota_contribuinte_wsversaoDados",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 747, 4
+        ),
+    )
+
     versaoDados = property(__versaoDados.value, __versaoDados.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_38_versao', _module_typeBindings.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 750, 3)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 750, 3)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_38_versao",
+        _module_typeBindings.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 750, 3
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 750, 3
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __versaoDados.name() : __versaoDados
-    })
-    _AttributeMap.update({
-        __versao.name() : __versao
-    })
+    _ElementMap.update({__versaoDados.name(): __versaoDados})
+    _AttributeMap.update({__versao.name(): __versao})
+
+
 _module_typeBindings.CTD_ANON_38 = CTD_ANON_38
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_39 (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_39(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 872, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 872, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
-    __Pedido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), 'Pedido', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_httpwww_betha_com_bre_nota_contribuinte_wsPedido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 874, 7), )
 
-    
+    # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Pedido uses Python identifier Pedido
+    __Pedido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        "Pedido",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_httpwww_betha_com_bre_nota_contribuinte_wsPedido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 874, 7
+        ),
+    )
+
     Pedido = property(__Pedido.value, __Pedido.set, None, None)
 
-    
     # Element {http://www.betha.com.br/e-nota-contribuinte-ws}Rps uses Python identifier Rps
-    __Rps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Rps'), 'Rps', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_httpwww_betha_com_bre_nota_contribuinte_wsRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 875, 7), )
+    __Rps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        "Rps",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_httpwww_betha_com_bre_nota_contribuinte_wsRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 875, 7
+        ),
+    )
 
-    
     Rps = property(__Rps.value, __Rps.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 877, 6)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 877, 6)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_betha_com_bre_nota_contribuinte_ws_CTD_ANON_39_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 877, 6
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 877, 6
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Pedido.name() : __Pedido,
-        __Rps.name() : __Rps
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__Pedido.name(): __Pedido, __Rps.name(): __Rps})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.CTD_ANON_39 = CTD_ANON_39
 
 
-ListaMensagemRetornoLote = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote'), CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 717, 2))
-Namespace.addCategoryObject('elementBinding', ListaMensagemRetornoLote.name().localName(), ListaMensagemRetornoLote)
+ListaMensagemRetornoLote = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote"),
+    CTD_ANON_,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 717, 2
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ListaMensagemRetornoLote.name().localName(), ListaMensagemRetornoLote
+)
 
-ListaMensagemRetorno = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1))
-Namespace.addCategoryObject('elementBinding', ListaMensagemRetorno.name().localName(), ListaMensagemRetorno)
+ListaMensagemRetorno = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+    CTD_ANON_2,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ListaMensagemRetorno.name().localName(), ListaMensagemRetorno
+)
 
-ListaMensagemAlertaRetorno = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), CTD_ANON_3, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1))
-Namespace.addCategoryObject('elementBinding', ListaMensagemAlertaRetorno.name().localName(), ListaMensagemAlertaRetorno)
+ListaMensagemAlertaRetorno = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+    CTD_ANON_3,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ListaMensagemAlertaRetorno.name().localName(), ListaMensagemAlertaRetorno
+)
 
-CompNfse = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1))
-Namespace.addCategoryObject('elementBinding', CompNfse.name().localName(), CompNfse)
+CompNfse = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+    tcCompNfse,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+    ),
+)
+Namespace.addCategoryObject("elementBinding", CompNfse.name().localName(), CompNfse)
 
-EnviarLoteRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsEnvio'), CTD_ANON_4, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 756, 2))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsEnvio.name().localName(), EnviarLoteRpsEnvio)
+EnviarLoteRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsEnvio"),
+    CTD_ANON_4,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 756, 2
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", EnviarLoteRpsEnvio.name().localName(), EnviarLoteRpsEnvio
+)
 
-EnviarLoteRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsResposta'), CTD_ANON_5, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 766, 1))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsResposta.name().localName(), EnviarLoteRpsResposta)
+EnviarLoteRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsResposta"),
+    CTD_ANON_5,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 766, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", EnviarLoteRpsResposta.name().localName(), EnviarLoteRpsResposta
+)
 
-EnviarLoteRpsSincronoEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsSincronoEnvio'), CTD_ANON_6, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 783, 1))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsSincronoEnvio.name().localName(), EnviarLoteRpsSincronoEnvio)
+EnviarLoteRpsSincronoEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsSincronoEnvio"),
+    CTD_ANON_6,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 783, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", EnviarLoteRpsSincronoEnvio.name().localName(), EnviarLoteRpsSincronoEnvio
+)
 
-EnviarLoteRpsSincronoResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsSincronoResposta'), CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 794, 1))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsSincronoResposta.name().localName(), EnviarLoteRpsSincronoResposta)
+EnviarLoteRpsSincronoResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsSincronoResposta"),
+    CTD_ANON_7,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 794, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    EnviarLoteRpsSincronoResposta.name().localName(),
+    EnviarLoteRpsSincronoResposta,
+)
 
-GerarNfseEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'GerarNfseEnvio'), CTD_ANON_9, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 822, 1))
-Namespace.addCategoryObject('elementBinding', GerarNfseEnvio.name().localName(), GerarNfseEnvio)
+GerarNfseEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "GerarNfseEnvio"),
+    CTD_ANON_9,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 822, 1
+    ),
+)
+Namespace.addCategoryObject("elementBinding", GerarNfseEnvio.name().localName(), GerarNfseEnvio)
 
-GerarNfseResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'GerarNfseResposta'), CTD_ANON_10, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 830, 1))
-Namespace.addCategoryObject('elementBinding', GerarNfseResposta.name().localName(), GerarNfseResposta)
+GerarNfseResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "GerarNfseResposta"),
+    CTD_ANON_10,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 830, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", GerarNfseResposta.name().localName(), GerarNfseResposta
+)
 
-CancelarNfseEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CancelarNfseEnvio'), CTD_ANON_12, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 850, 1))
-Namespace.addCategoryObject('elementBinding', CancelarNfseEnvio.name().localName(), CancelarNfseEnvio)
+CancelarNfseEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CancelarNfseEnvio"),
+    CTD_ANON_12,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 850, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CancelarNfseEnvio.name().localName(), CancelarNfseEnvio
+)
 
-CancelarNfseResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CancelarNfseResposta'), CTD_ANON_13, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 858, 1))
-Namespace.addCategoryObject('elementBinding', CancelarNfseResposta.name().localName(), CancelarNfseResposta)
+CancelarNfseResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CancelarNfseResposta"),
+    CTD_ANON_13,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 858, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CancelarNfseResposta.name().localName(), CancelarNfseResposta
+)
 
-SubstituirNfseEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SubstituirNfseEnvio'), CTD_ANON_14, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 867, 1))
-Namespace.addCategoryObject('elementBinding', SubstituirNfseEnvio.name().localName(), SubstituirNfseEnvio)
+SubstituirNfseEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SubstituirNfseEnvio"),
+    CTD_ANON_14,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 867, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SubstituirNfseEnvio.name().localName(), SubstituirNfseEnvio
+)
 
-SubstituirNfseResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SubstituirNfseResposta'), CTD_ANON_15, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 886, 1))
-Namespace.addCategoryObject('elementBinding', SubstituirNfseResposta.name().localName(), SubstituirNfseResposta)
+SubstituirNfseResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SubstituirNfseResposta"),
+    CTD_ANON_15,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 886, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SubstituirNfseResposta.name().localName(), SubstituirNfseResposta
+)
 
-ConsultarLoteRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarLoteRpsEnvio'), CTD_ANON_19, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 917, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarLoteRpsEnvio.name().localName(), ConsultarLoteRpsEnvio)
+ConsultarLoteRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarLoteRpsEnvio"),
+    CTD_ANON_19,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 917, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarLoteRpsEnvio.name().localName(), ConsultarLoteRpsEnvio
+)
 
-ConsultarLoteRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarLoteRpsResposta'), CTD_ANON_20, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 928, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarLoteRpsResposta.name().localName(), ConsultarLoteRpsResposta)
+ConsultarLoteRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarLoteRpsResposta"),
+    CTD_ANON_20,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 928, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarLoteRpsResposta.name().localName(), ConsultarLoteRpsResposta
+)
 
-ConsultarNfseRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseRpsEnvio'), CTD_ANON_22, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 951, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseRpsEnvio.name().localName(), ConsultarNfseRpsEnvio)
+ConsultarNfseRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseRpsEnvio"),
+    CTD_ANON_22,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 951, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseRpsEnvio.name().localName(), ConsultarNfseRpsEnvio
+)
 
-ConsultarNfseRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseRpsResposta'), CTD_ANON_23, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 962, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseRpsResposta.name().localName(), ConsultarNfseRpsResposta)
+ConsultarNfseRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseRpsResposta"),
+    CTD_ANON_23,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 962, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseRpsResposta.name().localName(), ConsultarNfseRpsResposta
+)
 
-ConsultarNfseServicoPrestadoEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseServicoPrestadoEnvio'), CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 972, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseServicoPrestadoEnvio.name().localName(), ConsultarNfseServicoPrestadoEnvio)
+ConsultarNfseServicoPrestadoEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseServicoPrestadoEnvio"),
+    CTD_ANON_24,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 972, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarNfseServicoPrestadoEnvio.name().localName(),
+    ConsultarNfseServicoPrestadoEnvio,
+)
 
-ConsultarNfseServicoPrestadoResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseServicoPrestadoResposta'), CTD_ANON_27, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1012, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseServicoPrestadoResposta.name().localName(), ConsultarNfseServicoPrestadoResposta)
+ConsultarNfseServicoPrestadoResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseServicoPrestadoResposta"),
+    CTD_ANON_27,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1012, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarNfseServicoPrestadoResposta.name().localName(),
+    ConsultarNfseServicoPrestadoResposta,
+)
 
-ConsultarNfseServicoTomadoEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseServicoTomadoEnvio'), CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1029, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseServicoTomadoEnvio.name().localName(), ConsultarNfseServicoTomadoEnvio)
+ConsultarNfseServicoTomadoEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseServicoTomadoEnvio"),
+    CTD_ANON_29,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1029, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarNfseServicoTomadoEnvio.name().localName(),
+    ConsultarNfseServicoTomadoEnvio,
+)
 
-ConsultarNfseServicoTomadoResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseServicoTomadoResposta'), CTD_ANON_32, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1071, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseServicoTomadoResposta.name().localName(), ConsultarNfseServicoTomadoResposta)
+ConsultarNfseServicoTomadoResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseServicoTomadoResposta"),
+    CTD_ANON_32,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1071, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarNfseServicoTomadoResposta.name().localName(),
+    ConsultarNfseServicoTomadoResposta,
+)
 
-ConsultarNfseFaixaEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseFaixaEnvio'), CTD_ANON_34, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1088, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseFaixaEnvio.name().localName(), ConsultarNfseFaixaEnvio)
+ConsultarNfseFaixaEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseFaixaEnvio"),
+    CTD_ANON_34,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1088, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseFaixaEnvio.name().localName(), ConsultarNfseFaixaEnvio
+)
 
-ConsultarNfseFaixaResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseFaixaResposta'), CTD_ANON_36, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1108, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseFaixaResposta.name().localName(), ConsultarNfseFaixaResposta)
+ConsultarNfseFaixaResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseFaixaResposta"),
+    CTD_ANON_36,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1108, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseFaixaResposta.name().localName(), ConsultarNfseFaixaResposta
+)
 
-cabecalho = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'cabecalho'), CTD_ANON_38, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 744, 1))
-Namespace.addCategoryObject('elementBinding', cabecalho.name().localName(), cabecalho)
+cabecalho = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "cabecalho"),
+    CTD_ANON_38,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 744, 1
+    ),
+)
+Namespace.addCategoryObject("elementBinding", cabecalho.name().localName(), cabecalho)
 
 
+tcCpfCnpj._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cpf"),
+        tsCpf,
+        scope=tcCpfCnpj,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 291, 3
+        ),
+    )
+)
 
-tcCpfCnpj._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cpf'), tsCpf, scope=tcCpfCnpj, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 291, 3)))
+tcCpfCnpj._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        tsCnpj,
+        scope=tcCpfCnpj,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 293, 3
+        ),
+    )
+)
 
-tcCpfCnpj._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), tsCnpj, scope=tcCpfCnpj, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 293, 3)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -4130,244 +6443,460 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cpf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 291, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cpf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 291, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 293, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 293, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCpfCnpj._Automaton = _BuildAutomaton()
 
 
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tsEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 300, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 302, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Complemento"),
+        tsComplementoEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 304, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Bairro"),
+        tsBairro,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 306, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 308, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        tsUf,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 310, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoPais"),
+        tsCodigoPaisBacen,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 312, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cep"),
+        tsCep,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 314, 3
+        ),
+    )
+)
 
 
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tsEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 300, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 302, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Complemento'), tsComplementoEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 304, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Bairro'), tsBairro, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 306, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 308, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Uf'), tsUf, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 310, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais'), tsCodigoPaisBacen, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 312, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cep'), tsCep, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 314, 3)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 300, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 300, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 302, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 302, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 304, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 304, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 306, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 306, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 308, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 308, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 310, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 310, 3
+        ),
+    )
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 312, 3))
+    cc_6 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 312, 3
+        ),
+    )
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 314, 3))
+    cc_7 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 314, 3
+        ),
+    )
     counters.add(cc_7)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 300, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 300, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 302, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 302, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Complemento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 304, 3))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Complemento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 304, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Bairro')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 306, 3))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Bairro")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 306, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 308, 3))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 308, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Uf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 310, 3))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Uf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 310, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 312, 3))
-    st_6 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoPais")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 312, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cep')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 314, 3))
-    st_7 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cep")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 314, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_3, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_4, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_5, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_5, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_5, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_6, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_6, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_6, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_6, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_7, True) ]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_7, True)]))
     st_7._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcEndereco._Automaton = _BuildAutomaton_()
 
 
+tcContato._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Telefone"),
+        tsTelefone,
+        scope=tcContato,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 321, 3
+        ),
+    )
+)
+
+tcContato._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Email"),
+        tsEmail,
+        scope=tcContato,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 323, 3
+        ),
+    )
+)
 
 
-tcContato._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Telefone'), tsTelefone, scope=tcContato, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 321, 3)))
-
-tcContato._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Email'), tsEmail, scope=tcContato, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 323, 3)))
-
-def _BuildAutomaton_2 ():
+def _BuildAutomaton_2():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_2
     del _BuildAutomaton_2
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 321, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 321, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 323, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 323, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Telefone')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 321, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Telefone")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 321, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Email')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 323, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Email")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 323, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcContato._Automaton = _BuildAutomaton_2()
 
 
+tcIdentificacaoOrgaoGerador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcIdentificacaoOrgaoGerador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 330, 3
+        ),
+    )
+)
+
+tcIdentificacaoOrgaoGerador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        tsUf,
+        scope=tcIdentificacaoOrgaoGerador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 332, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoOrgaoGerador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcIdentificacaoOrgaoGerador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 330, 3)))
-
-tcIdentificacaoOrgaoGerador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Uf'), tsUf, scope=tcIdentificacaoOrgaoGerador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 332, 3)))
-
-def _BuildAutomaton_3 ():
+def _BuildAutomaton_3():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_3
     del _BuildAutomaton_3
@@ -4376,32 +6905,75 @@ def _BuildAutomaton_3 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 330, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoOrgaoGerador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 330, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Uf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 332, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Uf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 332, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoOrgaoGerador._Automaton = _BuildAutomaton_3()
 
 
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 339, 3
+        ),
+    )
+)
+
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Serie"),
+        tsSerieRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 341, 3
+        ),
+    )
+)
+
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tipo"),
+        tsTipoRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 343, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 339, 3)))
-
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Serie'), tsSerieRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 341, 3)))
-
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tipo'), tsTipoRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 343, 3)))
-
-def _BuildAutomaton_4 ():
+def _BuildAutomaton_4():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_4
     del _BuildAutomaton_4
@@ -4410,279 +6982,567 @@ def _BuildAutomaton_4 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 339, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 339, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Serie')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 341, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Serie")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 341, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tipo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 343, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tipo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 343, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoRps._Automaton = _BuildAutomaton_4()
 
 
+tcIdentificacaoPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 350, 3
+        ),
+    )
+)
+
+tcIdentificacaoPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 352, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 350, 3)))
-
-tcIdentificacaoPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 352, 3)))
-
-def _BuildAutomaton_5 ():
+def _BuildAutomaton_5():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_5
     del _BuildAutomaton_5
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 350, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 350, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 352, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 352, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 350, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 350, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 352, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoPrestador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 352, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcIdentificacaoPrestador._Automaton = _BuildAutomaton_5()
 
 
+tcIdentificacaoTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 359, 3
+        ),
+    )
+)
+
+tcIdentificacaoTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 361, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 359, 3)))
-
-tcIdentificacaoTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 361, 3)))
-
-def _BuildAutomaton_6 ():
+def _BuildAutomaton_6():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_6
     del _BuildAutomaton_6
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 359, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 359, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 361, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 361, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 359, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 359, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 361, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoTomador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 361, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcIdentificacaoTomador._Automaton = _BuildAutomaton_6()
 
 
+tcIdentificacaoConsulente._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoConsulente,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 368, 3
+        ),
+    )
+)
+
+tcIdentificacaoConsulente._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoConsulente,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 370, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoConsulente._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoConsulente, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 368, 3)))
-
-tcIdentificacaoConsulente._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoConsulente, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 370, 3)))
-
-def _BuildAutomaton_7 ():
+def _BuildAutomaton_7():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_7
     del _BuildAutomaton_7
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 370, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 370, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoConsulente._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 368, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoConsulente._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 368, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoConsulente._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 370, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoConsulente._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 370, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoConsulente._Automaton = _BuildAutomaton_7()
 
 
+tcIdentificacaoIntermediario._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoIntermediario,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 377, 15
+        ),
+    )
+)
+
+tcIdentificacaoIntermediario._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoIntermediario,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 378, 14
+        ),
+    )
+)
 
 
-tcIdentificacaoIntermediario._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoIntermediario, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 377, 15)))
-
-tcIdentificacaoIntermediario._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoIntermediario, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 378, 14)))
-
-def _BuildAutomaton_8 ():
+def _BuildAutomaton_8():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_8
     del _BuildAutomaton_8
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 377, 15))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 377, 15
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 378, 14))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 378, 14
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 377, 15))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 377, 15
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 378, 14))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoIntermediario._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 378, 14
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcIdentificacaoIntermediario._Automaton = _BuildAutomaton_8()
 
 
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador"),
+        tcIdentificacaoTomador,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 384, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 386, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tcEndereco,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 388, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        tcContato,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 390, 3
+        ),
+    )
+)
 
 
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador'), tcIdentificacaoTomador, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 384, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 386, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tcEndereco, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 388, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Contato'), tcContato, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 390, 3)))
-
-def _BuildAutomaton_9 ():
+def _BuildAutomaton_9():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_9
     del _BuildAutomaton_9
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 384, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 384, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 386, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 386, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 388, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 388, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 390, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 390, 3
+        ),
+    )
     counters.add(cc_3)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 384, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 384, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 386, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 386, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 388, 3))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 388, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Contato')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 390, 3))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Contato")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 390, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_3, True) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_3, True)]))
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcDadosTomador._Automaton = _BuildAutomaton_9()
 
 
+tcDadosIntermediario._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoIntermediario"),
+        tcIdentificacaoIntermediario,
+        scope=tcDadosIntermediario,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 397, 12
+        ),
+    )
+)
+
+tcDadosIntermediario._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcDadosIntermediario,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 398, 12
+        ),
+    )
+)
 
 
-tcDadosIntermediario._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoIntermediario'), tcIdentificacaoIntermediario, scope=tcDadosIntermediario, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 397, 12)))
-
-tcDadosIntermediario._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcDadosIntermediario, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 398, 12)))
-
-def _BuildAutomaton_10 ():
+def _BuildAutomaton_10():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_10
     del _BuildAutomaton_10
@@ -4691,806 +7551,1580 @@ def _BuildAutomaton_10 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoIntermediario')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 397, 12))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosIntermediario._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoIntermediario")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 397, 12
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 398, 12))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosIntermediario._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 398, 12
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosIntermediario._Automaton = _BuildAutomaton_10()
 
 
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorServicos"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 404, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 406, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorPis"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 408, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCofins"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 410, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorInss"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 412, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIr"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 414, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCsll"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 416, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 418, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 420, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        tsAliquota,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 422, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 424, 3
+        ),
+    )
+)
+
+tcValoresDeclaracaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado"),
+        tsValor,
+        scope=tcValoresDeclaracaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 426, 3
+        ),
+    )
+)
 
 
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 404, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 406, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorPis'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 408, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 410, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorInss'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 412, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIr'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 414, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 416, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 418, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 420, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), tsAliquota, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 422, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 424, 3)))
-
-tcValoresDeclaracaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado'), tsValor, scope=tcValoresDeclaracaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 426, 3)))
-
-def _BuildAutomaton_11 ():
+def _BuildAutomaton_11():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_11
     del _BuildAutomaton_11
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 406, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 406, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 408, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 408, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 410, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 410, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 412, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 412, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 414, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 414, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 416, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 416, 3
+        ),
+    )
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 418, 3))
+    cc_6 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 418, 3
+        ),
+    )
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 420, 3))
+    cc_7 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 420, 3
+        ),
+    )
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 422, 3))
+    cc_8 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 422, 3
+        ),
+    )
     counters.add(cc_8)
-    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 424, 3))
+    cc_9 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 424, 3
+        ),
+    )
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 426, 3))
+    cc_10 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 426, 3
+        ),
+    )
     counters.add(cc_10)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 404, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ValorServicos")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 404, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 406, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 406, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorPis')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 408, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorPis")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 408, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 410, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ValorCofins")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 410, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorInss')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 412, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorInss")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 412, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIr')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 414, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIr")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 414, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 416, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorCsll")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 416, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 418, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 418, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIss')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 420, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIss")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 420, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Aliquota')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 422, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Aliquota")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 422, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_9, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 424, 3))
-    st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 424, 3
+        ),
+    )
+    st_10 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_10, False))
-    symbol = pyxb.binding.content.ElementUse(tcValoresDeclaracaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 426, 3))
-    st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresDeclaracaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 426, 3
+        ),
+    )
+    st_11 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_11)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
-    transitions.append(fac.Transition(st_8, [
-         ]))
-    transitions.append(fac.Transition(st_9, [
-         ]))
-    transitions.append(fac.Transition(st_10, [
-         ]))
-    transitions.append(fac.Transition(st_11, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
+    transitions.append(fac.Transition(st_8, []))
+    transitions.append(fac.Transition(st_9, []))
+    transitions.append(fac.Transition(st_10, []))
+    transitions.append(fac.Transition(st_11, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_2, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_3, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_4, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_5, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_5, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_5, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_5, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_5, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_5, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_5, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_5, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_5, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_6, True) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_6, False) ]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_6, True)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_6, False)]))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_7, True) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_7, False) ]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_7, True)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_7, False)]))
     st_8._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_8, True) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_8, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_8, False) ]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_8, True)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_8, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_8, False)]))
     st_9._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_9, True) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_9, False) ]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_9, True)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_9, False)]))
     st_10._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_10, True) ]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_10, True)]))
     st_11._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcValoresDeclaracaoServico._Automaton = _BuildAutomaton_11()
 
 
+tcValoresNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "BaseCalculo"),
+        tsValor,
+        scope=tcValoresNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 433, 3
+        ),
+    )
+)
+
+tcValoresNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        tsAliquota,
+        scope=tcValoresNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 435, 3
+        ),
+    )
+)
+
+tcValoresNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        tsValor,
+        scope=tcValoresNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 437, 3
+        ),
+    )
+)
+
+tcValoresNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse"),
+        tsValor,
+        scope=tcValoresNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 439, 3
+        ),
+    )
+)
 
 
-tcValoresNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo'), tsValor, scope=tcValoresNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 433, 3)))
-
-tcValoresNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), tsAliquota, scope=tcValoresNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 435, 3)))
-
-tcValoresNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), tsValor, scope=tcValoresNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 437, 3)))
-
-tcValoresNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse'), tsValor, scope=tcValoresNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 439, 3)))
-
-def _BuildAutomaton_12 ():
+def _BuildAutomaton_12():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_12
     del _BuildAutomaton_12
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 433, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 433, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 435, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 435, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 437, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 437, 3
+        ),
+    )
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 433, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "BaseCalculo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 433, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Aliquota')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 435, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Aliquota")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 435, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIss')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 437, 3))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIss")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 437, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 439, 3))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValoresNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 439, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcValoresNfse._Automaton = _BuildAutomaton_12()
 
 
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Valores"),
+        tcValoresDeclaracaoServico,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 446, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IssRetido"),
+        tsSimNao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 448, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ResponsavelRetencao"),
+        tsResponsavelRetencao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 450, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ItemListaServico"),
+        tsItemListaServico,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 452, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCnae"),
+        tsCodigoCnae,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 454, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio"),
+        tsCodigoTributacao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 456, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Discriminacao"),
+        tsDiscriminacao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 458, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 460, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoPais"),
+        tsCodigoPaisBacen,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 462, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ExigibilidadeISS"),
+        tsExigibilidadeISS,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 464, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MunicipioIncidencia"),
+        tsCodigoMunicipioIbge,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 466, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroProcesso"),
+        tsNumeroProcesso,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 468, 3
+        ),
+    )
+)
 
 
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Valores'), tcValoresDeclaracaoServico, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 446, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IssRetido'), tsSimNao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 448, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ResponsavelRetencao'), tsResponsavelRetencao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 450, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico'), tsItemListaServico, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 452, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae'), tsCodigoCnae, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 454, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio'), tsCodigoTributacao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 456, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao'), tsDiscriminacao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 458, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 460, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais'), tsCodigoPaisBacen, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 462, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ExigibilidadeISS'), tsExigibilidadeISS, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 464, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MunicipioIncidencia'), tsCodigoMunicipioIbge, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 466, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroProcesso'), tsNumeroProcesso, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 468, 3)))
-
-def _BuildAutomaton_13 ():
+def _BuildAutomaton_13():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_13
     del _BuildAutomaton_13
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 450, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 450, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 454, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 454, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 456, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 456, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 462, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 462, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 466, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 466, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 468, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 468, 3
+        ),
+    )
     counters.add(cc_5)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Valores')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 446, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Valores")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 446, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IssRetido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 448, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IssRetido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 448, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ResponsavelRetencao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 450, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ResponsavelRetencao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 450, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 452, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ItemListaServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 452, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 454, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoCnae")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 454, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 456, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 456, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 458, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Discriminacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 458, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 460, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 460, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoPais')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 462, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoPais")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 462, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ExigibilidadeISS')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 464, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ExigibilidadeISS")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 464, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MunicipioIncidencia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 466, 3))
-    st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MunicipioIncidencia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 466, 3
+        ),
+    )
+    st_10 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroProcesso')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 468, 3))
-    st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroProcesso")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 468, 3
+        ),
+    )
+    st_11 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_11)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_7, []))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-         ]))
-    transitions.append(fac.Transition(st_9, [
-         ]))
+    transitions.append(fac.Transition(st_8, []))
+    transitions.append(fac.Transition(st_9, []))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_3, False)]))
     st_8._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-         ]))
-    transitions.append(fac.Transition(st_11, [
-         ]))
+    transitions.append(fac.Transition(st_10, []))
+    transitions.append(fac.Transition(st_11, []))
     st_9._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_4, False)]))
     st_10._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_5, True) ]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_5, True)]))
     st_11._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosServico._Automaton = _BuildAutomaton_13()
 
 
+tcDadosConstrucaoCivil._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoObra"),
+        tsCodigoObra,
+        scope=tcDadosConstrucaoCivil,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 476, 3
+        ),
+    )
+)
+
+tcDadosConstrucaoCivil._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Art"),
+        tsArt,
+        scope=tcDadosConstrucaoCivil,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 478, 3
+        ),
+    )
+)
 
 
-tcDadosConstrucaoCivil._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra'), tsCodigoObra, scope=tcDadosConstrucaoCivil, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 476, 3)))
-
-tcDadosConstrucaoCivil._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Art'), tsArt, scope=tcDadosConstrucaoCivil, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 478, 3)))
-
-def _BuildAutomaton_14 ():
+def _BuildAutomaton_14():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_14
     del _BuildAutomaton_14
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 476, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 476, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 476, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoObra")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 476, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Art')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 478, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Art")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 478, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosConstrucaoCivil._Automaton = _BuildAutomaton_14()
 
 
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador"),
+        tcIdentificacaoPrestador,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 485, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 487, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NomeFantasia"),
+        tsNomeFantasia,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 489, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tcEndereco,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 491, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        tcContato,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 493, 3
+        ),
+    )
+)
 
 
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador'), tcIdentificacaoPrestador, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 485, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 487, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia'), tsNomeFantasia, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 489, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tcEndereco, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 491, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Contato'), tcContato, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 493, 3)))
-
-def _BuildAutomaton_15 ():
+def _BuildAutomaton_15():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_15
     del _BuildAutomaton_15
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 489, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 489, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 493, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 493, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 485, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 485, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 487, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 487, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 489, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NomeFantasia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 489, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 491, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 491, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Contato')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 493, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Contato")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 493, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosPrestador._Automaton = _BuildAutomaton_15()
 
 
+tcDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfDeclaracaoPrestacaoServico"),
+        tcInfDeclaracaoPrestacaoServico,
+        scope=tcDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 540, 3
+        ),
+    )
+)
+
+tcDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-tcDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfDeclaracaoPrestacaoServico'), tcInfDeclaracaoPrestacaoServico, scope=tcDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 540, 3)))
-
-tcDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_16 ():
+def _BuildAutomaton_16():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_16
     del _BuildAutomaton_16
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 542, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 542, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfDeclaracaoPrestacaoServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 540, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InfDeclaracaoPrestacaoServico")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 540, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 542, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 542, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDeclaracaoPrestacaoServico._Automaton = _BuildAutomaton_16()
 
 
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroNfse,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 549, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 551, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 553, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 555, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroNfse, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 549, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 551, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 553, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 555, 3)))
-
-def _BuildAutomaton_17 ():
+def _BuildAutomaton_17():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_17
     del _BuildAutomaton_17
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 553, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 553, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 549, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 549, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 551, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 551, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 553, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 553, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 555, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 555, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoNfse._Automaton = _BuildAutomaton_17()
 
 
+tcPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento"),
+        tcInfPedidoCancelamento,
+        scope=tcPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 607, 3
+        ),
+    )
+)
+
+tcPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-tcPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento'), tcInfPedidoCancelamento, scope=tcPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 607, 3)))
-
-tcPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_18 ():
+def _BuildAutomaton_18():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_18
     del _BuildAutomaton_18
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 609, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 609, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 607, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 607, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 609, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 609, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcPedidoCancelamento._Automaton = _BuildAutomaton_18()
 
 
+tcRetCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        tcCancelamentoNfse,
+        scope=tcRetCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 636, 3
+        ),
+    )
+)
 
 
-tcRetCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), tcCancelamentoNfse, scope=tcRetCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 636, 3)))
-
-def _BuildAutomaton_19 ():
+def _BuildAutomaton_19():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_19
     del _BuildAutomaton_19
@@ -5499,125 +9133,268 @@ def _BuildAutomaton_19 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcRetCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 636, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcRetCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 636, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcRetCancelamento._Automaton = _BuildAutomaton_19()
 
 
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Nfse"),
+        tcNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 662, 3
+        ),
+    )
+)
+
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        tcCancelamentoNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 664, 3
+        ),
+    )
+)
+
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao"),
+        tcSubstituicaoNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 666, 3
+        ),
+    )
+)
 
 
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Nfse'), tcNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 662, 3)))
-
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), tcCancelamentoNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 664, 3)))
-
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao'), tcSubstituicaoNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 666, 3)))
-
-def _BuildAutomaton_20 ():
+def _BuildAutomaton_20():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_20
     del _BuildAutomaton_20
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 664, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 664, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 666, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 666, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Nfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 662, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Nfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 662, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 664, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 664, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 666, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 666, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCompNfse._Automaton = _BuildAutomaton_20()
 
 
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        tsCodigoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 673, 3
+        ),
+    )
+)
+
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 675, 3
+        ),
+    )
+)
+
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Correcao"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 677, 3
+        ),
+    )
+)
 
 
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), tsCodigoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 673, 3)))
-
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), tsDescricaoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 675, 3)))
-
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Correcao'), tsDescricaoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 677, 3)))
-
-def _BuildAutomaton_21 ():
+def _BuildAutomaton_21():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_21
     del _BuildAutomaton_21
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 677, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 677, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Codigo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 673, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Codigo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 673, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Mensagem')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 675, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Mensagem")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 675, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Correcao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 677, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Correcao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 677, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcMensagemRetorno._Automaton = _BuildAutomaton_21()
 
 
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 684, 3
+        ),
+    )
+)
+
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        tsCodigoMensagemAlerta,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 686, 3
+        ),
+    )
+)
+
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 688, 3
+        ),
+    )
+)
 
 
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 684, 3)))
-
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), tsCodigoMensagemAlerta, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 686, 3)))
-
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), tsDescricaoMensagemAlerta, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 688, 3)))
-
-def _BuildAutomaton_22 ():
+def _BuildAutomaton_22():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_22
     del _BuildAutomaton_22
@@ -5626,36 +9403,67 @@ def _BuildAutomaton_22 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 684, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 684, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Codigo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 686, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Codigo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 686, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Mensagem')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 688, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Mensagem")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 688, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcMensagemRetornoLote._Automaton = _BuildAutomaton_22()
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        tcDeclaracaoPrestacaoServico,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 706, 6
+        ),
+    )
+)
 
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Rps'), tcDeclaracaoPrestacaoServico, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 706, 6)))
-
-def _BuildAutomaton_23 ():
+def _BuildAutomaton_23():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_23
     del _BuildAutomaton_23
@@ -5664,22 +9472,38 @@ def _BuildAutomaton_23 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Rps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 706, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Rps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 706, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON._Automaton = _BuildAutomaton_23()
 
 
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        tcMensagemRetornoLote,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 720, 4
+        ),
+    )
+)
 
 
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), tcMensagemRetornoLote, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 720, 4)))
-
-def _BuildAutomaton_24 ():
+def _BuildAutomaton_24():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_24
     del _BuildAutomaton_24
@@ -5688,22 +9512,38 @@ def _BuildAutomaton_24 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 720, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 720, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_._Automaton = _BuildAutomaton_24()
 
 
+CTD_ANON_2._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        tcMensagemRetorno,
+        scope=CTD_ANON_2,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 729, 4
+        ),
+    )
+)
 
 
-CTD_ANON_2._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), tcMensagemRetorno, scope=CTD_ANON_2, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 729, 4)))
-
-def _BuildAutomaton_25 ():
+def _BuildAutomaton_25():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_25
     del _BuildAutomaton_25
@@ -5712,22 +9552,38 @@ def _BuildAutomaton_25 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_2._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 729, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_2._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 729, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_2._Automaton = _BuildAutomaton_25()
 
 
+CTD_ANON_3._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        tcMensagemRetorno,
+        scope=CTD_ANON_3,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 738, 4
+        ),
+    )
+)
 
 
-CTD_ANON_3._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), tcMensagemRetorno, scope=CTD_ANON_3, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 738, 4)))
-
-def _BuildAutomaton_26 ():
+def _BuildAutomaton_26():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_26
     del _BuildAutomaton_26
@@ -5736,65 +9592,145 @@ def _BuildAutomaton_26 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_3._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 738, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_3._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 738, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_3._Automaton = _BuildAutomaton_26()
 
 
+CTD_ANON_4._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        tcLoteRps,
+        scope=CTD_ANON_4,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 759, 4
+        ),
+    )
+)
+
+CTD_ANON_4._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON_4,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-CTD_ANON_4._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), tcLoteRps, scope=CTD_ANON_4, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 759, 4)))
-
-CTD_ANON_4._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON_4, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_27 ():
+def _BuildAutomaton_27():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_27
     del _BuildAutomaton_27
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 760, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 760, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_4._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'LoteRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 759, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_4._UseForTag(pyxb.namespace.ExpandedName(Namespace, "LoteRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 759, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_4._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 760, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_4._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 760, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_4._Automaton = _BuildAutomaton_27()
 
 
+CTD_ANON_5._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_5,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_5._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        tsNumeroLote,
+        scope=CTD_ANON_5,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 770, 5
+        ),
+    )
+)
+
+CTD_ANON_5._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        pyxb.binding.datatypes.dateTime,
+        scope=CTD_ANON_5,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 772, 5
+        ),
+    )
+)
+
+CTD_ANON_5._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        tsNumeroProtocolo,
+        scope=CTD_ANON_5,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 774, 5
+        ),
+    )
+)
 
 
-CTD_ANON_5._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_5, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_5._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), tsNumeroLote, scope=CTD_ANON_5, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 770, 5)))
-
-CTD_ANON_5._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), pyxb.binding.datatypes.dateTime, scope=CTD_ANON_5, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 772, 5)))
-
-CTD_ANON_5._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), tsNumeroProtocolo, scope=CTD_ANON_5, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 774, 5)))
-
-def _BuildAutomaton_28 ():
+def _BuildAutomaton_28():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_28
     del _BuildAutomaton_28
@@ -5803,161 +9739,324 @@ def _BuildAutomaton_28 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 770, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 770, 5
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 772, 5))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataRecebimento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 772, 5
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 774, 5))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 774, 5
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 777, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_5._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 777, 4
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_5._Automaton = _BuildAutomaton_28()
 
 
+CTD_ANON_6._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        tcLoteRps,
+        scope=CTD_ANON_6,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 786, 4
+        ),
+    )
+)
+
+CTD_ANON_6._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON_6,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-CTD_ANON_6._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), tcLoteRps, scope=CTD_ANON_6, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 786, 4)))
-
-CTD_ANON_6._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON_6, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_29 ():
+def _BuildAutomaton_29():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_29
     del _BuildAutomaton_29
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 787, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 787, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_6._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'LoteRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 786, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_6._UseForTag(pyxb.namespace.ExpandedName(Namespace, "LoteRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 786, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_6._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 787, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_6._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 787, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_6._Automaton = _BuildAutomaton_29()
 
 
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote"),
+        CTD_ANON_,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 717, 2
+        ),
+    )
+)
+
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        tsNumeroLote,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 797, 4
+        ),
+    )
+)
+
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        pyxb.binding.datatypes.dateTime,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 799, 4
+        ),
+    )
+)
+
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        tsNumeroProtocolo,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 801, 4
+        ),
+    )
+)
+
+CTD_ANON_7._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_8,
+        scope=CTD_ANON_7,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 804, 5
+        ),
+    )
+)
 
 
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote'), CTD_ANON_, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 717, 2)))
-
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), tsNumeroLote, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 797, 4)))
-
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), pyxb.binding.datatypes.dateTime, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 799, 4)))
-
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), tsNumeroProtocolo, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 801, 4)))
-
-CTD_ANON_7._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_8, scope=CTD_ANON_7, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 804, 5)))
-
-def _BuildAutomaton_30 ():
+def _BuildAutomaton_30():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_30
     del _BuildAutomaton_30
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 797, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 797, 4
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 799, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 799, 4
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 801, 4))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 801, 4
+        ),
+    )
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 797, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 797, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 799, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataRecebimento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 799, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 801, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 801, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 804, 5))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 804, 5
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 813, 5))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 813, 5
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 815, 5))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_7._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 815, 5
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
@@ -5966,53 +10065,99 @@ def _BuildAutomaton_30 ():
     transitions = []
     st_5._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_7._Automaton = _BuildAutomaton_30()
 
 
+CTD_ANON_8._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        CTD_ANON_3,
+        scope=CTD_ANON_8,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
+)
+
+CTD_ANON_8._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_8,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_8._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), CTD_ANON_3, scope=CTD_ANON_8, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1)))
-
-CTD_ANON_8._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_8, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_31 ():
+def _BuildAutomaton_31():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_31
     del _BuildAutomaton_31
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 809, 8))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 809, 8
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_8._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 807, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_8._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 807, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_8._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 809, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_8._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 809, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_8._Automaton = _BuildAutomaton_31()
 
 
+CTD_ANON_9._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        tcDeclaracaoPrestacaoServico,
+        scope=CTD_ANON_9,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 825, 4
+        ),
+    )
+)
 
 
-CTD_ANON_9._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Rps'), tcDeclaracaoPrestacaoServico, scope=CTD_ANON_9, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 825, 4)))
-
-def _BuildAutomaton_32 ():
+def _BuildAutomaton_32():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_32
     del _BuildAutomaton_32
@@ -6021,22 +10166,48 @@ def _BuildAutomaton_32 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_9._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Rps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 825, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_9._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Rps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 825, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_9._Automaton = _BuildAutomaton_32()
 
 
+CTD_ANON_10._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_10,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_10._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_11,
+        scope=CTD_ANON_10,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 834, 5
+        ),
+    )
+)
 
 
-CTD_ANON_10._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_10, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_10._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_11, scope=CTD_ANON_10, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 834, 5)))
-
-def _BuildAutomaton_33 ():
+def _BuildAutomaton_33():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_33
     del _BuildAutomaton_33
@@ -6045,63 +10216,126 @@ def _BuildAutomaton_33 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_10._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 834, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_10._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 834, 5
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_10._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 843, 5))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_10._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 843, 5
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_10._Automaton = _BuildAutomaton_33()
 
 
+CTD_ANON_11._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        CTD_ANON_3,
+        scope=CTD_ANON_11,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
+)
+
+CTD_ANON_11._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_11,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_11._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), CTD_ANON_3, scope=CTD_ANON_11, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1)))
-
-CTD_ANON_11._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_11, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_34 ():
+def _BuildAutomaton_34():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_34
     del _BuildAutomaton_34
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 839, 8))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 839, 8
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_11._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 837, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_11._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 837, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_11._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 839, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_11._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 839, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_11._Automaton = _BuildAutomaton_34()
 
 
+CTD_ANON_12._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        tcPedidoCancelamento,
+        scope=CTD_ANON_12,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 853, 4
+        ),
+    )
+)
 
 
-CTD_ANON_12._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), tcPedidoCancelamento, scope=CTD_ANON_12, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 853, 4)))
-
-def _BuildAutomaton_35 ():
+def _BuildAutomaton_35():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_35
     del _BuildAutomaton_35
@@ -6110,22 +10344,48 @@ def _BuildAutomaton_35 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_12._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pedido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 853, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_12._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pedido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 853, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_12._Automaton = _BuildAutomaton_35()
 
 
+CTD_ANON_13._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_13,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_13._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RetCancelamento"),
+        tcRetCancelamento,
+        scope=CTD_ANON_13,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 861, 4
+        ),
+    )
+)
 
 
-CTD_ANON_13._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_13, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_13._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetCancelamento'), tcRetCancelamento, scope=CTD_ANON_13, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 861, 4)))
-
-def _BuildAutomaton_36 ():
+def _BuildAutomaton_36():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_36
     del _BuildAutomaton_36
@@ -6134,65 +10394,135 @@ def _BuildAutomaton_36 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_13._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RetCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 861, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_13._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RetCancelamento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 861, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_13._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 862, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_13._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 862, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_13._Automaton = _BuildAutomaton_36()
 
 
+CTD_ANON_14._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        CTD_ANON_39,
+        scope=CTD_ANON_14,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 870, 4
+        ),
+    )
+)
+
+CTD_ANON_14._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON_14,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-CTD_ANON_14._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), CTD_ANON_39, scope=CTD_ANON_14, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 870, 4)))
-
-CTD_ANON_14._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON_14, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_37 ():
+def _BuildAutomaton_37():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_37
     del _BuildAutomaton_37
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 880, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 880, 4
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_14._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 870, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_14._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 870, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_14._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 880, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_14._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 880, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_14._Automaton = _BuildAutomaton_37()
 
 
+CTD_ANON_15._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_15,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_15._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RetSubstituicao"),
+        CTD_ANON_16,
+        scope=CTD_ANON_15,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 889, 5
+        ),
+    )
+)
 
 
-CTD_ANON_15._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_15, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_15._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetSubstituicao'), CTD_ANON_16, scope=CTD_ANON_15, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 889, 5)))
-
-def _BuildAutomaton_38 ():
+def _BuildAutomaton_38():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_38
     del _BuildAutomaton_38
@@ -6201,28 +10531,61 @@ def _BuildAutomaton_38 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_15._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RetSubstituicao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 889, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_15._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RetSubstituicao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 889, 5
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_15._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 912, 5))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_15._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 912, 5
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_15._Automaton = _BuildAutomaton_38()
 
 
+CTD_ANON_16._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        CTD_ANON_17,
+        scope=CTD_ANON_16,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 892, 8
+        ),
+    )
+)
+
+CTD_ANON_16._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        CTD_ANON_18,
+        scope=CTD_ANON_16,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 901, 8
+        ),
+    )
+)
 
 
-CTD_ANON_16._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), CTD_ANON_17, scope=CTD_ANON_16, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 892, 8)))
-
-CTD_ANON_16._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), CTD_ANON_18, scope=CTD_ANON_16, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 901, 8)))
-
-def _BuildAutomaton_39 ():
+def _BuildAutomaton_39():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_39
     del _BuildAutomaton_39
@@ -6231,65 +10594,127 @@ def _BuildAutomaton_39 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_16._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 892, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_16._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 892, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_16._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 901, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_16._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 901, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_16._Automaton = _BuildAutomaton_39()
 
 
+CTD_ANON_17._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        CTD_ANON_3,
+        scope=CTD_ANON_17,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
+)
+
+CTD_ANON_17._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_17,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_17._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), CTD_ANON_3, scope=CTD_ANON_17, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1)))
-
-CTD_ANON_17._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_17, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_40 ():
+def _BuildAutomaton_40():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_40
     del _BuildAutomaton_40
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 897, 11))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 897, 11
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_17._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 895, 11))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_17._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 895, 11
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_17._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 897, 11))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_17._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 897, 11
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_17._Automaton = _BuildAutomaton_40()
 
 
+CTD_ANON_18._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_18,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_18._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_18, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_41 ():
+def _BuildAutomaton_41():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_41
     del _BuildAutomaton_41
@@ -6298,22 +10723,48 @@ def _BuildAutomaton_41 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_18._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 904, 11))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_18._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 904, 11
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_18._Automaton = _BuildAutomaton_41()
 
 
+CTD_ANON_19._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=CTD_ANON_19,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 920, 4
+        ),
+    )
+)
+
+CTD_ANON_19._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        tsNumeroProtocolo,
+        scope=CTD_ANON_19,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 922, 4
+        ),
+    )
+)
 
 
-CTD_ANON_19._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=CTD_ANON_19, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 920, 4)))
-
-CTD_ANON_19._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), tsNumeroProtocolo, scope=CTD_ANON_19, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 922, 4)))
-
-def _BuildAutomaton_42 ():
+def _BuildAutomaton_42():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_42
     del _BuildAutomaton_42
@@ -6322,34 +10773,84 @@ def _BuildAutomaton_42 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_19._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 920, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_19._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 920, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_19._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 922, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_19._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 922, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_19._Automaton = _BuildAutomaton_42()
 
 
+CTD_ANON_20._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote"),
+        CTD_ANON_,
+        scope=CTD_ANON_20,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 717, 2
+        ),
+    )
+)
+
+CTD_ANON_20._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_20,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_20._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Situacao"),
+        tsSituacaoLoteRps,
+        scope=CTD_ANON_20,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 931, 11
+        ),
+    )
+)
+
+CTD_ANON_20._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_21,
+        scope=CTD_ANON_20,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 933, 4
+        ),
+    )
+)
 
 
-CTD_ANON_20._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote'), CTD_ANON_, scope=CTD_ANON_20, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 717, 2)))
-
-CTD_ANON_20._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_20, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_20._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Situacao'), tsSituacaoLoteRps, scope=CTD_ANON_20, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 931, 11)))
-
-CTD_ANON_20._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_21, scope=CTD_ANON_20, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 933, 4)))
-
-def _BuildAutomaton_43 ():
+def _BuildAutomaton_43():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_43
     del _BuildAutomaton_43
@@ -6358,28 +10859,53 @@ def _BuildAutomaton_43 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Situacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 931, 11))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Situacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 931, 11
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 933, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 933, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 942, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 942, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetornoLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 944, 4))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_20._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetornoLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 944, 4
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
@@ -6388,58 +10914,121 @@ def _BuildAutomaton_43 ():
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_20._Automaton = _BuildAutomaton_43()
 
 
+CTD_ANON_21._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno"),
+        CTD_ANON_3,
+        scope=CTD_ANON_21,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 735, 1
+        ),
+    )
+)
+
+CTD_ANON_21._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_21,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_21._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno'), CTD_ANON_3, scope=CTD_ANON_21, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 735, 1)))
-
-CTD_ANON_21._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_21, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_44 ():
+def _BuildAutomaton_44():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_44
     del _BuildAutomaton_44
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=50, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 936, 7))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=50,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 936, 7
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 938, 7))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 938, 7
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_21._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 936, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_21._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 936, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_21._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemAlertaRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 938, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_21._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ListaMensagemAlertaRetorno")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 938, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_21._Automaton = _BuildAutomaton_44()
 
 
+CTD_ANON_22._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=CTD_ANON_22,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 954, 4
+        ),
+    )
+)
+
+CTD_ANON_22._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=CTD_ANON_22,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 956, 4
+        ),
+    )
+)
 
 
-CTD_ANON_22._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=CTD_ANON_22, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 954, 4)))
-
-CTD_ANON_22._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=CTD_ANON_22, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 956, 4)))
-
-def _BuildAutomaton_45 ():
+def _BuildAutomaton_45():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_45
     del _BuildAutomaton_45
@@ -6448,30 +11037,62 @@ def _BuildAutomaton_45 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_22._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 954, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_22._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 954, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_22._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 956, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_22._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 956, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_22._Automaton = _BuildAutomaton_45()
 
 
+CTD_ANON_23._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_23,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_23._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_23,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
 
 
-CTD_ANON_23._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_23, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_23._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_23, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-def _BuildAutomaton_46 ():
+def _BuildAutomaton_46():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_46
     del _BuildAutomaton_46
@@ -6480,158 +11101,309 @@ def _BuildAutomaton_46 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_23._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 965, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_23._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 965, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_23._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 966, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_23._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 966, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_23._Automaton = _BuildAutomaton_46()
 
 
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 975, 4
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        tsNumeroNfse,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 977, 4
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        CTD_ANON_25,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 980, 5
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia"),
+        CTD_ANON_26,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 991, 5
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        tcIdentificacaoTomador,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1003, 4
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        tcIdentificacaoIntermediario,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1005, 4
+        ),
+    )
+)
+
+CTD_ANON_24._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        tsPagina,
+        scope=CTD_ANON_24,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1007, 4
+        ),
+    )
+)
 
 
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 975, 4)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), tsNumeroNfse, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 977, 4)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), CTD_ANON_25, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 980, 5)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia'), CTD_ANON_26, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 991, 5)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), tcIdentificacaoTomador, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1003, 4)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), tcIdentificacaoIntermediario, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1005, 4)))
-
-CTD_ANON_24._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), tsPagina, scope=CTD_ANON_24, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1007, 4)))
-
-def _BuildAutomaton_47 ():
+def _BuildAutomaton_47():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_47
     del _BuildAutomaton_47
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 977, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 977, 4
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 980, 5))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 980, 5
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 991, 5))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 991, 5
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1003, 4))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1003, 4
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1005, 4))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1005, 4
+        ),
+    )
     counters.add(cc_4)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 975, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 975, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 977, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 977, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 980, 5))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 980, 5
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 991, 5))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 991, 5
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1003, 4))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1003, 4
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Intermediario')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1005, 4))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Intermediario")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1005, 4
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1007, 4))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_24._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1007, 4
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
     st_6._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_24._Automaton = _BuildAutomaton_47()
 
 
+CTD_ANON_25._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_25,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 984, 8
+        ),
+    )
+)
+
+CTD_ANON_25._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_25,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 986, 8
+        ),
+    )
+)
 
 
-CTD_ANON_25._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), pyxb.binding.datatypes.date, scope=CTD_ANON_25, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 984, 8)))
-
-CTD_ANON_25._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), pyxb.binding.datatypes.date, scope=CTD_ANON_25, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 986, 8)))
-
-def _BuildAutomaton_48 ():
+def _BuildAutomaton_48():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_48
     del _BuildAutomaton_48
@@ -6640,30 +11412,62 @@ def _BuildAutomaton_48 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_25._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 984, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_25._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 984, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_25._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 986, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_25._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 986, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_25._Automaton = _BuildAutomaton_48()
 
 
+CTD_ANON_26._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_26,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 995, 8
+        ),
+    )
+)
+
+CTD_ANON_26._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_26,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 997, 8
+        ),
+    )
+)
 
 
-CTD_ANON_26._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), pyxb.binding.datatypes.date, scope=CTD_ANON_26, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 995, 8)))
-
-CTD_ANON_26._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), pyxb.binding.datatypes.date, scope=CTD_ANON_26, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 997, 8)))
-
-def _BuildAutomaton_49 ():
+def _BuildAutomaton_49():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_49
     del _BuildAutomaton_49
@@ -6672,30 +11476,62 @@ def _BuildAutomaton_49 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_26._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 995, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_26._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 995, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_26._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 997, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_26._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 997, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_26._Automaton = _BuildAutomaton_49()
 
 
+CTD_ANON_27._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_27,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_27._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_28,
+        scope=CTD_ANON_27,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1015, 4
+        ),
+    )
+)
 
 
-CTD_ANON_27._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_27, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_27._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_28, scope=CTD_ANON_27, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1015, 4)))
-
-def _BuildAutomaton_50 ():
+def _BuildAutomaton_50():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_50
     del _BuildAutomaton_50
@@ -6704,226 +11540,433 @@ def _BuildAutomaton_50 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_27._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1015, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_27._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1015, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_27._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1023, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_27._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1023, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_27._Automaton = _BuildAutomaton_50()
 
 
+CTD_ANON_28._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_28,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
+
+CTD_ANON_28._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        tsPagina,
+        scope=CTD_ANON_28,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1019, 7
+        ),
+    )
+)
 
 
-CTD_ANON_28._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_28, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-CTD_ANON_28._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), tsPagina, scope=CTD_ANON_28, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1019, 7)))
-
-def _BuildAutomaton_51 ():
+def _BuildAutomaton_51():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_51
     del _BuildAutomaton_51
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=50, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1018, 7))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=50,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1018, 7
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1019, 7))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1019, 7
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_28._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1018, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_28._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1018, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_28._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1019, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_28._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ProximaPagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1019, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_28._Automaton = _BuildAutomaton_51()
 
 
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Consulente"),
+        tcIdentificacaoConsulente,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1032, 4
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        tsNumeroNfse,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1034, 4
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        CTD_ANON_30,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1037, 5
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia"),
+        CTD_ANON_31,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1048, 5
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1060, 4
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        tcIdentificacaoTomador,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1062, 4
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        tcIdentificacaoIntermediario,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1064, 4
+        ),
+    )
+)
+
+CTD_ANON_29._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        tsPagina,
+        scope=CTD_ANON_29,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1066, 4
+        ),
+    )
+)
 
 
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Consulente'), tcIdentificacaoConsulente, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1032, 4)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), tsNumeroNfse, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1034, 4)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), CTD_ANON_30, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1037, 5)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia'), CTD_ANON_31, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1048, 5)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1060, 4)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), tcIdentificacaoTomador, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1062, 4)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), tcIdentificacaoIntermediario, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1064, 4)))
-
-CTD_ANON_29._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), tsPagina, scope=CTD_ANON_29, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1066, 4)))
-
-def _BuildAutomaton_52 ():
+def _BuildAutomaton_52():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_52
     del _BuildAutomaton_52
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1034, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1034, 4
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1037, 5))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1037, 5
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1048, 5))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1048, 5
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1060, 4))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1060, 4
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1062, 4))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1062, 4
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1064, 4))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1064, 4
+        ),
+    )
     counters.add(cc_5)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Consulente')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1032, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Consulente")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1032, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1034, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1034, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1037, 5))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1037, 5
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PeriodoCompetencia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1048, 5))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PeriodoCompetencia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1048, 5
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1060, 4))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1060, 4
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1062, 4))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1062, 4
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Intermediario')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1064, 4))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Intermediario")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1064, 4
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1066, 4))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_29._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1066, 4
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_3, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_4, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_5, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
     st_7._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_29._Automaton = _BuildAutomaton_52()
 
 
+CTD_ANON_30._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_30,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1041, 8
+        ),
+    )
+)
+
+CTD_ANON_30._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_30,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1043, 8
+        ),
+    )
+)
 
 
-CTD_ANON_30._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), pyxb.binding.datatypes.date, scope=CTD_ANON_30, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1041, 8)))
-
-CTD_ANON_30._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), pyxb.binding.datatypes.date, scope=CTD_ANON_30, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1043, 8)))
-
-def _BuildAutomaton_53 ():
+def _BuildAutomaton_53():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_53
     del _BuildAutomaton_53
@@ -6932,30 +11975,62 @@ def _BuildAutomaton_53 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_30._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1041, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_30._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1041, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_30._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1043, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_30._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1043, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_30._Automaton = _BuildAutomaton_53()
 
 
+CTD_ANON_31._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_31,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1052, 8
+        ),
+    )
+)
+
+CTD_ANON_31._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_31,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1054, 8
+        ),
+    )
+)
 
 
-CTD_ANON_31._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), pyxb.binding.datatypes.date, scope=CTD_ANON_31, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1052, 8)))
-
-CTD_ANON_31._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), pyxb.binding.datatypes.date, scope=CTD_ANON_31, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1054, 8)))
-
-def _BuildAutomaton_54 ():
+def _BuildAutomaton_54():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_54
     del _BuildAutomaton_54
@@ -6964,30 +12039,62 @@ def _BuildAutomaton_54 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_31._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1052, 8))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_31._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1052, 8
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_31._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1054, 8))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_31._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1054, 8
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_31._Automaton = _BuildAutomaton_54()
 
 
+CTD_ANON_32._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_32,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_32._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_33,
+        scope=CTD_ANON_32,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1074, 4
+        ),
+    )
+)
 
 
-CTD_ANON_32._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_32, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_32._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_33, scope=CTD_ANON_32, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1074, 4)))
-
-def _BuildAutomaton_55 ():
+def _BuildAutomaton_55():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_55
     del _BuildAutomaton_55
@@ -6996,72 +12103,156 @@ def _BuildAutomaton_55 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_32._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1074, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_32._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1074, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_32._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1082, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_32._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1082, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_32._Automaton = _BuildAutomaton_55()
 
 
+CTD_ANON_33._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_33,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
+
+CTD_ANON_33._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        tsPagina,
+        scope=CTD_ANON_33,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1078, 7
+        ),
+    )
+)
 
 
-CTD_ANON_33._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_33, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-CTD_ANON_33._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), tsPagina, scope=CTD_ANON_33, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1078, 7)))
-
-def _BuildAutomaton_56 ():
+def _BuildAutomaton_56():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_56
     del _BuildAutomaton_56
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=50, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1077, 7))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=50,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1077, 7
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1078, 7))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1078, 7
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_33._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1077, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_33._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1077, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_33._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1078, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_33._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ProximaPagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1078, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_33._Automaton = _BuildAutomaton_56()
 
 
+CTD_ANON_34._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=CTD_ANON_34,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1091, 4
+        ),
+    )
+)
+
+CTD_ANON_34._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Faixa"),
+        CTD_ANON_35,
+        scope=CTD_ANON_34,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1093, 4
+        ),
+    )
+)
+
+CTD_ANON_34._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pagina"),
+        tsPagina,
+        scope=CTD_ANON_34,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1103, 4
+        ),
+    )
+)
 
 
-CTD_ANON_34._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=CTD_ANON_34, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1091, 4)))
-
-CTD_ANON_34._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Faixa'), CTD_ANON_35, scope=CTD_ANON_34, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1093, 4)))
-
-CTD_ANON_34._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pagina'), tsPagina, scope=CTD_ANON_34, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1103, 4)))
-
-def _BuildAutomaton_57 ():
+def _BuildAutomaton_57():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_57
     del _BuildAutomaton_57
@@ -7070,75 +12261,150 @@ def _BuildAutomaton_57 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1091, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1091, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Faixa')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1093, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Faixa")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1093, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1103, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_34._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1103, 4
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_34._Automaton = _BuildAutomaton_57()
 
 
+CTD_ANON_35._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfseInicial"),
+        tsNumeroNfse,
+        scope=CTD_ANON_35,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1096, 7
+        ),
+    )
+)
+
+CTD_ANON_35._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfseFinal"),
+        tsNumeroNfse,
+        scope=CTD_ANON_35,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1098, 7
+        ),
+    )
+)
 
 
-CTD_ANON_35._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseInicial'), tsNumeroNfse, scope=CTD_ANON_35, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1096, 7)))
-
-CTD_ANON_35._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseFinal'), tsNumeroNfse, scope=CTD_ANON_35, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1098, 7)))
-
-def _BuildAutomaton_58 ():
+def _BuildAutomaton_58():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_58
     del _BuildAutomaton_58
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1098, 7))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1098, 7
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_35._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1096, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_35._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroNfseInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1096, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_35._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfseFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1098, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_35._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroNfseFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1098, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_35._Automaton = _BuildAutomaton_58()
 
 
+CTD_ANON_36._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+        CTD_ANON_2,
+        scope=CTD_ANON_36,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 726, 1
+        ),
+    )
+)
+
+CTD_ANON_36._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_37,
+        scope=CTD_ANON_36,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1111, 4
+        ),
+    )
+)
 
 
-CTD_ANON_36._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON_2, scope=CTD_ANON_36, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 726, 1)))
-
-CTD_ANON_36._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_37, scope=CTD_ANON_36, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1111, 4)))
-
-def _BuildAutomaton_59 ():
+def _BuildAutomaton_59():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_59
     del _BuildAutomaton_59
@@ -7147,485 +12413,1053 @@ def _BuildAutomaton_59 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_36._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1111, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_36._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1111, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_36._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1119, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_36._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1119, 4
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_36._Automaton = _BuildAutomaton_59()
 
 
+CTD_ANON_37._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        tcCompNfse,
+        scope=CTD_ANON_37,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 754, 1
+        ),
+    )
+)
+
+CTD_ANON_37._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ProximaPagina"),
+        tsPagina,
+        scope=CTD_ANON_37,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1115, 7
+        ),
+    )
+)
 
 
-CTD_ANON_37._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), tcCompNfse, scope=CTD_ANON_37, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 754, 1)))
-
-CTD_ANON_37._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina'), tsPagina, scope=CTD_ANON_37, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1115, 7)))
-
-def _BuildAutomaton_60 ():
+def _BuildAutomaton_60():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_60
     del _BuildAutomaton_60
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=50, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1114, 7))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=50,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1114, 7
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1115, 7))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1115, 7
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_37._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1114, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_37._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1114, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_37._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ProximaPagina')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 1115, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_37._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ProximaPagina")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 1115, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_37._Automaton = _BuildAutomaton_60()
 
 
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 500, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        pyxb.binding.datatypes.date,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 502, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Status"),
+        tsStatusRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 504, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido"),
+        tcIdentificacaoRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 506, 3
+        ),
+    )
+)
 
 
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 500, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), pyxb.binding.datatypes.date, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 502, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Status'), tsStatusRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 504, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido'), tcIdentificacaoRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 506, 3)))
-
-def _BuildAutomaton_61 ():
+def _BuildAutomaton_61():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_61
     del _BuildAutomaton_61
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 506, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 506, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 500, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 500, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 502, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 502, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Status')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 504, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Status")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 504, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 506, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 506, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, True)]))
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfRps._Automaton = _BuildAutomaton_61()
 
 
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        tcInfRps,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 514, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Competencia"),
+        pyxb.binding.datatypes.date,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 516, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        tcDadosServico,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 518, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 520, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        tcDadosTomador,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 522, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Intermediario"),
+        tcDadosIntermediario,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 524, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        tcDadosConstrucaoCivil,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 526, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        tsRegimeEspecialTributacao,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 528, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        tsSimNao,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 530, 3
+        ),
+    )
+)
+
+tcInfDeclaracaoPrestacaoServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivoFiscal"),
+        tsSimNao,
+        scope=tcInfDeclaracaoPrestacaoServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 532, 3
+        ),
+    )
+)
 
 
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Rps'), tcInfRps, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 514, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Competencia'), pyxb.binding.datatypes.date, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 516, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Servico'), tcDadosServico, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 518, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 520, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), tcDadosTomador, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 522, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Intermediario'), tcDadosIntermediario, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 524, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), tcDadosConstrucaoCivil, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 526, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), tsRegimeEspecialTributacao, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 528, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), tsSimNao, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 530, 3)))
-
-tcInfDeclaracaoPrestacaoServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IncentivoFiscal'), tsSimNao, scope=tcInfDeclaracaoPrestacaoServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 532, 3)))
-
-def _BuildAutomaton_62 ():
+def _BuildAutomaton_62():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_62
     del _BuildAutomaton_62
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 514, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 514, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 522, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 522, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 524, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 524, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 526, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 526, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 528, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 528, 3
+        ),
+    )
     counters.add(cc_4)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Rps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 514, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Rps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 514, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Competencia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 516, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "Competencia")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 516, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Servico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 518, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "Servico")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 518, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 520, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "Prestador")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 520, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 522, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "Tomador")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 522, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Intermediario')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 524, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "Intermediario")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 524, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 526, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 526, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 528, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 528, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 530, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 530, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfDeclaracaoPrestacaoServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IncentivoFiscal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 532, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfDeclaracaoPrestacaoServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IncentivoFiscal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 532, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
-    transitions.append(fac.Transition(st_8, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
+    transitions.append(fac.Transition(st_8, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_1, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_2, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_3, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_4, False)]))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-         ]))
+    transitions.append(fac.Transition(st_9, []))
     st_8._set_transitionSet(transitions)
     transitions = []
     st_9._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfDeclaracaoPrestacaoServico._Automaton = _BuildAutomaton_62()
 
 
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroNfse,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 562, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao"),
+        tsCodigoVerificacao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 564, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        pyxb.binding.datatypes.dateTime,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 566, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        tsNumeroNfse,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 568, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes"),
+        tsOutrasInformacoes,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 570, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValoresNfse"),
+        tcValoresNfse,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 572, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCredito"),
+        tsValor,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 574, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PrestadorServico"),
+        tcDadosPrestador,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 576, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador"),
+        tcIdentificacaoOrgaoGerador,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 578, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DeclaracaoPrestacaoServico"),
+        tcDeclaracaoPrestacaoServico,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 580, 3
+        ),
+    )
+)
 
 
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroNfse, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 562, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao'), tsCodigoVerificacao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 564, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), pyxb.binding.datatypes.dateTime, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 566, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), tsNumeroNfse, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 568, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes'), tsOutrasInformacoes, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 570, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValoresNfse'), tcValoresNfse, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 572, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito'), tsValor, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 574, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico'), tcDadosPrestador, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 576, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador'), tcIdentificacaoOrgaoGerador, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 578, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DeclaracaoPrestacaoServico'), tcDeclaracaoPrestacaoServico, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 580, 3)))
-
-def _BuildAutomaton_63 ():
+def _BuildAutomaton_63():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_63
     del _BuildAutomaton_63
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 568, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 568, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 570, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 570, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 574, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 574, 3
+        ),
+    )
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 562, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 562, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 564, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 564, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 566, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 566, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 568, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 568, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 570, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 570, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValoresNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 572, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValoresNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 572, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 574, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorCredito")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 574, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 576, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PrestadorServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 576, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 578, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 578, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DeclaracaoPrestacaoServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 580, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DeclaracaoPrestacaoServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 580, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-         ]))
+    transitions.append(fac.Transition(st_8, []))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-         ]))
+    transitions.append(fac.Transition(st_9, []))
     st_8._set_transitionSet(transitions)
     transitions = []
     st_9._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfNfse._Automaton = _BuildAutomaton_63()
 
 
+tcNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfNfse"),
+        tcInfNfse,
+        scope=tcNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 587, 3
+        ),
+    )
+)
+
+tcNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-tcNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfNfse'), tcInfNfse, scope=tcNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 587, 3)))
-
-tcNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_64 ():
+def _BuildAutomaton_64():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_64
     del _BuildAutomaton_64
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 589, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 589, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 587, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "InfNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 587, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 589, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 589, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcNfse._Automaton = _BuildAutomaton_64()
 
 
+tcInfPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse"),
+        tcIdentificacaoNfse,
+        scope=tcInfPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 597, 3
+        ),
+    )
+)
+
+tcInfPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento"),
+        tsCodigoCancelamentoNfse,
+        scope=tcInfPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 599, 3
+        ),
+    )
+)
 
 
-tcInfPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse'), tcIdentificacaoNfse, scope=tcInfPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 597, 3)))
-
-tcInfPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento'), tsCodigoCancelamentoNfse, scope=tcInfPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 599, 3)))
-
-def _BuildAutomaton_65 ():
+def _BuildAutomaton_65():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_65
     del _BuildAutomaton_65
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 599, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 599, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 597, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 597, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcInfPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 599, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 599, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfPedidoCancelamento._Automaton = _BuildAutomaton_65()
 
 
+tcConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        tcPedidoCancelamento,
+        scope=tcConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 616, 3
+        ),
+    )
+)
+
+tcConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataHora"),
+        pyxb.binding.datatypes.dateTime,
+        scope=tcConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 618, 3
+        ),
+    )
+)
 
 
-tcConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), tcPedidoCancelamento, scope=tcConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 616, 3)))
-
-tcConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataHora'), pyxb.binding.datatypes.dateTime, scope=tcConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 618, 3)))
-
-def _BuildAutomaton_66 ():
+def _BuildAutomaton_66():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_66
     del _BuildAutomaton_66
@@ -7634,65 +13468,125 @@ def _BuildAutomaton_66 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pedido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 616, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pedido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 616, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataHora')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 618, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataHora")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 618, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcConfirmacaoCancelamento._Automaton = _BuildAutomaton_66()
 
 
+tcCancelamentoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Confirmacao"),
+        tcConfirmacaoCancelamento,
+        scope=tcCancelamentoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 626, 3
+        ),
+    )
+)
+
+tcCancelamentoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcCancelamentoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-tcCancelamentoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao'), tcConfirmacaoCancelamento, scope=tcCancelamentoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 626, 3)))
-
-tcCancelamentoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcCancelamentoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_67 ():
+def _BuildAutomaton_67():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_67
     del _BuildAutomaton_67
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 628, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 628, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 626, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Confirmacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 626, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 628, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 628, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCancelamentoNfse._Automaton = _BuildAutomaton_67()
 
 
+tcInfSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        tsNumeroNfse,
+        scope=tcInfSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 644, 3
+        ),
+    )
+)
 
 
-tcInfSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), tsNumeroNfse, scope=tcInfSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 644, 3)))
-
-def _BuildAutomaton_68 ():
+def _BuildAutomaton_68():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_68
     del _BuildAutomaton_68
@@ -7701,125 +13595,262 @@ def _BuildAutomaton_68 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 644, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfSubstituicaoNfse._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 644, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfSubstituicaoNfse._Automaton = _BuildAutomaton_68()
 
 
+tcSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        tcInfSubstituicaoNfse,
+        scope=tcSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 652, 3
+        ),
+    )
+)
+
+tcSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd", 41, 0
+        ),
+    )
+)
 
 
-tcSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), tcInfSubstituicaoNfse, scope=tcSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 652, 3)))
-
-tcSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/xmldsig-core-schema20020212.xsd', 41, 0)))
-
-def _BuildAutomaton_69 ():
+def _BuildAutomaton_69():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_69
     del _BuildAutomaton_69
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=2, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 654, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=2,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 654, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 652, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 652, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 654, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 654, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcSubstituicaoNfse._Automaton = _BuildAutomaton_69()
 
 
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        tsNumeroLote,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 695, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 697, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 699, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps"),
+        tsQuantidadeRps,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 701, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaRps"),
+        CTD_ANON,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 703, 3
+        ),
+    )
+)
 
 
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), tsNumeroLote, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 695, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 697, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 699, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps'), tsQuantidadeRps, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 701, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaRps'), CTD_ANON, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 703, 3)))
-
-def _BuildAutomaton_70 ():
+def _BuildAutomaton_70():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_70
     del _BuildAutomaton_70
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 699, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 699, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 695, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 695, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 697, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 697, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 699, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 699, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 701, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 701, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 703, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 703, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcLoteRps._Automaton = _BuildAutomaton_70()
 
 
+CTD_ANON_38._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "versaoDados"),
+        tsVersao,
+        scope=CTD_ANON_38,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 747, 4
+        ),
+    )
+)
 
 
-CTD_ANON_38._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'versaoDados'), tsVersao, scope=CTD_ANON_38, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 747, 4)))
-
-def _BuildAutomaton_71 ():
+def _BuildAutomaton_71():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_71
     del _BuildAutomaton_71
@@ -7828,22 +13859,48 @@ def _BuildAutomaton_71 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_38._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'versaoDados')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 747, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_38._UseForTag(pyxb.namespace.ExpandedName(Namespace, "versaoDados")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 747, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_38._Automaton = _BuildAutomaton_71()
 
 
+CTD_ANON_39._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        tcPedidoCancelamento,
+        scope=CTD_ANON_39,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 874, 7
+        ),
+    )
+)
+
+CTD_ANON_39._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        tcDeclaracaoPrestacaoServico,
+        scope=CTD_ANON_39,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 875, 7
+        ),
+    )
+)
 
 
-CTD_ANON_39._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), tcPedidoCancelamento, scope=CTD_ANON_39, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 874, 7)))
-
-CTD_ANON_39._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Rps'), tcDeclaracaoPrestacaoServico, scope=CTD_ANON_39, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 875, 7)))
-
-def _BuildAutomaton_72 ():
+def _BuildAutomaton_72():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_72
     del _BuildAutomaton_72
@@ -7852,19 +13909,33 @@ def _BuildAutomaton_72 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_39._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pedido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 874, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_39._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pedido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 874, 7
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_39._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Rps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd', 875, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_39._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Rps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Betha/nfse_v202.xsd", 875, 7
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON_39._Automaton = _BuildAutomaton_72()
 
+
+CTD_ANON_39._Automaton = _BuildAutomaton_72()

--- a/pynfe/utils/nfse/ginfes/_dsig.py
+++ b/pynfe/utils/nfse/ginfes/_dsig.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:80f44f0e-46bd-4e0a-b679-b20d27356b57')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:80f44f0e-46bd-4e0a-b679-b20d27356b57"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -28,10 +31,15 @@ _module_typeBindings = pyxb.utils.utility.Object()
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.w3.org/2000/09/xmldsig#', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.w3.org/2000/09/xmldsig#", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -62,7 +70,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -71,7 +81,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -84,1160 +95,2027 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}CryptoBinary
-class CryptoBinary (pyxb.binding.datatypes.base64Binary):
-
+class CryptoBinary(pyxb.binding.datatypes.base64Binary):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CryptoBinary')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 34, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "CryptoBinary")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 34, 0
+    )
     _Documentation = None
+
+
 CryptoBinary._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'CryptoBinary', CryptoBinary)
+Namespace.addCategoryObject("typeBinding", "CryptoBinary", CryptoBinary)
 _module_typeBindings.CryptoBinary = CryptoBinary
 
-# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}DigestValueType
-class DigestValueType (pyxb.binding.datatypes.base64Binary):
 
+# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}DigestValueType
+class DigestValueType(pyxb.binding.datatypes.base64Binary):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DigestValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 134, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DigestValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 134, 0
+    )
     _Documentation = None
+
+
 DigestValueType._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'DigestValueType', DigestValueType)
+Namespace.addCategoryObject("typeBinding", "DigestValueType", DigestValueType)
 _module_typeBindings.DigestValueType = DigestValueType
 
-# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}HMACOutputLengthType
-class HMACOutputLengthType (pyxb.binding.datatypes.integer):
 
+# Atomic simple type: {http://www.w3.org/2000/09/xmldsig#}HMACOutputLengthType
+class HMACOutputLengthType(pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLengthType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 281, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "HMACOutputLengthType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 281, 0
+    )
     _Documentation = None
+
+
 HMACOutputLengthType._InitializeFacetMap()
-Namespace.addCategoryObject('typeBinding', 'HMACOutputLengthType', HMACOutputLengthType)
+Namespace.addCategoryObject("typeBinding", "HMACOutputLengthType", HMACOutputLengthType)
 _module_typeBindings.HMACOutputLengthType = HMACOutputLengthType
 
+
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureType with content type ELEMENT_ONLY
-class SignatureType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 42, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 42, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureValue uses Python identifier SignatureValue
-    __SignatureValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), 'SignatureValue', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignatureValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 52, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureValue uses Python identifier SignatureValue
+    __SignatureValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+        "SignatureValue",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignatureValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            52,
+            2,
+        ),
+    )
+
     SignatureValue = property(__SignatureValue.value, __SignatureValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignedInfo uses Python identifier SignedInfo
-    __SignedInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), 'SignedInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignedInfo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 63, 0), )
+    __SignedInfo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+        "SignedInfo",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignedInfo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            63,
+            0,
+        ),
+    )
 
-    
     SignedInfo = property(__SignedInfo.value, __SignedInfo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyInfo uses Python identifier KeyInfo
-    __KeyInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), 'KeyInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigKeyInfo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 142, 0), )
+    __KeyInfo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+        "KeyInfo",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigKeyInfo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            142,
+            0,
+        ),
+    )
 
-    
     KeyInfo = property(__KeyInfo.value, __KeyInfo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Object uses Python identifier Object
-    __Object = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Object'), 'Object', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigObject', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 241, 0), )
+    __Object = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Object"),
+        "Object",
+        "__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigObject",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            241,
+            0,
+        ),
+    )
 
-    
     Object = property(__Object.value, __Object.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 49, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 49, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignatureType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 49, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 49, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __SignatureValue.name() : __SignatureValue,
-        __SignedInfo.name() : __SignedInfo,
-        __KeyInfo.name() : __KeyInfo,
-        __Object.name() : __Object
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __SignatureValue.name(): __SignatureValue,
+            __SignedInfo.name(): __SignedInfo,
+            __KeyInfo.name(): __KeyInfo,
+            __Object.name(): __Object,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignatureType = SignatureType
-Namespace.addCategoryObject('typeBinding', 'SignatureType', SignatureType)
+Namespace.addCategoryObject("typeBinding", "SignatureType", SignatureType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureValueType with content type SIMPLE
-class SignatureValueType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureValueType with content type SIMPLE"""
+
     _TypeDefinition = pyxb.binding.datatypes.base64Binary
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_SIMPLE
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 53, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 53, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.base64Binary
-    
+
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureValueType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 56, 8)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 56, 8)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignatureValueType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 56, 8
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 56, 8
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignatureValueType = SignatureValueType
-Namespace.addCategoryObject('typeBinding', 'SignatureValueType', SignatureValueType)
+Namespace.addCategoryObject("typeBinding", "SignatureValueType", SignatureValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignedInfoType with content type ELEMENT_ONLY
-class SignedInfoType (pyxb.binding.basis.complexTypeDefinition):
+class SignedInfoType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignedInfoType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignedInfoType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 64, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignedInfoType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 64, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethod uses Python identifier CanonicalizationMethod
-    __CanonicalizationMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), 'CanonicalizationMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigCanonicalizationMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 73, 2), )
+    __CanonicalizationMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+        "CanonicalizationMethod",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigCanonicalizationMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            73,
+            2,
+        ),
+    )
 
-    
-    CanonicalizationMethod = property(__CanonicalizationMethod.value, __CanonicalizationMethod.set, None, None)
+    CanonicalizationMethod = property(
+        __CanonicalizationMethod.value, __CanonicalizationMethod.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignatureMethod uses Python identifier SignatureMethod
-    __SignatureMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), 'SignatureMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigSignatureMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 82, 2), )
+    __SignatureMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+        "SignatureMethod",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigSignatureMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            82,
+            2,
+        ),
+    )
 
-    
     SignatureMethod = property(__SignatureMethod.value, __SignatureMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
-    __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 94, 0), )
+    __Reference = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        "Reference",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigReference",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            94,
+            0,
+        ),
+    )
 
-    
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignedInfoType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 70, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 70, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignedInfoType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 70, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 70, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __CanonicalizationMethod.name() : __CanonicalizationMethod,
-        __SignatureMethod.name() : __SignatureMethod,
-        __Reference.name() : __Reference
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __CanonicalizationMethod.name(): __CanonicalizationMethod,
+            __SignatureMethod.name(): __SignatureMethod,
+            __Reference.name(): __Reference,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignedInfoType = SignedInfoType
-Namespace.addCategoryObject('typeBinding', 'SignedInfoType', SignedInfoType)
+Namespace.addCategoryObject("typeBinding", "SignedInfoType", SignedInfoType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethodType with content type MIXED
-class CanonicalizationMethodType (pyxb.binding.basis.complexTypeDefinition):
+class CanonicalizationMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 74, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 74, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_CanonicalizationMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 79, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 79, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_CanonicalizationMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 79, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 79, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.CanonicalizationMethodType = CanonicalizationMethodType
-Namespace.addCategoryObject('typeBinding', 'CanonicalizationMethodType', CanonicalizationMethodType)
+Namespace.addCategoryObject("typeBinding", "CanonicalizationMethodType", CanonicalizationMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureMethodType with content type MIXED
-class SignatureMethodType (pyxb.binding.basis.complexTypeDefinition):
+class SignatureMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignatureMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignatureMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 83, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignatureMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 83, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}HMACOutputLength uses Python identifier HMACOutputLength
-    __HMACOutputLength = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength'), 'HMACOutputLength', '__httpwww_w3_org200009xmldsig_SignatureMethodType_httpwww_w3_org200009xmldsigHMACOutputLength', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 85, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}HMACOutputLength uses Python identifier HMACOutputLength
+    __HMACOutputLength = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength"),
+        "HMACOutputLength",
+        "__httpwww_w3_org200009xmldsig_SignatureMethodType_httpwww_w3_org200009xmldsigHMACOutputLength",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            85,
+            6,
+        ),
+    )
+
     HMACOutputLength = property(__HMACOutputLength.value, __HMACOutputLength.set, None, None)
 
-    
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_SignatureMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 89, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 89, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_SignatureMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 89, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 89, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __HMACOutputLength.name() : __HMACOutputLength
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({__HMACOutputLength.name(): __HMACOutputLength})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.SignatureMethodType = SignatureMethodType
-Namespace.addCategoryObject('typeBinding', 'SignatureMethodType', SignatureMethodType)
+Namespace.addCategoryObject("typeBinding", "SignatureMethodType", SignatureMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ReferenceType with content type ELEMENT_ONLY
-class ReferenceType (pyxb.binding.basis.complexTypeDefinition):
+class ReferenceType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ReferenceType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ReferenceType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 95, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ReferenceType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 95, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
-    __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 106, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
+    __Transforms = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        "Transforms",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigTransforms",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            106,
+            2,
+        ),
+    )
+
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestMethod uses Python identifier DigestMethod
-    __DigestMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), 'DigestMethod', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestMethod', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 125, 0), )
+    __DigestMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+        "DigestMethod",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestMethod",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            125,
+            0,
+        ),
+    )
 
-    
     DigestMethod = property(__DigestMethod.value, __DigestMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestValue uses Python identifier DigestValue
-    __DigestValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), 'DigestValue', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 133, 0), )
+    __DigestValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+        "DigestValue",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            133,
+            0,
+        ),
+    )
 
-    
     DigestValue = property(__DigestValue.value, __DigestValue.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ReferenceType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 101, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 101, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 101, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 101, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    
     # Attribute URI uses Python identifier URI
-    __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_ReferenceType_URI', pyxb.binding.datatypes.anyURI)
-    __URI._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 102, 2)
-    __URI._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 102, 2)
-    
+    __URI = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "URI"),
+        "URI",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_URI",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __URI._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 102, 2
+    )
+    __URI._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 102, 2
+    )
+
     URI = property(__URI.value, __URI.set, None, None)
 
-    
     # Attribute Type uses Python identifier Type
-    __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_ReferenceType_Type', pyxb.binding.datatypes.anyURI)
-    __Type._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 103, 2)
-    __Type._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 103, 2)
-    
+    __Type = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Type"),
+        "Type",
+        "__httpwww_w3_org200009xmldsig_ReferenceType_Type",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Type._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 103, 2
+    )
+    __Type._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 103, 2
+    )
+
     Type = property(__Type.value, __Type.set, None, None)
 
-    _ElementMap.update({
-        __Transforms.name() : __Transforms,
-        __DigestMethod.name() : __DigestMethod,
-        __DigestValue.name() : __DigestValue
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id,
-        __URI.name() : __URI,
-        __Type.name() : __Type
-    })
+    _ElementMap.update(
+        {
+            __Transforms.name(): __Transforms,
+            __DigestMethod.name(): __DigestMethod,
+            __DigestValue.name(): __DigestValue,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id, __URI.name(): __URI, __Type.name(): __Type})
+
+
 _module_typeBindings.ReferenceType = ReferenceType
-Namespace.addCategoryObject('typeBinding', 'ReferenceType', ReferenceType)
+Namespace.addCategoryObject("typeBinding", "ReferenceType", ReferenceType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}TransformsType with content type ELEMENT_ONLY
-class TransformsType (pyxb.binding.basis.complexTypeDefinition):
+class TransformsType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}TransformsType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TransformsType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 107, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "TransformsType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 107, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transform uses Python identifier Transform
-    __Transform = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transform'), 'Transform', '__httpwww_w3_org200009xmldsig_TransformsType_httpwww_w3_org200009xmldsigTransform', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 113, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transform uses Python identifier Transform
+    __Transform = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transform"),
+        "Transform",
+        "__httpwww_w3_org200009xmldsig_TransformsType_httpwww_w3_org200009xmldsigTransform",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            113,
+            2,
+        ),
+    )
+
     Transform = property(__Transform.value, __Transform.set, None, None)
 
-    _ElementMap.update({
-        __Transform.name() : __Transform
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Transform.name(): __Transform})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.TransformsType = TransformsType
-Namespace.addCategoryObject('typeBinding', 'TransformsType', TransformsType)
+Namespace.addCategoryObject("typeBinding", "TransformsType", TransformsType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}TransformType with content type MIXED
-class TransformType (pyxb.binding.basis.complexTypeDefinition):
+class TransformType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}TransformType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TransformType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 114, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "TransformType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 114, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}XPath uses Python identifier XPath
-    __XPath = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'XPath'), 'XPath', '__httpwww_w3_org200009xmldsig_TransformType_httpwww_w3_org200009xmldsigXPath', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 118, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}XPath uses Python identifier XPath
+    __XPath = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "XPath"),
+        "XPath",
+        "__httpwww_w3_org200009xmldsig_TransformType_httpwww_w3_org200009xmldsigXPath",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            118,
+            6,
+        ),
+    )
+
     XPath = property(__XPath.value, __XPath.set, None, None)
 
-    
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_TransformType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 120, 4)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 120, 4)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_TransformType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 120, 4
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 120, 4
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __XPath.name() : __XPath
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({__XPath.name(): __XPath})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.TransformType = TransformType
-Namespace.addCategoryObject('typeBinding', 'TransformType', TransformType)
+Namespace.addCategoryObject("typeBinding", "TransformType", TransformType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}DigestMethodType with content type MIXED
-class DigestMethodType (pyxb.binding.basis.complexTypeDefinition):
+class DigestMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}DigestMethodType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DigestMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 126, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DigestMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 126, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Algorithm uses Python identifier Algorithm
-    __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_DigestMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
-    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 130, 2)
-    __Algorithm._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 130, 2)
-    
+    __Algorithm = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Algorithm"),
+        "Algorithm",
+        "__httpwww_w3_org200009xmldsig_DigestMethodType_Algorithm",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Algorithm._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 130, 2
+    )
+    __Algorithm._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 130, 2
+    )
+
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Algorithm.name() : __Algorithm
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Algorithm.name(): __Algorithm})
+
+
 _module_typeBindings.DigestMethodType = DigestMethodType
-Namespace.addCategoryObject('typeBinding', 'DigestMethodType', DigestMethodType)
+Namespace.addCategoryObject("typeBinding", "DigestMethodType", DigestMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}KeyInfoType with content type MIXED
-class KeyInfoType (pyxb.binding.basis.complexTypeDefinition):
+class KeyInfoType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}KeyInfoType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'KeyInfoType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 143, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "KeyInfoType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 143, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}KeyName uses Python identifier KeyName
-    __KeyName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), 'KeyName', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyName', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 158, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}KeyName uses Python identifier KeyName
+    __KeyName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+        "KeyName",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyName",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            158,
+            2,
+        ),
+    )
+
     KeyName = property(__KeyName.value, __KeyName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}MgmtData uses Python identifier MgmtData
-    __MgmtData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), 'MgmtData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigMgmtData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 159, 2), )
+    __MgmtData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+        "MgmtData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigMgmtData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            159,
+            2,
+        ),
+    )
 
-    
     MgmtData = property(__MgmtData.value, __MgmtData.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyValue uses Python identifier KeyValue
-    __KeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), 'KeyValue', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyValue', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 161, 2), )
+    __KeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+        "KeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyValue",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            161,
+            2,
+        ),
+    )
 
-    
     KeyValue = property(__KeyValue.value, __KeyValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}RetrievalMethod uses Python identifier RetrievalMethod
-    __RetrievalMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), 'RetrievalMethod', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigRetrievalMethod', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 170, 2), )
+    __RetrievalMethod = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+        "RetrievalMethod",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigRetrievalMethod",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            170,
+            2,
+        ),
+    )
 
-    
     RetrievalMethod = property(__RetrievalMethod.value, __RetrievalMethod.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Data uses Python identifier X509Data
-    __X509Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), 'X509Data', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigX509Data', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 181, 0), )
+    __X509Data = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+        "X509Data",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigX509Data",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            181,
+            0,
+        ),
+    )
 
-    
     X509Data = property(__X509Data.value, __X509Data.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPData uses Python identifier PGPData
-    __PGPData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), 'PGPData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigPGPData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 206, 0), )
+    __PGPData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+        "PGPData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigPGPData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            206,
+            0,
+        ),
+    )
 
-    
     PGPData = property(__PGPData.value, __PGPData.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}SPKIData uses Python identifier SPKIData
-    __SPKIData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), 'SPKIData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigSPKIData', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 227, 0), )
+    __SPKIData = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+        "SPKIData",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigSPKIData",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            227,
+            0,
+        ),
+    )
 
-    
     SPKIData = property(__SPKIData.value, __SPKIData.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_KeyInfoType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 155, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 155, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_KeyInfoType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 155, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 155, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __KeyName.name() : __KeyName,
-        __MgmtData.name() : __MgmtData,
-        __KeyValue.name() : __KeyValue,
-        __RetrievalMethod.name() : __RetrievalMethod,
-        __X509Data.name() : __X509Data,
-        __PGPData.name() : __PGPData,
-        __SPKIData.name() : __SPKIData
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __KeyName.name(): __KeyName,
+            __MgmtData.name(): __MgmtData,
+            __KeyValue.name(): __KeyValue,
+            __RetrievalMethod.name(): __RetrievalMethod,
+            __X509Data.name(): __X509Data,
+            __PGPData.name(): __PGPData,
+            __SPKIData.name(): __SPKIData,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.KeyInfoType = KeyInfoType
-Namespace.addCategoryObject('typeBinding', 'KeyInfoType', KeyInfoType)
+Namespace.addCategoryObject("typeBinding", "KeyInfoType", KeyInfoType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}KeyValueType with content type MIXED
-class KeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class KeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}KeyValueType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'KeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 162, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "KeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 162, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}DSAKeyValue uses Python identifier DSAKeyValue
-    __DSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), 'DSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigDSAKeyValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 287, 0), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}DSAKeyValue uses Python identifier DSAKeyValue
+    __DSAKeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+        "DSAKeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigDSAKeyValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            287,
+            0,
+        ),
+    )
+
     DSAKeyValue = property(__DSAKeyValue.value, __DSAKeyValue.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}RSAKeyValue uses Python identifier RSAKeyValue
-    __RSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), 'RSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigRSAKeyValue', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 304, 0), )
+    __RSAKeyValue = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+        "RSAKeyValue",
+        "__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigRSAKeyValue",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            304,
+            0,
+        ),
+    )
 
-    
     RSAKeyValue = property(__RSAKeyValue.value, __RSAKeyValue.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __DSAKeyValue.name() : __DSAKeyValue,
-        __RSAKeyValue.name() : __RSAKeyValue
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DSAKeyValue.name(): __DSAKeyValue, __RSAKeyValue.name(): __RSAKeyValue})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.KeyValueType = KeyValueType
-Namespace.addCategoryObject('typeBinding', 'KeyValueType', KeyValueType)
+Namespace.addCategoryObject("typeBinding", "KeyValueType", KeyValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}RetrievalMethodType with content type ELEMENT_ONLY
-class RetrievalMethodType (pyxb.binding.basis.complexTypeDefinition):
+class RetrievalMethodType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}RetrievalMethodType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethodType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 171, 2)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "RetrievalMethodType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 171, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
-    __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 106, 2), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
+    __Transforms = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        "Transforms",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_httpwww_w3_org200009xmldsigTransforms",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            106,
+            2,
+        ),
+    )
+
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-    
     # Attribute URI uses Python identifier URI
-    __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_URI', pyxb.binding.datatypes.anyURI)
-    __URI._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 175, 4)
-    __URI._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 175, 4)
-    
+    __URI = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "URI"),
+        "URI",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_URI",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __URI._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 175, 4
+    )
+    __URI._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 175, 4
+    )
+
     URI = property(__URI.value, __URI.set, None, None)
 
-    
     # Attribute Type uses Python identifier Type
-    __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_Type', pyxb.binding.datatypes.anyURI)
-    __Type._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 176, 4)
-    __Type._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 176, 4)
-    
+    __Type = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Type"),
+        "Type",
+        "__httpwww_w3_org200009xmldsig_RetrievalMethodType_Type",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Type._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 176, 4
+    )
+    __Type._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 176, 4
+    )
+
     Type = property(__Type.value, __Type.set, None, None)
 
-    _ElementMap.update({
-        __Transforms.name() : __Transforms
-    })
-    _AttributeMap.update({
-        __URI.name() : __URI,
-        __Type.name() : __Type
-    })
+    _ElementMap.update({__Transforms.name(): __Transforms})
+    _AttributeMap.update({__URI.name(): __URI, __Type.name(): __Type})
+
+
 _module_typeBindings.RetrievalMethodType = RetrievalMethodType
-Namespace.addCategoryObject('typeBinding', 'RetrievalMethodType', RetrievalMethodType)
+Namespace.addCategoryObject("typeBinding", "RetrievalMethodType", RetrievalMethodType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}X509DataType with content type ELEMENT_ONLY
-class X509DataType (pyxb.binding.basis.complexTypeDefinition):
+class X509DataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}X509DataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'X509DataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 182, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "X509DataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 182, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerial uses Python identifier X509IssuerSerial
-    __X509IssuerSerial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial'), 'X509IssuerSerial', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509IssuerSerial', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 185, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerial uses Python identifier X509IssuerSerial
+    __X509IssuerSerial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial"),
+        "X509IssuerSerial",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509IssuerSerial",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            185,
+            6,
+        ),
+    )
+
     X509IssuerSerial = property(__X509IssuerSerial.value, __X509IssuerSerial.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SKI uses Python identifier X509SKI
-    __X509SKI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SKI'), 'X509SKI', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SKI', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 186, 6), )
+    __X509SKI = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SKI"),
+        "X509SKI",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SKI",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            186,
+            6,
+        ),
+    )
 
-    
     X509SKI = property(__X509SKI.value, __X509SKI.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SubjectName uses Python identifier X509SubjectName
-    __X509SubjectName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName'), 'X509SubjectName', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SubjectName', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 187, 6), )
+    __X509SubjectName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SubjectName"),
+        "X509SubjectName",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SubjectName",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            187,
+            6,
+        ),
+    )
 
-    
     X509SubjectName = property(__X509SubjectName.value, __X509SubjectName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Certificate uses Python identifier X509Certificate
-    __X509Certificate = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate'), 'X509Certificate', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509Certificate', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 188, 6), )
+    __X509Certificate = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509Certificate"),
+        "X509Certificate",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509Certificate",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            188,
+            6,
+        ),
+    )
 
-    
     X509Certificate = property(__X509Certificate.value, __X509Certificate.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509CRL uses Python identifier X509CRL
-    __X509CRL = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509CRL'), 'X509CRL', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509CRL', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 189, 6), )
+    __X509CRL = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509CRL"),
+        "X509CRL",
+        "__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509CRL",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            189,
+            6,
+        ),
+    )
 
-    
     X509CRL = property(__X509CRL.value, __X509CRL.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __X509IssuerSerial.name() : __X509IssuerSerial,
-        __X509SKI.name() : __X509SKI,
-        __X509SubjectName.name() : __X509SubjectName,
-        __X509Certificate.name() : __X509Certificate,
-        __X509CRL.name() : __X509CRL
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __X509IssuerSerial.name(): __X509IssuerSerial,
+            __X509SKI.name(): __X509SKI,
+            __X509SubjectName.name(): __X509SubjectName,
+            __X509Certificate.name(): __X509Certificate,
+            __X509CRL.name(): __X509CRL,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.X509DataType = X509DataType
-Namespace.addCategoryObject('typeBinding', 'X509DataType', X509DataType)
+Namespace.addCategoryObject("typeBinding", "X509DataType", X509DataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerialType with content type ELEMENT_ONLY
-class X509IssuerSerialType (pyxb.binding.basis.complexTypeDefinition):
+class X509IssuerSerialType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerialType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerialType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 195, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerialType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 195, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerName uses Python identifier X509IssuerName
-    __X509IssuerName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName'), 'X509IssuerName', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509IssuerName', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 197, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerName uses Python identifier X509IssuerName
+    __X509IssuerName = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerName"),
+        "X509IssuerName",
+        "__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509IssuerName",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            197,
+            4,
+        ),
+    )
+
     X509IssuerName = property(__X509IssuerName.value, __X509IssuerName.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SerialNumber uses Python identifier X509SerialNumber
-    __X509SerialNumber = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber'), 'X509SerialNumber', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509SerialNumber', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 198, 4), )
+    __X509SerialNumber = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber"),
+        "X509SerialNumber",
+        "__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509SerialNumber",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            198,
+            4,
+        ),
+    )
 
-    
     X509SerialNumber = property(__X509SerialNumber.value, __X509SerialNumber.set, None, None)
 
-    _ElementMap.update({
-        __X509IssuerName.name() : __X509IssuerName,
-        __X509SerialNumber.name() : __X509SerialNumber
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__X509IssuerName.name(): __X509IssuerName, __X509SerialNumber.name(): __X509SerialNumber}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.X509IssuerSerialType = X509IssuerSerialType
-Namespace.addCategoryObject('typeBinding', 'X509IssuerSerialType', X509IssuerSerialType)
+Namespace.addCategoryObject("typeBinding", "X509IssuerSerialType", X509IssuerSerialType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}PGPDataType with content type ELEMENT_ONLY
-class PGPDataType (pyxb.binding.basis.complexTypeDefinition):
+class PGPDataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}PGPDataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'PGPDataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 207, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "PGPDataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 207, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyID uses Python identifier PGPKeyID
-    __PGPKeyID = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID'), 'PGPKeyID', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyID', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 210, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyID uses Python identifier PGPKeyID
+    __PGPKeyID = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyID"),
+        "PGPKeyID",
+        "__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyID",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            210,
+            6,
+        ),
+    )
+
     PGPKeyID = property(__PGPKeyID.value, __PGPKeyID.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyPacket uses Python identifier PGPKeyPacket
-    __PGPKeyPacket = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket'), 'PGPKeyPacket', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyPacket', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 211, 6), )
+    __PGPKeyPacket = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket"),
+        "PGPKeyPacket",
+        "__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyPacket",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            211,
+            6,
+        ),
+    )
 
-    
     PGPKeyPacket = property(__PGPKeyPacket.value, __PGPKeyPacket.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __PGPKeyID.name() : __PGPKeyID,
-        __PGPKeyPacket.name() : __PGPKeyPacket
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__PGPKeyID.name(): __PGPKeyID, __PGPKeyPacket.name(): __PGPKeyPacket})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.PGPDataType = PGPDataType
-Namespace.addCategoryObject('typeBinding', 'PGPDataType', PGPDataType)
+Namespace.addCategoryObject("typeBinding", "PGPDataType", PGPDataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SPKIDataType with content type ELEMENT_ONLY
-class SPKIDataType (pyxb.binding.basis.complexTypeDefinition):
+class SPKIDataType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SPKIDataType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SPKIDataType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 228, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SPKIDataType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 228, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SPKISexp uses Python identifier SPKISexp
-    __SPKISexp = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp'), 'SPKISexp', '__httpwww_w3_org200009xmldsig_SPKIDataType_httpwww_w3_org200009xmldsigSPKISexp', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 230, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SPKISexp uses Python identifier SPKISexp
+    __SPKISexp = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SPKISexp"),
+        "SPKISexp",
+        "__httpwww_w3_org200009xmldsig_SPKIDataType_httpwww_w3_org200009xmldsigSPKISexp",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            230,
+            4,
+        ),
+    )
+
     SPKISexp = property(__SPKISexp.value, __SPKISexp.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        __SPKISexp.name() : __SPKISexp
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__SPKISexp.name(): __SPKISexp})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.SPKIDataType = SPKIDataType
-Namespace.addCategoryObject('typeBinding', 'SPKIDataType', SPKIDataType)
+Namespace.addCategoryObject("typeBinding", "SPKIDataType", SPKIDataType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ObjectType with content type MIXED
-class ObjectType (pyxb.binding.basis.complexTypeDefinition):
+class ObjectType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ObjectType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ObjectType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 242, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ObjectType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 242, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ObjectType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 246, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 246, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ObjectType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 246, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 246, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    
     # Attribute MimeType uses Python identifier MimeType
-    __MimeType = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'MimeType'), 'MimeType', '__httpwww_w3_org200009xmldsig_ObjectType_MimeType', pyxb.binding.datatypes.string)
-    __MimeType._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 247, 2)
-    __MimeType._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 247, 2)
-    
+    __MimeType = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "MimeType"),
+        "MimeType",
+        "__httpwww_w3_org200009xmldsig_ObjectType_MimeType",
+        pyxb.binding.datatypes.string,
+    )
+    __MimeType._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 247, 2
+    )
+    __MimeType._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 247, 2
+    )
+
     MimeType = property(__MimeType.value, __MimeType.set, None, None)
 
-    
     # Attribute Encoding uses Python identifier Encoding
-    __Encoding = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Encoding'), 'Encoding', '__httpwww_w3_org200009xmldsig_ObjectType_Encoding', pyxb.binding.datatypes.anyURI)
-    __Encoding._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 248, 2)
-    __Encoding._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 248, 2)
-    
+    __Encoding = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Encoding"),
+        "Encoding",
+        "__httpwww_w3_org200009xmldsig_ObjectType_Encoding",
+        pyxb.binding.datatypes.anyURI,
+    )
+    __Encoding._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 248, 2
+    )
+    __Encoding._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 248, 2
+    )
+
     Encoding = property(__Encoding.value, __Encoding.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id,
-        __MimeType.name() : __MimeType,
-        __Encoding.name() : __Encoding
-    })
+    _ElementMap.update({})
+    _AttributeMap.update(
+        {__Id.name(): __Id, __MimeType.name(): __MimeType, __Encoding.name(): __Encoding}
+    )
+
+
 _module_typeBindings.ObjectType = ObjectType
-Namespace.addCategoryObject('typeBinding', 'ObjectType', ObjectType)
+Namespace.addCategoryObject("typeBinding", "ObjectType", ObjectType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}ManifestType with content type ELEMENT_ONLY
-class ManifestType (pyxb.binding.basis.complexTypeDefinition):
+class ManifestType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}ManifestType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ManifestType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 252, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "ManifestType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 252, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
-    __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_ManifestType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 94, 0), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
+    __Reference = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        "Reference",
+        "__httpwww_w3_org200009xmldsig_ManifestType_httpwww_w3_org200009xmldsigReference",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            94,
+            0,
+        ),
+    )
+
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ManifestType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 256, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 256, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_ManifestType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 256, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 256, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Reference.name() : __Reference
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__Reference.name(): __Reference})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.ManifestType = ManifestType
-Namespace.addCategoryObject('typeBinding', 'ManifestType', ManifestType)
+Namespace.addCategoryObject("typeBinding", "ManifestType", ManifestType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertiesType with content type ELEMENT_ONLY
-class SignaturePropertiesType (pyxb.binding.basis.complexTypeDefinition):
+class SignaturePropertiesType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertiesType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignaturePropertiesType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 260, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignaturePropertiesType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 260, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureProperty uses Python identifier SignatureProperty
-    __SignatureProperty = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), 'SignatureProperty', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_httpwww_w3_org200009xmldsigSignatureProperty', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 267, 3), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}SignatureProperty uses Python identifier SignatureProperty
+    __SignatureProperty = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+        "SignatureProperty",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertiesType_httpwww_w3_org200009xmldsigSignatureProperty",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            267,
+            3,
+        ),
+    )
+
     SignatureProperty = property(__SignatureProperty.value, __SignatureProperty.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 264, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 264, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertiesType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 264, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 264, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __SignatureProperty.name() : __SignatureProperty
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__SignatureProperty.name(): __SignatureProperty})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.SignaturePropertiesType = SignaturePropertiesType
-Namespace.addCategoryObject('typeBinding', 'SignaturePropertiesType', SignaturePropertiesType)
+Namespace.addCategoryObject("typeBinding", "SignaturePropertiesType", SignaturePropertiesType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertyType with content type MIXED
-class SignaturePropertyType (pyxb.binding.basis.complexTypeDefinition):
+class SignaturePropertyType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}SignaturePropertyType with content type MIXED"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_MIXED
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SignaturePropertyType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 268, 3)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "SignaturePropertyType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 268, 3
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Attribute Target uses Python identifier Target
-    __Target = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Target'), 'Target', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Target', pyxb.binding.datatypes.anyURI, required=True)
-    __Target._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 273, 5)
-    __Target._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 273, 5)
-    
+    __Target = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Target"),
+        "Target",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertyType_Target",
+        pyxb.binding.datatypes.anyURI,
+        required=True,
+    )
+    __Target._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 273, 5
+    )
+    __Target._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 273, 5
+    )
+
     Target = property(__Target.value, __Target.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Id', pyxb.binding.datatypes.ID)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 274, 5)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 274, 5)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_w3_org200009xmldsig_SignaturePropertyType_Id",
+        pyxb.binding.datatypes.ID,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 274, 5
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 274, 5
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
-    _ElementMap.update({
-        
-    })
-    _AttributeMap.update({
-        __Target.name() : __Target,
-        __Id.name() : __Id
-    })
+    _ElementMap.update({})
+    _AttributeMap.update({__Target.name(): __Target, __Id.name(): __Id})
+
+
 _module_typeBindings.SignaturePropertyType = SignaturePropertyType
-Namespace.addCategoryObject('typeBinding', 'SignaturePropertyType', SignaturePropertyType)
+Namespace.addCategoryObject("typeBinding", "SignaturePropertyType", SignaturePropertyType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}DSAKeyValueType with content type ELEMENT_ONLY
-class DSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class DSAKeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}DSAKeyValueType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 288, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "DSAKeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 288, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}P uses Python identifier P
-    __P = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'P'), 'P', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigP', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 291, 6), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}P uses Python identifier P
+    __P = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "P"),
+        "P",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigP",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            291,
+            6,
+        ),
+    )
+
     P = property(__P.value, __P.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Q uses Python identifier Q
-    __Q = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Q'), 'Q', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigQ', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 292, 6), )
+    __Q = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Q"),
+        "Q",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigQ",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            292,
+            6,
+        ),
+    )
 
-    
     Q = property(__Q.value, __Q.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}G uses Python identifier G
-    __G = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'G'), 'G', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigG', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 294, 4), )
+    __G = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "G"),
+        "G",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigG",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            294,
+            4,
+        ),
+    )
 
-    
     G = property(__G.value, __G.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Y uses Python identifier Y
-    __Y = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Y'), 'Y', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigY', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 295, 4), )
+    __Y = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Y"),
+        "Y",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigY",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            295,
+            4,
+        ),
+    )
 
-    
     Y = property(__Y.value, __Y.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}J uses Python identifier J
-    __J = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'J'), 'J', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigJ', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 296, 4), )
+    __J = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "J"),
+        "J",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigJ",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            296,
+            4,
+        ),
+    )
 
-    
     J = property(__J.value, __J.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Seed uses Python identifier Seed
-    __Seed = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Seed'), 'Seed', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigSeed', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 298, 6), )
+    __Seed = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Seed"),
+        "Seed",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigSeed",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            298,
+            6,
+        ),
+    )
 
-    
     Seed = property(__Seed.value, __Seed.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}PgenCounter uses Python identifier PgenCounter
-    __PgenCounter = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter'), 'PgenCounter', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigPgenCounter', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 299, 6), )
+    __PgenCounter = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PgenCounter"),
+        "PgenCounter",
+        "__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigPgenCounter",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            299,
+            6,
+        ),
+    )
 
-    
     PgenCounter = property(__PgenCounter.value, __PgenCounter.set, None, None)
 
-    _ElementMap.update({
-        __P.name() : __P,
-        __Q.name() : __Q,
-        __G.name() : __G,
-        __Y.name() : __Y,
-        __J.name() : __J,
-        __Seed.name() : __Seed,
-        __PgenCounter.name() : __PgenCounter
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __P.name(): __P,
+            __Q.name(): __Q,
+            __G.name(): __G,
+            __Y.name(): __Y,
+            __J.name(): __J,
+            __Seed.name(): __Seed,
+            __PgenCounter.name(): __PgenCounter,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.DSAKeyValueType = DSAKeyValueType
-Namespace.addCategoryObject('typeBinding', 'DSAKeyValueType', DSAKeyValueType)
+Namespace.addCategoryObject("typeBinding", "DSAKeyValueType", DSAKeyValueType)
 
 
 # Complex type {http://www.w3.org/2000/09/xmldsig#}RSAKeyValueType with content type ELEMENT_ONLY
-class RSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
+class RSAKeyValueType(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.w3.org/2000/09/xmldsig#}RSAKeyValueType with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValueType')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 305, 0)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "RSAKeyValueType")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 305, 0
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.w3.org/2000/09/xmldsig#}Modulus uses Python identifier Modulus
-    __Modulus = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Modulus'), 'Modulus', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigModulus', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 307, 4), )
 
-    
+    # Element {http://www.w3.org/2000/09/xmldsig#}Modulus uses Python identifier Modulus
+    __Modulus = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Modulus"),
+        "Modulus",
+        "__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigModulus",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            307,
+            4,
+        ),
+    )
+
     Modulus = property(__Modulus.value, __Modulus.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Exponent uses Python identifier Exponent
-    __Exponent = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Exponent'), 'Exponent', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigExponent', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 308, 4), )
+    __Exponent = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Exponent"),
+        "Exponent",
+        "__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigExponent",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            308,
+            4,
+        ),
+    )
 
-    
     Exponent = property(__Exponent.value, __Exponent.set, None, None)
 
-    _ElementMap.update({
-        __Modulus.name() : __Modulus,
-        __Exponent.name() : __Exponent
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Modulus.name(): __Modulus, __Exponent.name(): __Exponent})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.RSAKeyValueType = RSAKeyValueType
-Namespace.addCategoryObject('typeBinding', 'RSAKeyValueType', RSAKeyValueType)
+Namespace.addCategoryObject("typeBinding", "RSAKeyValueType", RSAKeyValueType)
 
 
-KeyName = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), pyxb.binding.datatypes.string, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 158, 2))
-Namespace.addCategoryObject('elementBinding', KeyName.name().localName(), KeyName)
+KeyName = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+    pyxb.binding.datatypes.string,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 158, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyName.name().localName(), KeyName)
 
-MgmtData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), pyxb.binding.datatypes.string, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 159, 2))
-Namespace.addCategoryObject('elementBinding', MgmtData.name().localName(), MgmtData)
+MgmtData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+    pyxb.binding.datatypes.string,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 159, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", MgmtData.name().localName(), MgmtData)
 
-Signature = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Signature'), SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0))
-Namespace.addCategoryObject('elementBinding', Signature.name().localName(), Signature)
+Signature = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Signature"),
+    SignatureType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 41, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Signature.name().localName(), Signature)
 
-SignatureValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), SignatureValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 52, 2))
-Namespace.addCategoryObject('elementBinding', SignatureValue.name().localName(), SignatureValue)
+SignatureValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+    SignatureValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 52, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignatureValue.name().localName(), SignatureValue)
 
-SignedInfo = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 63, 0))
-Namespace.addCategoryObject('elementBinding', SignedInfo.name().localName(), SignedInfo)
+SignedInfo = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+    SignedInfoType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 63, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignedInfo.name().localName(), SignedInfo)
 
-CanonicalizationMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), CanonicalizationMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 73, 2))
-Namespace.addCategoryObject('elementBinding', CanonicalizationMethod.name().localName(), CanonicalizationMethod)
+CanonicalizationMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+    CanonicalizationMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 73, 2
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CanonicalizationMethod.name().localName(), CanonicalizationMethod
+)
 
-SignatureMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), SignatureMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 82, 2))
-Namespace.addCategoryObject('elementBinding', SignatureMethod.name().localName(), SignatureMethod)
+SignatureMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+    SignatureMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 82, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SignatureMethod.name().localName(), SignatureMethod)
 
-Reference = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 94, 0))
-Namespace.addCategoryObject('elementBinding', Reference.name().localName(), Reference)
+Reference = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Reference"),
+    ReferenceType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 94, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Reference.name().localName(), Reference)
 
-Transforms = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 106, 2))
-Namespace.addCategoryObject('elementBinding', Transforms.name().localName(), Transforms)
+Transforms = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+    TransformsType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 106, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Transforms.name().localName(), Transforms)
 
-Transform = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transform'), TransformType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 113, 2))
-Namespace.addCategoryObject('elementBinding', Transform.name().localName(), Transform)
+Transform = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Transform"),
+    TransformType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 113, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Transform.name().localName(), Transform)
 
-DigestMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), DigestMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 125, 0))
-Namespace.addCategoryObject('elementBinding', DigestMethod.name().localName(), DigestMethod)
+DigestMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+    DigestMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 125, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DigestMethod.name().localName(), DigestMethod)
 
-DigestValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), DigestValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 133, 0))
-Namespace.addCategoryObject('elementBinding', DigestValue.name().localName(), DigestValue)
+DigestValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+    DigestValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 133, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DigestValue.name().localName(), DigestValue)
 
-KeyInfo = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 142, 0))
-Namespace.addCategoryObject('elementBinding', KeyInfo.name().localName(), KeyInfo)
+KeyInfo = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+    KeyInfoType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 142, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyInfo.name().localName(), KeyInfo)
 
-KeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 161, 2))
-Namespace.addCategoryObject('elementBinding', KeyValue.name().localName(), KeyValue)
+KeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+    KeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 161, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", KeyValue.name().localName(), KeyValue)
 
-RetrievalMethod = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), RetrievalMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 170, 2))
-Namespace.addCategoryObject('elementBinding', RetrievalMethod.name().localName(), RetrievalMethod)
+RetrievalMethod = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+    RetrievalMethodType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 170, 2
+    ),
+)
+Namespace.addCategoryObject("elementBinding", RetrievalMethod.name().localName(), RetrievalMethod)
 
-X509Data = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 181, 0))
-Namespace.addCategoryObject('elementBinding', X509Data.name().localName(), X509Data)
+X509Data = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+    X509DataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 181, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", X509Data.name().localName(), X509Data)
 
-PGPData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 206, 0))
-Namespace.addCategoryObject('elementBinding', PGPData.name().localName(), PGPData)
+PGPData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+    PGPDataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 206, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", PGPData.name().localName(), PGPData)
 
-SPKIData = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), SPKIDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 227, 0))
-Namespace.addCategoryObject('elementBinding', SPKIData.name().localName(), SPKIData)
+SPKIData = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+    SPKIDataType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 227, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", SPKIData.name().localName(), SPKIData)
 
-Object = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Object'), ObjectType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 241, 0))
-Namespace.addCategoryObject('elementBinding', Object.name().localName(), Object)
+Object = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Object"),
+    ObjectType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 241, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Object.name().localName(), Object)
 
-Manifest = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Manifest'), ManifestType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 251, 0))
-Namespace.addCategoryObject('elementBinding', Manifest.name().localName(), Manifest)
+Manifest = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "Manifest"),
+    ManifestType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 251, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", Manifest.name().localName(), Manifest)
 
-SignatureProperties = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperties'), SignaturePropertiesType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 259, 0))
-Namespace.addCategoryObject('elementBinding', SignatureProperties.name().localName(), SignatureProperties)
+SignatureProperties = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureProperties"),
+    SignaturePropertiesType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 259, 0
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SignatureProperties.name().localName(), SignatureProperties
+)
 
-SignatureProperty = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), SignaturePropertyType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 267, 3))
-Namespace.addCategoryObject('elementBinding', SignatureProperty.name().localName(), SignatureProperty)
+SignatureProperty = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+    SignaturePropertyType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 267, 3
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", SignatureProperty.name().localName(), SignatureProperty
+)
 
-DSAKeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 287, 0))
-Namespace.addCategoryObject('elementBinding', DSAKeyValue.name().localName(), DSAKeyValue)
+DSAKeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+    DSAKeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 287, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", DSAKeyValue.name().localName(), DSAKeyValue)
 
-RSAKeyValue = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 304, 0))
-Namespace.addCategoryObject('elementBinding', RSAKeyValue.name().localName(), RSAKeyValue)
+RSAKeyValue = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+    RSAKeyValueType,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd", 304, 0
+    ),
+)
+Namespace.addCategoryObject("elementBinding", RSAKeyValue.name().localName(), RSAKeyValue)
 
 
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureValue"),
+        SignatureValueType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            52,
+            2,
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), SignatureValueType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 52, 2)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignedInfo"),
+        SignedInfoType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            63,
+            0,
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), SignedInfoType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 63, 0)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyInfo"),
+        KeyInfoType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            142,
+            0,
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), KeyInfoType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 142, 0)))
+SignatureType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Object"),
+        ObjectType,
+        scope=SignatureType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            241,
+            0,
+        ),
+    )
+)
 
-SignatureType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Object'), ObjectType, scope=SignatureType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 241, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 46, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            46,
+            4,
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 47, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            47,
+            4,
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 44, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignedInfo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            44,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 45, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignatureValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            45,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 46, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyInfo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            46,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Object')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 47, 4))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Object")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            47,
+            4,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, True)]))
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignatureType._Automaton = _BuildAutomaton()
 
 
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod"),
+        CanonicalizationMethodType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            73,
+            2,
+        ),
+    )
+)
+
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureMethod"),
+        SignatureMethodType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            82,
+            2,
+        ),
+    )
+)
+
+SignedInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        ReferenceType,
+        scope=SignedInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            94,
+            0,
+        ),
+    )
+)
 
 
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), CanonicalizationMethodType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 73, 2)))
-
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), SignatureMethodType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 82, 2)))
-
-SignedInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, scope=SignedInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 94, 0)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
@@ -1246,149 +2124,319 @@ def _BuildAutomaton_ ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 66, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CanonicalizationMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            66,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 67, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SignatureMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            67,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Reference')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 68, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignedInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Reference")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            68,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignedInfoType._Automaton = _BuildAutomaton_()
 
 
-
-
-def _BuildAutomaton_2 ():
+def _BuildAutomaton_2():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_2
     del _BuildAutomaton_2
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 76, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            76,
+            6,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_strict, namespace_constraint=pyxb.binding.content.Wildcard.NC_any), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 76, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_strict,
+            namespace_constraint=pyxb.binding.content.Wildcard.NC_any,
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            76,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 CanonicalizationMethodType._Automaton = _BuildAutomaton_2()
 
 
+SignatureMethodType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength"),
+        HMACOutputLengthType,
+        scope=SignatureMethodType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            85,
+            6,
+        ),
+    )
+)
 
 
-SignatureMethodType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength'), HMACOutputLengthType, scope=SignatureMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 85, 6)))
-
-def _BuildAutomaton_3 ():
+def _BuildAutomaton_3():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_3
     del _BuildAutomaton_3
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 85, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            85,
+            6,
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 86, 6))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            86,
+            6,
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(SignatureMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 85, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignatureMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "HMACOutputLength")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            85,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_strict, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 86, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_strict,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            86,
+            6,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 SignatureMethodType._Automaton = _BuildAutomaton_3()
 
 
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        TransformsType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            106,
+            2,
+        ),
+    )
+)
+
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DigestMethod"),
+        DigestMethodType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            125,
+            0,
+        ),
+    )
+)
+
+ReferenceType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DigestValue"),
+        DigestValueType,
+        scope=ReferenceType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            133,
+            0,
+        ),
+    )
+)
 
 
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 106, 2)))
-
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), DigestMethodType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 125, 0)))
-
-ReferenceType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), DigestValueType, scope=ReferenceType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 133, 0)))
-
-def _BuildAutomaton_4 ():
+def _BuildAutomaton_4():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_4
     del _BuildAutomaton_4
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 97, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            97,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transforms')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 97, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transforms")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            97,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 98, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DigestMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            98,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DigestValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 99, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ReferenceType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DigestValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            99,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 ReferenceType._Automaton = _BuildAutomaton_4()
 
 
+TransformsType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transform"),
+        TransformType,
+        scope=TransformsType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            113,
+            2,
+        ),
+    )
+)
 
 
-TransformsType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transform'), TransformType, scope=TransformsType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 113, 2)))
-
-def _BuildAutomaton_5 ():
+def _BuildAutomaton_5():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_5
     del _BuildAutomaton_5
@@ -1397,99 +2445,247 @@ def _BuildAutomaton_5 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(TransformsType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transform')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 109, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        TransformsType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transform")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            109,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 TransformsType._Automaton = _BuildAutomaton_5()
 
 
+TransformType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "XPath"),
+        pyxb.binding.datatypes.string,
+        scope=TransformType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            118,
+            6,
+        ),
+    )
+)
 
 
-TransformType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'XPath'), pyxb.binding.datatypes.string, scope=TransformType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 118, 6)))
-
-def _BuildAutomaton_6 ():
+def _BuildAutomaton_6():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_6
     del _BuildAutomaton_6
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 115, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            115,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 116, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            116,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(TransformType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'XPath')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 118, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        TransformType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "XPath")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            118,
+            6,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 TransformType._Automaton = _BuildAutomaton_6()
 
 
-
-
-def _BuildAutomaton_7 ():
+def _BuildAutomaton_7():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_7
     del _BuildAutomaton_7
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 128, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            128,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 128, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            128,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 DigestMethodType._Automaton = _BuildAutomaton_7()
 
 
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyName"),
+        pyxb.binding.datatypes.string,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            158,
+            2,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MgmtData"),
+        pyxb.binding.datatypes.string,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            159,
+            2,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "KeyValue"),
+        KeyValueType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            161,
+            2,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod"),
+        RetrievalMethodType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            170,
+            2,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509Data"),
+        X509DataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            181,
+            0,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPData"),
+        PGPDataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            206,
+            0,
+        ),
+    )
+)
+
+KeyInfoType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SPKIData"),
+        SPKIDataType,
+        scope=KeyInfoType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            227,
+            0,
+        ),
+    )
+)
 
 
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), pyxb.binding.datatypes.string, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 158, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), pyxb.binding.datatypes.string, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 159, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), KeyValueType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 161, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), RetrievalMethodType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 170, 2)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), X509DataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 181, 0)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), PGPDataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 206, 0)))
-
-KeyInfoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), SPKIDataType, scope=KeyInfoType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 227, 0)))
-
-def _BuildAutomaton_8 ():
+def _BuildAutomaton_8():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_8
     del _BuildAutomaton_8
@@ -1498,192 +2694,229 @@ def _BuildAutomaton_8 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 145, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            145,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'KeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 146, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "KeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            146,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 147, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RetrievalMethod")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            147,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509Data')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 148, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509Data")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            148,
+            4,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 149, 4))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            149,
+            4,
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SPKIData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 150, 4))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SPKIData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            150,
+            4,
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MgmtData')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 151, 4))
-    st_6 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyInfoType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MgmtData")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            151,
+            4,
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 152, 4))
-    st_7 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            152,
+            4,
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_7._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 KeyInfoType._Automaton = _BuildAutomaton_8()
 
 
+KeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue"),
+        DSAKeyValueType,
+        scope=KeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            287,
+            0,
+        ),
+    )
+)
+
+KeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue"),
+        RSAKeyValueType,
+        scope=KeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            304,
+            0,
+        ),
+    )
+)
 
 
-KeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), DSAKeyValueType, scope=KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 287, 0)))
-
-KeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), RSAKeyValueType, scope=KeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 304, 0)))
-
-def _BuildAutomaton_9 ():
+def _BuildAutomaton_9():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_9
     del _BuildAutomaton_9
@@ -1692,16 +2925,49 @@ def _BuildAutomaton_9 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 164, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DSAKeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            164,
+            5,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 165, 5))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        KeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RSAKeyValue")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            165,
+            5,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 166, 5))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            166,
+            5,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
     st_0._set_transitionSet(transitions)
@@ -1710,49 +2976,133 @@ def _BuildAutomaton_9 ():
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 KeyValueType._Automaton = _BuildAutomaton_9()
 
 
+RetrievalMethodType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Transforms"),
+        TransformsType,
+        scope=RetrievalMethodType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            106,
+            2,
+        ),
+    )
+)
 
 
-RetrievalMethodType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), TransformsType, scope=RetrievalMethodType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 106, 2)))
-
-def _BuildAutomaton_10 ():
+def _BuildAutomaton_10():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_10
     del _BuildAutomaton_10
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 173, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            173,
+            6,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(RetrievalMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Transforms')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 173, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RetrievalMethodType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Transforms")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            173,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 RetrievalMethodType._Automaton = _BuildAutomaton_10()
 
 
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial"),
+        X509IssuerSerialType,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            185,
+            6,
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SKI"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            186,
+            6,
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SubjectName"),
+        pyxb.binding.datatypes.string,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            187,
+            6,
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509Certificate"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            188,
+            6,
+        ),
+    )
+)
+
+X509DataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509CRL"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=X509DataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            189,
+            6,
+        ),
+    )
+)
 
 
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial'), X509IssuerSerialType, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 185, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SKI'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 186, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName'), pyxb.binding.datatypes.string, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 187, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 188, 6)))
-
-X509DataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509CRL'), pyxb.binding.datatypes.base64Binary, scope=X509DataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 189, 6)))
-
-def _BuildAutomaton_11 ():
+def _BuildAutomaton_11():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_11
     del _BuildAutomaton_11
@@ -1761,124 +3111,171 @@ def _BuildAutomaton_11 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 185, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509IssuerSerial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            185,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SKI')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 186, 6))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SKI")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            186,
+            6,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 187, 6))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SubjectName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            187,
+            6,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 188, 6))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509Certificate")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            188,
+            6,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509CRL')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 189, 6))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509DataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509CRL")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            189,
+            6,
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 190, 6))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            190,
+            6,
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_5._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 X509DataType._Automaton = _BuildAutomaton_11()
 
 
+X509IssuerSerialType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509IssuerName"),
+        pyxb.binding.datatypes.string,
+        scope=X509IssuerSerialType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            197,
+            4,
+        ),
+    )
+)
+
+X509IssuerSerialType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber"),
+        pyxb.binding.datatypes.integer,
+        scope=X509IssuerSerialType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            198,
+            4,
+        ),
+    )
+)
 
 
-X509IssuerSerialType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName'), pyxb.binding.datatypes.string, scope=X509IssuerSerialType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 197, 4)))
-
-X509IssuerSerialType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber'), pyxb.binding.datatypes.integer, scope=X509IssuerSerialType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 198, 4)))
-
-def _BuildAutomaton_12 ():
+def _BuildAutomaton_12():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_12
     del _BuildAutomaton_12
@@ -1887,163 +3284,348 @@ def _BuildAutomaton_12 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 197, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509IssuerName")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            197,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 198, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        X509IssuerSerialType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "X509SerialNumber")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            198,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 X509IssuerSerialType._Automaton = _BuildAutomaton_12()
 
 
+PGPDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyID"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=PGPDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            210,
+            6,
+        ),
+    )
+)
+
+PGPDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=PGPDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            211,
+            6,
+        ),
+    )
+)
 
 
-PGPDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID'), pyxb.binding.datatypes.base64Binary, scope=PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 210, 6)))
-
-PGPDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket'), pyxb.binding.datatypes.base64Binary, scope=PGPDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 211, 6)))
-
-def _BuildAutomaton_13 ():
+def _BuildAutomaton_13():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_13
     del _BuildAutomaton_13
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 211, 6))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            211,
+            6,
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 212, 6))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            212,
+            6,
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 217, 6))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            217,
+            6,
+        ),
+    )
     counters.add(cc_2)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 210, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyID")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            210,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 211, 6))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            211,
+            6,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 212, 6))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            212,
+            6,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 216, 6))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        PGPDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PGPKeyPacket")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            216,
+            6,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 217, 6))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            217,
+            6,
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, True) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, True)]))
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 PGPDataType._Automaton = _BuildAutomaton_13()
 
 
+SPKIDataType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SPKISexp"),
+        pyxb.binding.datatypes.base64Binary,
+        scope=SPKIDataType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            230,
+            4,
+        ),
+    )
+)
 
 
-SPKIDataType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp'), pyxb.binding.datatypes.base64Binary, scope=SPKIDataType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 230, 4)))
-
-def _BuildAutomaton_14 ():
+def _BuildAutomaton_14():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_14
     del _BuildAutomaton_14
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 231, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            231,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SPKIDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 230, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SPKIDataType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SPKISexp")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            230,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 231, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            231,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SPKIDataType._Automaton = _BuildAutomaton_14()
 
 
-
-
-def _BuildAutomaton_15 ():
+def _BuildAutomaton_15():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_15
     del _BuildAutomaton_15
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 243, 2))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            243,
+            2,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=pyxb.binding.content.Wildcard.NC_any), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 244, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=pyxb.binding.content.Wildcard.NC_any,
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            244,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 ObjectType._Automaton = _BuildAutomaton_15()
 
 
+ManifestType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Reference"),
+        ReferenceType,
+        scope=ManifestType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            94,
+            0,
+        ),
+    )
+)
 
 
-ManifestType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Reference'), ReferenceType, scope=ManifestType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 94, 0)))
-
-def _BuildAutomaton_16 ():
+def _BuildAutomaton_16():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_16
     del _BuildAutomaton_16
@@ -2052,22 +3634,42 @@ def _BuildAutomaton_16 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(ManifestType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Reference')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 254, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        ManifestType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Reference")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            254,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 ManifestType._Automaton = _BuildAutomaton_16()
 
 
+SignaturePropertiesType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SignatureProperty"),
+        SignaturePropertyType,
+        scope=SignaturePropertiesType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            267,
+            3,
+        ),
+    )
+)
 
 
-SignaturePropertiesType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), SignaturePropertyType, scope=SignaturePropertiesType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 267, 3)))
-
-def _BuildAutomaton_17 ():
+def _BuildAutomaton_17():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_17
     del _BuildAutomaton_17
@@ -2076,20 +3678,30 @@ def _BuildAutomaton_17 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(SignaturePropertiesType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 262, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        SignaturePropertiesType._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "SignatureProperty")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            262,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignaturePropertiesType._Automaton = _BuildAutomaton_17()
 
 
-
-
-def _BuildAutomaton_18 ():
+def _BuildAutomaton_18():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_18
     del _BuildAutomaton_18
@@ -2098,128 +3710,326 @@ def _BuildAutomaton_18 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.WildcardUse(pyxb.binding.content.Wildcard(process_contents=pyxb.binding.content.Wildcard.PC_lax, namespace_constraint=(pyxb.binding.content.Wildcard.NC_not, 'http://www.w3.org/2000/09/xmldsig#')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 270, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.WildcardUse(
+        pyxb.binding.content.Wildcard(
+            process_contents=pyxb.binding.content.Wildcard.PC_lax,
+            namespace_constraint=(
+                pyxb.binding.content.Wildcard.NC_not,
+                "http://www.w3.org/2000/09/xmldsig#",
+            ),
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            270,
+            7,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 SignaturePropertyType._Automaton = _BuildAutomaton_18()
 
 
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "P"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            291,
+            6,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Q"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            292,
+            6,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "G"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            294,
+            4,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Y"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            295,
+            4,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "J"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            296,
+            4,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Seed"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            298,
+            6,
+        ),
+    )
+)
+
+DSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PgenCounter"),
+        CryptoBinary,
+        scope=DSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            299,
+            6,
+        ),
+    )
+)
 
 
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'P'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 291, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Q'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 292, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'G'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 294, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Y'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 295, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'J'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 296, 4)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Seed'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 298, 6)))
-
-DSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter'), CryptoBinary, scope=DSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 299, 6)))
-
-def _BuildAutomaton_19 ():
+def _BuildAutomaton_19():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_19
     del _BuildAutomaton_19
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 290, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            290,
+            4,
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 294, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            294,
+            4,
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 296, 4))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            296,
+            4,
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 297, 4))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            297,
+            4,
+        ),
+    )
     counters.add(cc_3)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'P')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 291, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "P")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            291,
+            6,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Q')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 292, 6))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Q")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            292,
+            6,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'G')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 294, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "G")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            294,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Y')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 295, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Y")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            295,
+            4,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'J')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 296, 4))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "J")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            296,
+            4,
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Seed')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 298, 6))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Seed")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            298,
+            6,
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 299, 6))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        DSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PgenCounter")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            299,
+            6,
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-         ]))
+    transitions.append(fac.Transition(st_6, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, True) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, True)]))
     st_6._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 DSAKeyValueType._Automaton = _BuildAutomaton_19()
 
 
+RSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Modulus"),
+        CryptoBinary,
+        scope=RSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            307,
+            4,
+        ),
+    )
+)
+
+RSAKeyValueType._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Exponent"),
+        CryptoBinary,
+        scope=RSAKeyValueType,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            308,
+            4,
+        ),
+    )
+)
 
 
-RSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Modulus'), CryptoBinary, scope=RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 307, 4)))
-
-RSAKeyValueType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Exponent'), CryptoBinary, scope=RSAKeyValueType, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 308, 4)))
-
-def _BuildAutomaton_20 ():
+def _BuildAutomaton_20():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_20
     del _BuildAutomaton_20
@@ -2228,19 +4038,37 @@ def _BuildAutomaton_20 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Modulus')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 307, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Modulus")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            307,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Exponent')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 308, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        RSAKeyValueType._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Exponent")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            308,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-RSAKeyValueType._Automaton = _BuildAutomaton_20()
 
+
+RSAKeyValueType._Automaton = _BuildAutomaton_20()

--- a/pynfe/utils/nfse/ginfes/_tipos.py
+++ b/pynfe/utils/nfse/ginfes/_tipos.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:9559ba2f-ca50-4313-910d-fe9d437f0e44')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:9559ba2f-ca50-4313-910d-fe9d437f0e44"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _dsig as _ImportedBinding__dsig
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/tipos_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/tipos_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,2383 +98,3744 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroNfse
-class tsNumeroNfse (pyxb.binding.datatypes.nonNegativeInteger):
-
+class tsNumeroNfse(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 4, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 4, 1
+    )
     _Documentation = None
-tsNumeroNfse._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
-tsNumeroNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroNfse._InitializeFacetMap(tsNumeroNfse._CF_totalDigits,
-   tsNumeroNfse._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroNfse', tsNumeroNfse)
+
+
+tsNumeroNfse._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
+tsNumeroNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroNfse._InitializeFacetMap(tsNumeroNfse._CF_totalDigits, tsNumeroNfse._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsNumeroNfse", tsNumeroNfse)
 _module_typeBindings.tsNumeroNfse = tsNumeroNfse
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoVerificacao
-class tsCodigoVerificacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoVerificacao
+class tsCodigoVerificacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoVerificacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 10, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoVerificacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 10, 1
+    )
     _Documentation = None
-tsCodigoVerificacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(9))
-tsCodigoVerificacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoVerificacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoVerificacao._InitializeFacetMap(tsCodigoVerificacao._CF_maxLength,
-   tsCodigoVerificacao._CF_minLength,
-   tsCodigoVerificacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoVerificacao', tsCodigoVerificacao)
+
+
+tsCodigoVerificacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(9)
+)
+tsCodigoVerificacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoVerificacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoVerificacao._InitializeFacetMap(
+    tsCodigoVerificacao._CF_maxLength,
+    tsCodigoVerificacao._CF_minLength,
+    tsCodigoVerificacao._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoVerificacao", tsCodigoVerificacao)
 _module_typeBindings.tsCodigoVerificacao = tsCodigoVerificacao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsStatusRps
-class tsStatusRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsStatusRps
+class tsStatusRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsStatusRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 17, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsStatusRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 17, 1
+    )
     _Documentation = None
+
+
 tsStatusRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsStatusRps._CF_pattern.addPattern(pattern='1|2')
-tsStatusRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsStatusRps._InitializeFacetMap(tsStatusRps._CF_pattern,
-   tsStatusRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsStatusRps', tsStatusRps)
+tsStatusRps._CF_pattern.addPattern(pattern="1|2")
+tsStatusRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsStatusRps._InitializeFacetMap(tsStatusRps._CF_pattern, tsStatusRps._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsStatusRps", tsStatusRps)
 _module_typeBindings.tsStatusRps = tsStatusRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsStatusNfse
-class tsStatusNfse (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsStatusNfse
+class tsStatusNfse(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsStatusNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 23, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsStatusNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 23, 1
+    )
     _Documentation = None
+
+
 tsStatusNfse._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsStatusNfse._CF_pattern.addPattern(pattern='1|2')
-tsStatusNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsStatusNfse._InitializeFacetMap(tsStatusNfse._CF_pattern,
-   tsStatusNfse._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsStatusNfse', tsStatusNfse)
+tsStatusNfse._CF_pattern.addPattern(pattern="1|2")
+tsStatusNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsStatusNfse._InitializeFacetMap(tsStatusNfse._CF_pattern, tsStatusNfse._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsStatusNfse", tsStatusNfse)
 _module_typeBindings.tsStatusNfse = tsStatusNfse
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNaturezaOperacao
-class tsNaturezaOperacao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNaturezaOperacao
+class tsNaturezaOperacao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNaturezaOperacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 29, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNaturezaOperacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 29, 1
+    )
     _Documentation = None
+
+
 tsNaturezaOperacao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsNaturezaOperacao._CF_pattern.addPattern(pattern='1|2|3|4|5|6')
-tsNaturezaOperacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNaturezaOperacao._InitializeFacetMap(tsNaturezaOperacao._CF_pattern,
-   tsNaturezaOperacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNaturezaOperacao', tsNaturezaOperacao)
+tsNaturezaOperacao._CF_pattern.addPattern(pattern="1|2|3|4|5|6")
+tsNaturezaOperacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNaturezaOperacao._InitializeFacetMap(
+    tsNaturezaOperacao._CF_pattern, tsNaturezaOperacao._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNaturezaOperacao", tsNaturezaOperacao)
 _module_typeBindings.tsNaturezaOperacao = tsNaturezaOperacao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsRegimeEspecialTributacao
-class tsRegimeEspecialTributacao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsRegimeEspecialTributacao
+class tsRegimeEspecialTributacao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsRegimeEspecialTributacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 35, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsRegimeEspecialTributacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 35, 1
+    )
     _Documentation = None
+
+
 tsRegimeEspecialTributacao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsRegimeEspecialTributacao._CF_pattern.addPattern(pattern='1|2|3|4|5|6')
-tsRegimeEspecialTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsRegimeEspecialTributacao._InitializeFacetMap(tsRegimeEspecialTributacao._CF_pattern,
-   tsRegimeEspecialTributacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsRegimeEspecialTributacao', tsRegimeEspecialTributacao)
+tsRegimeEspecialTributacao._CF_pattern.addPattern(pattern="1|2|3|4|5|6")
+tsRegimeEspecialTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsRegimeEspecialTributacao._InitializeFacetMap(
+    tsRegimeEspecialTributacao._CF_pattern, tsRegimeEspecialTributacao._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsRegimeEspecialTributacao", tsRegimeEspecialTributacao)
 _module_typeBindings.tsRegimeEspecialTributacao = tsRegimeEspecialTributacao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSimNao
-class tsSimNao (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSimNao
+class tsSimNao(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSimNao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 41, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSimNao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 41, 1
+    )
     _Documentation = None
+
+
 tsSimNao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsSimNao._CF_pattern.addPattern(pattern='1|2')
-tsSimNao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsSimNao._InitializeFacetMap(tsSimNao._CF_pattern,
-   tsSimNao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsSimNao', tsSimNao)
+tsSimNao._CF_pattern.addPattern(pattern="1|2")
+tsSimNao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsSimNao._InitializeFacetMap(tsSimNao._CF_pattern, tsSimNao._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsSimNao", tsSimNao)
 _module_typeBindings.tsSimNao = tsSimNao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroRps
-class tsNumeroRps (pyxb.binding.datatypes.nonNegativeInteger):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroRps
+class tsNumeroRps(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 47, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 47, 1
+    )
     _Documentation = None
-tsNumeroRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
-tsNumeroRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroRps._InitializeFacetMap(tsNumeroRps._CF_totalDigits,
-   tsNumeroRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroRps', tsNumeroRps)
+
+
+tsNumeroRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
+tsNumeroRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroRps._InitializeFacetMap(tsNumeroRps._CF_totalDigits, tsNumeroRps._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsNumeroRps", tsNumeroRps)
 _module_typeBindings.tsNumeroRps = tsNumeroRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSerieRps
-class tsSerieRps (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSerieRps
+class tsSerieRps(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSerieRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 53, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSerieRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 53, 1
+    )
     _Documentation = None
-tsSerieRps._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(5))
-tsSerieRps._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsSerieRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsSerieRps._InitializeFacetMap(tsSerieRps._CF_maxLength,
-   tsSerieRps._CF_minLength,
-   tsSerieRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsSerieRps', tsSerieRps)
+
+
+tsSerieRps._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(5)
+)
+tsSerieRps._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsSerieRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsSerieRps._InitializeFacetMap(
+    tsSerieRps._CF_maxLength, tsSerieRps._CF_minLength, tsSerieRps._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsSerieRps", tsSerieRps)
 _module_typeBindings.tsSerieRps = tsSerieRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsTipoRps
-class tsTipoRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsTipoRps
+class tsTipoRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsTipoRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 60, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsTipoRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 60, 1
+    )
     _Documentation = None
+
+
 tsTipoRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsTipoRps._CF_pattern.addPattern(pattern='1|2|3')
-tsTipoRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsTipoRps._InitializeFacetMap(tsTipoRps._CF_pattern,
-   tsTipoRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsTipoRps', tsTipoRps)
+tsTipoRps._CF_pattern.addPattern(pattern="1|2|3")
+tsTipoRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsTipoRps._InitializeFacetMap(tsTipoRps._CF_pattern, tsTipoRps._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsTipoRps", tsTipoRps)
 _module_typeBindings.tsTipoRps = tsTipoRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsOutrasInformacoes
-class tsOutrasInformacoes (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsOutrasInformacoes
+class tsOutrasInformacoes(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsOutrasInformacoes')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 66, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsOutrasInformacoes")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 66, 1
+    )
     _Documentation = None
-tsOutrasInformacoes._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(255))
-tsOutrasInformacoes._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsOutrasInformacoes._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsOutrasInformacoes._InitializeFacetMap(tsOutrasInformacoes._CF_maxLength,
-   tsOutrasInformacoes._CF_minLength,
-   tsOutrasInformacoes._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsOutrasInformacoes', tsOutrasInformacoes)
+
+
+tsOutrasInformacoes._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(255)
+)
+tsOutrasInformacoes._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsOutrasInformacoes._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsOutrasInformacoes._InitializeFacetMap(
+    tsOutrasInformacoes._CF_maxLength,
+    tsOutrasInformacoes._CF_minLength,
+    tsOutrasInformacoes._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsOutrasInformacoes", tsOutrasInformacoes)
 _module_typeBindings.tsOutrasInformacoes = tsOutrasInformacoes
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsValor
-class tsValor (pyxb.binding.datatypes.decimal):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsValor
+class tsValor(pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsValor')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 73, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsValor")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 73, 1
+    )
     _Documentation = None
-tsValor._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(value=pyxb.binding.datatypes.nonNegativeInteger(2))
-tsValor._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value=pyxb.binding.datatypes.decimal('0.0'), value_datatype=tsValor)
-tsValor._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
-tsValor._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsValor._InitializeFacetMap(tsValor._CF_fractionDigits,
-   tsValor._CF_minInclusive,
-   tsValor._CF_totalDigits,
-   tsValor._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsValor', tsValor)
+
+
+tsValor._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(
+    value=pyxb.binding.datatypes.nonNegativeInteger(2)
+)
+tsValor._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(
+    value=pyxb.binding.datatypes.decimal("0.0"), value_datatype=tsValor
+)
+tsValor._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
+tsValor._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsValor._InitializeFacetMap(
+    tsValor._CF_fractionDigits,
+    tsValor._CF_minInclusive,
+    tsValor._CF_totalDigits,
+    tsValor._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsValor", tsValor)
 _module_typeBindings.tsValor = tsValor
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsItemListaServico
-class tsItemListaServico (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsItemListaServico
+class tsItemListaServico(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsItemListaServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 81, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsItemListaServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 81, 1
+    )
     _Documentation = None
-tsItemListaServico._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(5))
-tsItemListaServico._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsItemListaServico._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsItemListaServico._InitializeFacetMap(tsItemListaServico._CF_maxLength,
-   tsItemListaServico._CF_minLength,
-   tsItemListaServico._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsItemListaServico', tsItemListaServico)
+
+
+tsItemListaServico._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(5)
+)
+tsItemListaServico._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsItemListaServico._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsItemListaServico._InitializeFacetMap(
+    tsItemListaServico._CF_maxLength,
+    tsItemListaServico._CF_minLength,
+    tsItemListaServico._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsItemListaServico", tsItemListaServico)
 _module_typeBindings.tsItemListaServico = tsItemListaServico
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoCnae
-class tsCodigoCnae (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoCnae
+class tsCodigoCnae(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoCnae')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 88, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoCnae")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 88, 1
+    )
     _Documentation = None
-tsCodigoCnae._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(7))
-tsCodigoCnae._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoCnae._InitializeFacetMap(tsCodigoCnae._CF_totalDigits,
-   tsCodigoCnae._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoCnae', tsCodigoCnae)
+
+
+tsCodigoCnae._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(7)
+)
+tsCodigoCnae._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoCnae._InitializeFacetMap(tsCodigoCnae._CF_totalDigits, tsCodigoCnae._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsCodigoCnae", tsCodigoCnae)
 _module_typeBindings.tsCodigoCnae = tsCodigoCnae
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoTributacao
-class tsCodigoTributacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoTributacao
+class tsCodigoTributacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoTributacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 94, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoTributacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 94, 1
+    )
     _Documentation = None
-tsCodigoTributacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(20))
-tsCodigoTributacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoTributacao._InitializeFacetMap(tsCodigoTributacao._CF_maxLength,
-   tsCodigoTributacao._CF_minLength,
-   tsCodigoTributacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoTributacao', tsCodigoTributacao)
+
+
+tsCodigoTributacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(20)
+)
+tsCodigoTributacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoTributacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoTributacao._InitializeFacetMap(
+    tsCodigoTributacao._CF_maxLength,
+    tsCodigoTributacao._CF_minLength,
+    tsCodigoTributacao._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoTributacao", tsCodigoTributacao)
 _module_typeBindings.tsCodigoTributacao = tsCodigoTributacao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsAliquota
-class tsAliquota (pyxb.binding.datatypes.decimal):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsAliquota
+class tsAliquota(pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsAliquota')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 101, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsAliquota")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 101, 1
+    )
     _Documentation = None
-tsAliquota._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsAliquota._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value=pyxb.binding.datatypes.decimal('0.0'), value_datatype=tsAliquota)
-tsAliquota._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(5))
-tsAliquota._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsAliquota._InitializeFacetMap(tsAliquota._CF_fractionDigits,
-   tsAliquota._CF_minInclusive,
-   tsAliquota._CF_totalDigits,
-   tsAliquota._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsAliquota', tsAliquota)
+
+
+tsAliquota._CF_fractionDigits = pyxb.binding.facets.CF_fractionDigits(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsAliquota._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(
+    value=pyxb.binding.datatypes.decimal("0.0"), value_datatype=tsAliquota
+)
+tsAliquota._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(5)
+)
+tsAliquota._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsAliquota._InitializeFacetMap(
+    tsAliquota._CF_fractionDigits,
+    tsAliquota._CF_minInclusive,
+    tsAliquota._CF_totalDigits,
+    tsAliquota._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsAliquota", tsAliquota)
 _module_typeBindings.tsAliquota = tsAliquota
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsDiscriminacao
-class tsDiscriminacao (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsDiscriminacao
+class tsDiscriminacao(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsDiscriminacao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 109, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsDiscriminacao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 109, 1
+    )
     _Documentation = None
-tsDiscriminacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(2000))
-tsDiscriminacao._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsDiscriminacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsDiscriminacao._InitializeFacetMap(tsDiscriminacao._CF_maxLength,
-   tsDiscriminacao._CF_minLength,
-   tsDiscriminacao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsDiscriminacao', tsDiscriminacao)
+
+
+tsDiscriminacao._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(2000)
+)
+tsDiscriminacao._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsDiscriminacao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsDiscriminacao._InitializeFacetMap(
+    tsDiscriminacao._CF_maxLength, tsDiscriminacao._CF_minLength, tsDiscriminacao._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsDiscriminacao", tsDiscriminacao)
 _module_typeBindings.tsDiscriminacao = tsDiscriminacao
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoMunicipioIbge
-class tsCodigoMunicipioIbge (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoMunicipioIbge
+class tsCodigoMunicipioIbge(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoMunicipioIbge')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 116, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoMunicipioIbge")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 116, 1
+    )
     _Documentation = None
-tsCodigoMunicipioIbge._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(7))
-tsCodigoMunicipioIbge._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoMunicipioIbge._InitializeFacetMap(tsCodigoMunicipioIbge._CF_totalDigits,
-   tsCodigoMunicipioIbge._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoMunicipioIbge', tsCodigoMunicipioIbge)
+
+
+tsCodigoMunicipioIbge._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(7)
+)
+tsCodigoMunicipioIbge._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoMunicipioIbge._InitializeFacetMap(
+    tsCodigoMunicipioIbge._CF_totalDigits, tsCodigoMunicipioIbge._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoMunicipioIbge", tsCodigoMunicipioIbge)
 _module_typeBindings.tsCodigoMunicipioIbge = tsCodigoMunicipioIbge
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsInscricaoMunicipal
-class tsInscricaoMunicipal (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsInscricaoMunicipal
+class tsInscricaoMunicipal(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsInscricaoMunicipal')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 122, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsInscricaoMunicipal")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 122, 1
+    )
     _Documentation = None
-tsInscricaoMunicipal._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsInscricaoMunicipal._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsInscricaoMunicipal._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsInscricaoMunicipal._InitializeFacetMap(tsInscricaoMunicipal._CF_maxLength,
-   tsInscricaoMunicipal._CF_minLength,
-   tsInscricaoMunicipal._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsInscricaoMunicipal', tsInscricaoMunicipal)
+
+
+tsInscricaoMunicipal._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsInscricaoMunicipal._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsInscricaoMunicipal._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsInscricaoMunicipal._InitializeFacetMap(
+    tsInscricaoMunicipal._CF_maxLength,
+    tsInscricaoMunicipal._CF_minLength,
+    tsInscricaoMunicipal._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsInscricaoMunicipal", tsInscricaoMunicipal)
 _module_typeBindings.tsInscricaoMunicipal = tsInscricaoMunicipal
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsRazaoSocial
-class tsRazaoSocial (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsRazaoSocial
+class tsRazaoSocial(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsRazaoSocial')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 129, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsRazaoSocial")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 129, 1
+    )
     _Documentation = None
-tsRazaoSocial._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(115))
-tsRazaoSocial._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsRazaoSocial._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsRazaoSocial._InitializeFacetMap(tsRazaoSocial._CF_maxLength,
-   tsRazaoSocial._CF_minLength,
-   tsRazaoSocial._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsRazaoSocial', tsRazaoSocial)
+
+
+tsRazaoSocial._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(115)
+)
+tsRazaoSocial._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsRazaoSocial._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsRazaoSocial._InitializeFacetMap(
+    tsRazaoSocial._CF_maxLength, tsRazaoSocial._CF_minLength, tsRazaoSocial._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsRazaoSocial", tsRazaoSocial)
 _module_typeBindings.tsRazaoSocial = tsRazaoSocial
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNomeFantasia
-class tsNomeFantasia (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNomeFantasia
+class tsNomeFantasia(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNomeFantasia')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 136, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNomeFantasia")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 136, 1
+    )
     _Documentation = None
-tsNomeFantasia._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsNomeFantasia._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsNomeFantasia._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNomeFantasia._InitializeFacetMap(tsNomeFantasia._CF_maxLength,
-   tsNomeFantasia._CF_minLength,
-   tsNomeFantasia._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNomeFantasia', tsNomeFantasia)
+
+
+tsNomeFantasia._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsNomeFantasia._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsNomeFantasia._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNomeFantasia._InitializeFacetMap(
+    tsNomeFantasia._CF_maxLength, tsNomeFantasia._CF_minLength, tsNomeFantasia._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNomeFantasia", tsNomeFantasia)
 _module_typeBindings.tsNomeFantasia = tsNomeFantasia
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCnpj
-class tsCnpj (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCnpj
+class tsCnpj(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCnpj')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 143, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCnpj")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 143, 1
+    )
     _Documentation = None
-tsCnpj._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(14))
-tsCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCnpj._InitializeFacetMap(tsCnpj._CF_length,
-   tsCnpj._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCnpj', tsCnpj)
+
+
+tsCnpj._CF_length = pyxb.binding.facets.CF_length(
+    value=pyxb.binding.datatypes.nonNegativeInteger(14)
+)
+tsCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCnpj._InitializeFacetMap(tsCnpj._CF_length, tsCnpj._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsCnpj", tsCnpj)
 _module_typeBindings.tsCnpj = tsCnpj
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsEndereco
-class tsEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsEndereco
+class tsEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 149, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 149, 1
+    )
     _Documentation = None
-tsEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(125))
-tsEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsEndereco._InitializeFacetMap(tsEndereco._CF_maxLength,
-   tsEndereco._CF_minLength,
-   tsEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsEndereco', tsEndereco)
+
+
+tsEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(125)
+)
+tsEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsEndereco._InitializeFacetMap(
+    tsEndereco._CF_maxLength, tsEndereco._CF_minLength, tsEndereco._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsEndereco", tsEndereco)
 _module_typeBindings.tsEndereco = tsEndereco
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroEndereco
-class tsNumeroEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroEndereco
+class tsNumeroEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 156, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 156, 1
+    )
     _Documentation = None
-tsNumeroEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(10))
-tsNumeroEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsNumeroEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroEndereco._InitializeFacetMap(tsNumeroEndereco._CF_maxLength,
-   tsNumeroEndereco._CF_minLength,
-   tsNumeroEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroEndereco', tsNumeroEndereco)
+
+
+tsNumeroEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(10)
+)
+tsNumeroEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsNumeroEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroEndereco._InitializeFacetMap(
+    tsNumeroEndereco._CF_maxLength, tsNumeroEndereco._CF_minLength, tsNumeroEndereco._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNumeroEndereco", tsNumeroEndereco)
 _module_typeBindings.tsNumeroEndereco = tsNumeroEndereco
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsComplementoEndereco
-class tsComplementoEndereco (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsComplementoEndereco
+class tsComplementoEndereco(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsComplementoEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 163, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsComplementoEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 163, 1
+    )
     _Documentation = None
-tsComplementoEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsComplementoEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsComplementoEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsComplementoEndereco._InitializeFacetMap(tsComplementoEndereco._CF_maxLength,
-   tsComplementoEndereco._CF_minLength,
-   tsComplementoEndereco._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsComplementoEndereco', tsComplementoEndereco)
+
+
+tsComplementoEndereco._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsComplementoEndereco._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsComplementoEndereco._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsComplementoEndereco._InitializeFacetMap(
+    tsComplementoEndereco._CF_maxLength,
+    tsComplementoEndereco._CF_minLength,
+    tsComplementoEndereco._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsComplementoEndereco", tsComplementoEndereco)
 _module_typeBindings.tsComplementoEndereco = tsComplementoEndereco
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsBairro
-class tsBairro (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsBairro
+class tsBairro(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsBairro')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 170, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsBairro")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 170, 1
+    )
     _Documentation = None
-tsBairro._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(60))
-tsBairro._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsBairro._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsBairro._InitializeFacetMap(tsBairro._CF_maxLength,
-   tsBairro._CF_minLength,
-   tsBairro._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsBairro', tsBairro)
+
+
+tsBairro._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(60)
+)
+tsBairro._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsBairro._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsBairro._InitializeFacetMap(
+    tsBairro._CF_maxLength, tsBairro._CF_minLength, tsBairro._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsBairro", tsBairro)
 _module_typeBindings.tsBairro = tsBairro
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsUf
-class tsUf (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsUf
+class tsUf(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsUf')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 177, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsUf")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 177, 1
+    )
     _Documentation = None
+
+
 tsUf._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
-tsUf._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsUf._InitializeFacetMap(tsUf._CF_length,
-   tsUf._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsUf', tsUf)
+tsUf._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsUf._InitializeFacetMap(tsUf._CF_length, tsUf._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsUf", tsUf)
 _module_typeBindings.tsUf = tsUf
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCep
-class tsCep (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCep
+class tsCep(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCep')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 183, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCep")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 183, 1
+    )
     _Documentation = None
-tsCep._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(8))
-tsCep._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCep._InitializeFacetMap(tsCep._CF_totalDigits,
-   tsCep._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCep', tsCep)
+
+
+tsCep._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(8)
+)
+tsCep._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCep._InitializeFacetMap(tsCep._CF_totalDigits, tsCep._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsCep", tsCep)
 _module_typeBindings.tsCep = tsCep
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsEmail
-class tsEmail (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsEmail
+class tsEmail(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsEmail')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 189, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsEmail")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 189, 1
+    )
     _Documentation = None
-tsEmail._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(80))
-tsEmail._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsEmail._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsEmail._InitializeFacetMap(tsEmail._CF_maxLength,
-   tsEmail._CF_minLength,
-   tsEmail._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsEmail', tsEmail)
+
+
+tsEmail._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(80)
+)
+tsEmail._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsEmail._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsEmail._InitializeFacetMap(tsEmail._CF_maxLength, tsEmail._CF_minLength, tsEmail._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsEmail", tsEmail)
 _module_typeBindings.tsEmail = tsEmail
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsTelefone
-class tsTelefone (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsTelefone
+class tsTelefone(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsTelefone')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 196, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsTelefone")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 196, 1
+    )
     _Documentation = None
-tsTelefone._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(11))
-tsTelefone._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsTelefone._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsTelefone._InitializeFacetMap(tsTelefone._CF_maxLength,
-   tsTelefone._CF_minLength,
-   tsTelefone._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsTelefone', tsTelefone)
+
+
+tsTelefone._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(11)
+)
+tsTelefone._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsTelefone._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsTelefone._InitializeFacetMap(
+    tsTelefone._CF_maxLength, tsTelefone._CF_minLength, tsTelefone._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsTelefone", tsTelefone)
 _module_typeBindings.tsTelefone = tsTelefone
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCpf
-class tsCpf (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCpf
+class tsCpf(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCpf')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 203, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCpf")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 203, 1
+    )
     _Documentation = None
-tsCpf._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(11))
-tsCpf._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCpf._InitializeFacetMap(tsCpf._CF_length,
-   tsCpf._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCpf', tsCpf)
+
+
+tsCpf._CF_length = pyxb.binding.facets.CF_length(
+    value=pyxb.binding.datatypes.nonNegativeInteger(11)
+)
+tsCpf._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCpf._InitializeFacetMap(tsCpf._CF_length, tsCpf._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsCpf", tsCpf)
 _module_typeBindings.tsCpf = tsCpf
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsIndicacaoCpfCnpj
-class tsIndicacaoCpfCnpj (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsIndicacaoCpfCnpj
+class tsIndicacaoCpfCnpj(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsIndicacaoCpfCnpj')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 209, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsIndicacaoCpfCnpj")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 209, 1
+    )
     _Documentation = None
+
+
 tsIndicacaoCpfCnpj._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsIndicacaoCpfCnpj._CF_pattern.addPattern(pattern='1|2|3')
-tsIndicacaoCpfCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsIndicacaoCpfCnpj._InitializeFacetMap(tsIndicacaoCpfCnpj._CF_pattern,
-   tsIndicacaoCpfCnpj._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsIndicacaoCpfCnpj', tsIndicacaoCpfCnpj)
+tsIndicacaoCpfCnpj._CF_pattern.addPattern(pattern="1|2|3")
+tsIndicacaoCpfCnpj._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsIndicacaoCpfCnpj._InitializeFacetMap(
+    tsIndicacaoCpfCnpj._CF_pattern, tsIndicacaoCpfCnpj._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsIndicacaoCpfCnpj", tsIndicacaoCpfCnpj)
 _module_typeBindings.tsIndicacaoCpfCnpj = tsIndicacaoCpfCnpj
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoObra
-class tsCodigoObra (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoObra
+class tsCodigoObra(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoObra')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 215, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoObra")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 215, 1
+    )
     _Documentation = None
-tsCodigoObra._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsCodigoObra._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoObra._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoObra._InitializeFacetMap(tsCodigoObra._CF_maxLength,
-   tsCodigoObra._CF_minLength,
-   tsCodigoObra._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoObra', tsCodigoObra)
+
+
+tsCodigoObra._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsCodigoObra._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoObra._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoObra._InitializeFacetMap(
+    tsCodigoObra._CF_maxLength, tsCodigoObra._CF_minLength, tsCodigoObra._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoObra", tsCodigoObra)
 _module_typeBindings.tsCodigoObra = tsCodigoObra
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsArt
-class tsArt (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsArt
+class tsArt(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsArt')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 222, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsArt")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 222, 1
+    )
     _Documentation = None
-tsArt._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(15))
-tsArt._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsArt._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsArt._InitializeFacetMap(tsArt._CF_maxLength,
-   tsArt._CF_minLength,
-   tsArt._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsArt', tsArt)
+
+
+tsArt._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(15)
+)
+tsArt._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsArt._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsArt._InitializeFacetMap(tsArt._CF_maxLength, tsArt._CF_minLength, tsArt._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsArt", tsArt)
 _module_typeBindings.tsArt = tsArt
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroLote
-class tsNumeroLote (pyxb.binding.datatypes.nonNegativeInteger):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroLote
+class tsNumeroLote(pyxb.binding.datatypes.nonNegativeInteger):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroLote')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 229, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroLote")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 229, 1
+    )
     _Documentation = None
-tsNumeroLote._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(15))
-tsNumeroLote._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroLote._InitializeFacetMap(tsNumeroLote._CF_totalDigits,
-   tsNumeroLote._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroLote', tsNumeroLote)
+
+
+tsNumeroLote._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(15)
+)
+tsNumeroLote._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroLote._InitializeFacetMap(tsNumeroLote._CF_totalDigits, tsNumeroLote._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsNumeroLote", tsNumeroLote)
 _module_typeBindings.tsNumeroLote = tsNumeroLote
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroProtocolo
-class tsNumeroProtocolo (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsNumeroProtocolo
+class tsNumeroProtocolo(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsNumeroProtocolo')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 235, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsNumeroProtocolo")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 235, 1
+    )
     _Documentation = None
-tsNumeroProtocolo._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(50))
-tsNumeroProtocolo._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsNumeroProtocolo._InitializeFacetMap(tsNumeroProtocolo._CF_maxLength,
-   tsNumeroProtocolo._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsNumeroProtocolo', tsNumeroProtocolo)
+
+
+tsNumeroProtocolo._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(50)
+)
+tsNumeroProtocolo._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsNumeroProtocolo._InitializeFacetMap(
+    tsNumeroProtocolo._CF_maxLength, tsNumeroProtocolo._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsNumeroProtocolo", tsNumeroProtocolo)
 _module_typeBindings.tsNumeroProtocolo = tsNumeroProtocolo
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSituacaoLoteRps
-class tsSituacaoLoteRps (pyxb.binding.datatypes.byte):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsSituacaoLoteRps
+class tsSituacaoLoteRps(pyxb.binding.datatypes.byte):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsSituacaoLoteRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 241, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsSituacaoLoteRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 241, 1
+    )
     _Documentation = None
+
+
 tsSituacaoLoteRps._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsSituacaoLoteRps._CF_pattern.addPattern(pattern='1|2|3|4')
-tsSituacaoLoteRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsSituacaoLoteRps._InitializeFacetMap(tsSituacaoLoteRps._CF_pattern,
-   tsSituacaoLoteRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsSituacaoLoteRps', tsSituacaoLoteRps)
+tsSituacaoLoteRps._CF_pattern.addPattern(pattern="1|2|3|4")
+tsSituacaoLoteRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsSituacaoLoteRps._InitializeFacetMap(
+    tsSituacaoLoteRps._CF_pattern, tsSituacaoLoteRps._CF_whiteSpace
+)
+Namespace.addCategoryObject("typeBinding", "tsSituacaoLoteRps", tsSituacaoLoteRps)
 _module_typeBindings.tsSituacaoLoteRps = tsSituacaoLoteRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsQuantidadeRps
-class tsQuantidadeRps (pyxb.binding.datatypes.int):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsQuantidadeRps
+class tsQuantidadeRps(pyxb.binding.datatypes.int):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsQuantidadeRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 247, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsQuantidadeRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 247, 1
+    )
     _Documentation = None
-tsQuantidadeRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(value=pyxb.binding.datatypes.positiveInteger(4))
-tsQuantidadeRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsQuantidadeRps._InitializeFacetMap(tsQuantidadeRps._CF_totalDigits,
-   tsQuantidadeRps._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsQuantidadeRps', tsQuantidadeRps)
+
+
+tsQuantidadeRps._CF_totalDigits = pyxb.binding.facets.CF_totalDigits(
+    value=pyxb.binding.datatypes.positiveInteger(4)
+)
+tsQuantidadeRps._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsQuantidadeRps._InitializeFacetMap(tsQuantidadeRps._CF_totalDigits, tsQuantidadeRps._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsQuantidadeRps", tsQuantidadeRps)
 _module_typeBindings.tsQuantidadeRps = tsQuantidadeRps
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoMensagemAlerta
-class tsCodigoMensagemAlerta (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoMensagemAlerta
+class tsCodigoMensagemAlerta(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoMensagemAlerta')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 253, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoMensagemAlerta")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 253, 1
+    )
     _Documentation = None
-tsCodigoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsCodigoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoMensagemAlerta._InitializeFacetMap(tsCodigoMensagemAlerta._CF_maxLength,
-   tsCodigoMensagemAlerta._CF_minLength,
-   tsCodigoMensagemAlerta._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoMensagemAlerta', tsCodigoMensagemAlerta)
+
+
+tsCodigoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsCodigoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoMensagemAlerta._InitializeFacetMap(
+    tsCodigoMensagemAlerta._CF_maxLength,
+    tsCodigoMensagemAlerta._CF_minLength,
+    tsCodigoMensagemAlerta._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoMensagemAlerta", tsCodigoMensagemAlerta)
 _module_typeBindings.tsCodigoMensagemAlerta = tsCodigoMensagemAlerta
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsDescricaoMensagemAlerta
-class tsDescricaoMensagemAlerta (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsDescricaoMensagemAlerta
+class tsDescricaoMensagemAlerta(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsDescricaoMensagemAlerta')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 260, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsDescricaoMensagemAlerta")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 260, 1
+    )
     _Documentation = None
-tsDescricaoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(200))
-tsDescricaoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsDescricaoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsDescricaoMensagemAlerta._InitializeFacetMap(tsDescricaoMensagemAlerta._CF_maxLength,
-   tsDescricaoMensagemAlerta._CF_minLength,
-   tsDescricaoMensagemAlerta._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsDescricaoMensagemAlerta', tsDescricaoMensagemAlerta)
+
+
+tsDescricaoMensagemAlerta._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(200)
+)
+tsDescricaoMensagemAlerta._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsDescricaoMensagemAlerta._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsDescricaoMensagemAlerta._InitializeFacetMap(
+    tsDescricaoMensagemAlerta._CF_maxLength,
+    tsDescricaoMensagemAlerta._CF_minLength,
+    tsDescricaoMensagemAlerta._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsDescricaoMensagemAlerta", tsDescricaoMensagemAlerta)
 _module_typeBindings.tsDescricaoMensagemAlerta = tsDescricaoMensagemAlerta
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoCancelamentoNfse
-class tsCodigoCancelamentoNfse (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsCodigoCancelamentoNfse
+class tsCodigoCancelamentoNfse(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsCodigoCancelamentoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 267, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsCodigoCancelamentoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 267, 1
+    )
     _Documentation = None
-tsCodigoCancelamentoNfse._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(4))
-tsCodigoCancelamentoNfse._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
-tsCodigoCancelamentoNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsCodigoCancelamentoNfse._InitializeFacetMap(tsCodigoCancelamentoNfse._CF_maxLength,
-   tsCodigoCancelamentoNfse._CF_minLength,
-   tsCodigoCancelamentoNfse._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsCodigoCancelamentoNfse', tsCodigoCancelamentoNfse)
+
+
+tsCodigoCancelamentoNfse._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(4)
+)
+tsCodigoCancelamentoNfse._CF_minLength = pyxb.binding.facets.CF_minLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(1)
+)
+tsCodigoCancelamentoNfse._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsCodigoCancelamentoNfse._InitializeFacetMap(
+    tsCodigoCancelamentoNfse._CF_maxLength,
+    tsCodigoCancelamentoNfse._CF_minLength,
+    tsCodigoCancelamentoNfse._CF_whiteSpace,
+)
+Namespace.addCategoryObject("typeBinding", "tsCodigoCancelamentoNfse", tsCodigoCancelamentoNfse)
 _module_typeBindings.tsCodigoCancelamentoNfse = tsCodigoCancelamentoNfse
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsIdTag
-class tsIdTag (pyxb.binding.datatypes.string):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsIdTag
+class tsIdTag(pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsIdTag')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 274, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsIdTag")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 274, 1
+    )
     _Documentation = None
-tsIdTag._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(255))
-tsIdTag._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsIdTag._InitializeFacetMap(tsIdTag._CF_maxLength,
-   tsIdTag._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsIdTag', tsIdTag)
+
+
+tsIdTag._CF_maxLength = pyxb.binding.facets.CF_maxLength(
+    value=pyxb.binding.datatypes.nonNegativeInteger(255)
+)
+tsIdTag._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsIdTag._InitializeFacetMap(tsIdTag._CF_maxLength, tsIdTag._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsIdTag", tsIdTag)
 _module_typeBindings.tsIdTag = tsIdTag
 
-# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsVersao
-class tsVersao (pyxb.binding.datatypes.token):
 
+# Atomic simple type: {http://www.ginfes.com.br/tipos_v03.xsd}tsVersao
+class tsVersao(pyxb.binding.datatypes.token):
     """An atomic simple type."""
 
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tsVersao')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 280, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tsVersao")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 280, 1
+    )
     _Documentation = None
+
+
 tsVersao._CF_pattern = pyxb.binding.facets.CF_pattern()
-tsVersao._CF_pattern.addPattern(pattern='[0-9]{1,4}')
-tsVersao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(value=pyxb.binding.facets._WhiteSpace_enum.collapse)
-tsVersao._InitializeFacetMap(tsVersao._CF_pattern,
-   tsVersao._CF_whiteSpace)
-Namespace.addCategoryObject('typeBinding', 'tsVersao', tsVersao)
+tsVersao._CF_pattern.addPattern(pattern="[0-9]{1,4}")
+tsVersao._CF_whiteSpace = pyxb.binding.facets.CF_whiteSpace(
+    value=pyxb.binding.facets._WhiteSpace_enum.collapse
+)
+tsVersao._InitializeFacetMap(tsVersao._CF_pattern, tsVersao._CF_whiteSpace)
+Namespace.addCategoryObject("typeBinding", "tsVersao", tsVersao)
 _module_typeBindings.tsVersao = tsVersao
 
+
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCpfCnpj with content type ELEMENT_ONLY
-class tcCpfCnpj (pyxb.binding.basis.complexTypeDefinition):
+class tcCpfCnpj(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCpfCnpj with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCpfCnpj')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 287, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCpfCnpj")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 287, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cpf uses Python identifier Cpf
-    __Cpf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cpf'), 'Cpf', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCpfCnpj_httpwww_ginfes_com_brtipos_v03_xsdCpf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 289, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cpf uses Python identifier Cpf
+    __Cpf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cpf"),
+        "Cpf",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCpfCnpj_httpwww_ginfes_com_brtipos_v03_xsdCpf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 289, 3
+        ),
+    )
+
     Cpf = property(__Cpf.value, __Cpf.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cnpj uses Python identifier Cnpj
-    __Cnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), 'Cnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCpfCnpj_httpwww_ginfes_com_brtipos_v03_xsdCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 290, 3), )
+    __Cnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        "Cnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCpfCnpj_httpwww_ginfes_com_brtipos_v03_xsdCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 290, 3
+        ),
+    )
 
-    
     Cnpj = property(__Cnpj.value, __Cnpj.set, None, None)
 
-    _ElementMap.update({
-        __Cpf.name() : __Cpf,
-        __Cnpj.name() : __Cnpj
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Cpf.name(): __Cpf, __Cnpj.name(): __Cnpj})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcCpfCnpj = tcCpfCnpj
-Namespace.addCategoryObject('typeBinding', 'tcCpfCnpj', tcCpfCnpj)
+Namespace.addCategoryObject("typeBinding", "tcCpfCnpj", tcCpfCnpj)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcEndereco with content type ELEMENT_ONLY
-class tcEndereco (pyxb.binding.basis.complexTypeDefinition):
+class tcEndereco(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcEndereco with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcEndereco')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 293, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcEndereco")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 293, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 295, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Endereco uses Python identifier Endereco
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 295, 3
+        ),
+    )
+
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 296, 3), )
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 296, 3
+        ),
+    )
 
-    
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Complemento uses Python identifier Complemento
-    __Complemento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Complemento'), 'Complemento', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdComplemento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 297, 3), )
+    __Complemento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Complemento"),
+        "Complemento",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdComplemento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 297, 3
+        ),
+    )
 
-    
     Complemento = property(__Complemento.value, __Complemento.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Bairro uses Python identifier Bairro
-    __Bairro = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Bairro'), 'Bairro', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdBairro', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 298, 3), )
+    __Bairro = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Bairro"),
+        "Bairro",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdBairro",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 298, 3
+        ),
+    )
 
-    
     Bairro = property(__Bairro.value, __Bairro.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 299, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 299, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Uf uses Python identifier Uf
-    __Uf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Uf'), 'Uf', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdUf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 300, 3), )
+    __Uf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        "Uf",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdUf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 300, 3
+        ),
+    )
 
-    
     Uf = property(__Uf.value, __Uf.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cep uses Python identifier Cep
-    __Cep = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cep'), 'Cep', '__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdCep', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 301, 3), )
+    __Cep = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cep"),
+        "Cep",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcEndereco_httpwww_ginfes_com_brtipos_v03_xsdCep",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 301, 3
+        ),
+    )
 
-    
     Cep = property(__Cep.value, __Cep.set, None, None)
 
-    _ElementMap.update({
-        __Endereco.name() : __Endereco,
-        __Numero.name() : __Numero,
-        __Complemento.name() : __Complemento,
-        __Bairro.name() : __Bairro,
-        __CodigoMunicipio.name() : __CodigoMunicipio,
-        __Uf.name() : __Uf,
-        __Cep.name() : __Cep
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Endereco.name(): __Endereco,
+            __Numero.name(): __Numero,
+            __Complemento.name(): __Complemento,
+            __Bairro.name(): __Bairro,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+            __Uf.name(): __Uf,
+            __Cep.name(): __Cep,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcEndereco = tcEndereco
-Namespace.addCategoryObject('typeBinding', 'tcEndereco', tcEndereco)
+Namespace.addCategoryObject("typeBinding", "tcEndereco", tcEndereco)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcContato with content type ELEMENT_ONLY
-class tcContato (pyxb.binding.basis.complexTypeDefinition):
+class tcContato(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcContato with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcContato')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 304, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcContato")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 304, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Telefone uses Python identifier Telefone
-    __Telefone = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Telefone'), 'Telefone', '__httpwww_ginfes_com_brtipos_v03_xsd_tcContato_httpwww_ginfes_com_brtipos_v03_xsdTelefone', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 306, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Telefone uses Python identifier Telefone
+    __Telefone = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Telefone"),
+        "Telefone",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcContato_httpwww_ginfes_com_brtipos_v03_xsdTelefone",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 306, 3
+        ),
+    )
+
     Telefone = property(__Telefone.value, __Telefone.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Email uses Python identifier Email
-    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Email'), 'Email', '__httpwww_ginfes_com_brtipos_v03_xsd_tcContato_httpwww_ginfes_com_brtipos_v03_xsdEmail', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 307, 3), )
+    __Email = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Email"),
+        "Email",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcContato_httpwww_ginfes_com_brtipos_v03_xsdEmail",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 307, 3
+        ),
+    )
 
-    
     Email = property(__Email.value, __Email.set, None, None)
 
-    _ElementMap.update({
-        __Telefone.name() : __Telefone,
-        __Email.name() : __Email
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Telefone.name(): __Telefone, __Email.name(): __Email})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcContato = tcContato
-Namespace.addCategoryObject('typeBinding', 'tcContato', tcContato)
+Namespace.addCategoryObject("typeBinding", "tcContato", tcContato)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoOrgaoGerador with content type ELEMENT_ONLY
-class tcIdentificacaoOrgaoGerador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoOrgaoGerador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoOrgaoGerador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoOrgaoGerador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 310, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoOrgaoGerador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 310, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoOrgaoGerador_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 312, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoMunicipio uses Python identifier CodigoMunicipio
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoOrgaoGerador_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 312, 3
+        ),
+    )
+
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Uf uses Python identifier Uf
-    __Uf = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Uf'), 'Uf', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoOrgaoGerador_httpwww_ginfes_com_brtipos_v03_xsdUf', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 313, 3), )
+    __Uf = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        "Uf",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoOrgaoGerador_httpwww_ginfes_com_brtipos_v03_xsdUf",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 313, 3
+        ),
+    )
 
-    
     Uf = property(__Uf.value, __Uf.set, None, None)
 
-    _ElementMap.update({
-        __CodigoMunicipio.name() : __CodigoMunicipio,
-        __Uf.name() : __Uf
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CodigoMunicipio.name(): __CodigoMunicipio, __Uf.name(): __Uf})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoOrgaoGerador = tcIdentificacaoOrgaoGerador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoOrgaoGerador', tcIdentificacaoOrgaoGerador)
+Namespace.addCategoryObject(
+    "typeBinding", "tcIdentificacaoOrgaoGerador", tcIdentificacaoOrgaoGerador
+)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoRps with content type ELEMENT_ONLY
-class tcIdentificacaoRps (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 316, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 316, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 318, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 318, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Serie uses Python identifier Serie
-    __Serie = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Serie'), 'Serie', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdSerie', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 319, 3), )
+    __Serie = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Serie"),
+        "Serie",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdSerie",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 319, 3
+        ),
+    )
 
-    
     Serie = property(__Serie.value, __Serie.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Tipo uses Python identifier Tipo
-    __Tipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tipo'), 'Tipo', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdTipo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 320, 3), )
+    __Tipo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tipo"),
+        "Tipo",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoRps_httpwww_ginfes_com_brtipos_v03_xsdTipo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 320, 3
+        ),
+    )
 
-    
     Tipo = property(__Tipo.value, __Tipo.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __Serie.name() : __Serie,
-        __Tipo.name() : __Tipo
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Numero.name(): __Numero, __Serie.name(): __Serie, __Tipo.name(): __Tipo})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoRps = tcIdentificacaoRps
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoRps', tcIdentificacaoRps)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoRps", tcIdentificacaoRps)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoPrestador with content type ELEMENT_ONLY
-class tcIdentificacaoPrestador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoPrestador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoPrestador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoPrestador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 323, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoPrestador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 323, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cnpj uses Python identifier Cnpj
-    __Cnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), 'Cnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoPrestador_httpwww_ginfes_com_brtipos_v03_xsdCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 325, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cnpj uses Python identifier Cnpj
+    __Cnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        "Cnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoPrestador_httpwww_ginfes_com_brtipos_v03_xsdCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 325, 3
+        ),
+    )
+
     Cnpj = property(__Cnpj.value, __Cnpj.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoPrestador_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 326, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoPrestador_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 326, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __Cnpj.name() : __Cnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Cnpj.name(): __Cnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoPrestador = tcIdentificacaoPrestador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoPrestador', tcIdentificacaoPrestador)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoPrestador", tcIdentificacaoPrestador)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoTomador with content type ELEMENT_ONLY
-class tcIdentificacaoTomador (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoTomador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoTomador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoTomador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 329, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoTomador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 329, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoTomador_httpwww_ginfes_com_brtipos_v03_xsdCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 331, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CpfCnpj uses Python identifier CpfCnpj
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoTomador_httpwww_ginfes_com_brtipos_v03_xsdCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 331, 3
+        ),
+    )
+
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoTomador_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 332, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoTomador_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 332, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CpfCnpj.name(): __CpfCnpj, __InscricaoMunicipal.name(): __InscricaoMunicipal}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoTomador = tcIdentificacaoTomador
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoTomador', tcIdentificacaoTomador)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoTomador", tcIdentificacaoTomador)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosTomador with content type ELEMENT_ONLY
-class tcDadosTomador (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosTomador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosTomador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosTomador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 335, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosTomador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 335, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoTomador uses Python identifier IdentificacaoTomador
-    __IdentificacaoTomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador'), 'IdentificacaoTomador', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 337, 3), )
+    __IdentificacaoTomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador"),
+        "IdentificacaoTomador",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 337, 3
+        ),
+    )
 
-    
-    IdentificacaoTomador = property(__IdentificacaoTomador.value, __IdentificacaoTomador.set, None, None)
+    IdentificacaoTomador = property(
+        __IdentificacaoTomador.value, __IdentificacaoTomador.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 338, 3), )
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 338, 3
+        ),
+    )
 
-    
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 339, 3), )
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 339, 3
+        ),
+    )
 
-    
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Contato uses Python identifier Contato
-    __Contato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Contato'), 'Contato', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdContato', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 340, 3), )
+    __Contato = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        "Contato",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosTomador_httpwww_ginfes_com_brtipos_v03_xsdContato",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 340, 3
+        ),
+    )
 
-    
     Contato = property(__Contato.value, __Contato.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoTomador.name() : __IdentificacaoTomador,
-        __RazaoSocial.name() : __RazaoSocial,
-        __Endereco.name() : __Endereco,
-        __Contato.name() : __Contato
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoTomador.name(): __IdentificacaoTomador,
+            __RazaoSocial.name(): __RazaoSocial,
+            __Endereco.name(): __Endereco,
+            __Contato.name(): __Contato,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosTomador = tcDadosTomador
-Namespace.addCategoryObject('typeBinding', 'tcDadosTomador', tcDadosTomador)
+Namespace.addCategoryObject("typeBinding", "tcDadosTomador", tcDadosTomador)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoIntermediarioServico with content type ELEMENT_ONLY
-class tcIdentificacaoIntermediarioServico (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoIntermediarioServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoIntermediarioServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoIntermediarioServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 343, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoIntermediarioServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 343, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 345, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}RazaoSocial uses Python identifier RazaoSocial
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 345, 3
+        ),
+    )
+
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CpfCnpj uses Python identifier CpfCnpj
-    __CpfCnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), 'CpfCnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdCpfCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 346, 3), )
+    __CpfCnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        "CpfCnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdCpfCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 346, 3
+        ),
+    )
 
-    
     CpfCnpj = property(__CpfCnpj.value, __CpfCnpj.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 347, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoIntermediarioServico_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 347, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    _ElementMap.update({
-        __RazaoSocial.name() : __RazaoSocial,
-        __CpfCnpj.name() : __CpfCnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __RazaoSocial.name(): __RazaoSocial,
+            __CpfCnpj.name(): __CpfCnpj,
+            __InscricaoMunicipal.name(): __InscricaoMunicipal,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoIntermediarioServico = tcIdentificacaoIntermediarioServico
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoIntermediarioServico', tcIdentificacaoIntermediarioServico)
+Namespace.addCategoryObject(
+    "typeBinding", "tcIdentificacaoIntermediarioServico", tcIdentificacaoIntermediarioServico
+)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcValores with content type ELEMENT_ONLY
-class tcValores (pyxb.binding.basis.complexTypeDefinition):
+class tcValores(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcValores with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcValores')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 350, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcValores")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 350, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorServicos uses Python identifier ValorServicos
-    __ValorServicos = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos'), 'ValorServicos', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorServicos', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 352, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorServicos uses Python identifier ValorServicos
+    __ValorServicos = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorServicos"),
+        "ValorServicos",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorServicos",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 352, 3
+        ),
+    )
+
     ValorServicos = property(__ValorServicos.value, __ValorServicos.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorDeducoes uses Python identifier ValorDeducoes
-    __ValorDeducoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes'), 'ValorDeducoes', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorDeducoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 353, 3), )
+    __ValorDeducoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes"),
+        "ValorDeducoes",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorDeducoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 353, 3
+        ),
+    )
 
-    
     ValorDeducoes = property(__ValorDeducoes.value, __ValorDeducoes.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorPis uses Python identifier ValorPis
-    __ValorPis = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorPis'), 'ValorPis', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorPis', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 354, 3), )
+    __ValorPis = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorPis"),
+        "ValorPis",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorPis",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 354, 3
+        ),
+    )
 
-    
     ValorPis = property(__ValorPis.value, __ValorPis.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorCofins uses Python identifier ValorCofins
-    __ValorCofins = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins'), 'ValorCofins', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorCofins', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 355, 3), )
+    __ValorCofins = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCofins"),
+        "ValorCofins",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorCofins",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 355, 3
+        ),
+    )
 
-    
     ValorCofins = property(__ValorCofins.value, __ValorCofins.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorInss uses Python identifier ValorInss
-    __ValorInss = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorInss'), 'ValorInss', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorInss', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 356, 3), )
+    __ValorInss = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorInss"),
+        "ValorInss",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorInss",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 356, 3
+        ),
+    )
 
-    
     ValorInss = property(__ValorInss.value, __ValorInss.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorIr uses Python identifier ValorIr
-    __ValorIr = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIr'), 'ValorIr', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIr', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 357, 3), )
+    __ValorIr = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIr"),
+        "ValorIr",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIr",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 357, 3
+        ),
+    )
 
-    
     ValorIr = property(__ValorIr.value, __ValorIr.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorCsll uses Python identifier ValorCsll
-    __ValorCsll = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll'), 'ValorCsll', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorCsll', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 358, 3), )
+    __ValorCsll = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCsll"),
+        "ValorCsll",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorCsll",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 358, 3
+        ),
+    )
 
-    
     ValorCsll = property(__ValorCsll.value, __ValorCsll.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IssRetido uses Python identifier IssRetido
-    __IssRetido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IssRetido'), 'IssRetido', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdIssRetido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 359, 3), )
+    __IssRetido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IssRetido"),
+        "IssRetido",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdIssRetido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 359, 3
+        ),
+    )
 
-    
     IssRetido = property(__IssRetido.value, __IssRetido.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorIss uses Python identifier ValorIss
-    __ValorIss = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), 'ValorIss', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIss', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 360, 3), )
+    __ValorIss = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        "ValorIss",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIss",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 360, 3
+        ),
+    )
 
-    
     ValorIss = property(__ValorIss.value, __ValorIss.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorIssRetido uses Python identifier ValorIssRetido
-    __ValorIssRetido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorIssRetido'), 'ValorIssRetido', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIssRetido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 361, 3), )
+    __ValorIssRetido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIssRetido"),
+        "ValorIssRetido",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorIssRetido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 361, 3
+        ),
+    )
 
-    
     ValorIssRetido = property(__ValorIssRetido.value, __ValorIssRetido.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}OutrasRetencoes uses Python identifier OutrasRetencoes
-    __OutrasRetencoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes'), 'OutrasRetencoes', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdOutrasRetencoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 362, 3), )
+    __OutrasRetencoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes"),
+        "OutrasRetencoes",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdOutrasRetencoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 362, 3
+        ),
+    )
 
-    
     OutrasRetencoes = property(__OutrasRetencoes.value, __OutrasRetencoes.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}BaseCalculo uses Python identifier BaseCalculo
-    __BaseCalculo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo'), 'BaseCalculo', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdBaseCalculo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 363, 3), )
+    __BaseCalculo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "BaseCalculo"),
+        "BaseCalculo",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdBaseCalculo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 363, 3
+        ),
+    )
 
-    
     BaseCalculo = property(__BaseCalculo.value, __BaseCalculo.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Aliquota uses Python identifier Aliquota
-    __Aliquota = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), 'Aliquota', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdAliquota', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 364, 3), )
+    __Aliquota = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        "Aliquota",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdAliquota",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 364, 3
+        ),
+    )
 
-    
     Aliquota = property(__Aliquota.value, __Aliquota.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorLiquidoNfse uses Python identifier ValorLiquidoNfse
-    __ValorLiquidoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse'), 'ValorLiquidoNfse', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorLiquidoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 365, 3), )
+    __ValorLiquidoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse"),
+        "ValorLiquidoNfse",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdValorLiquidoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 365, 3
+        ),
+    )
 
-    
     ValorLiquidoNfse = property(__ValorLiquidoNfse.value, __ValorLiquidoNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DescontoIncondicionado uses Python identifier DescontoIncondicionado
-    __DescontoIncondicionado = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado'), 'DescontoIncondicionado', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdDescontoIncondicionado', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 366, 3), )
+    __DescontoIncondicionado = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado"),
+        "DescontoIncondicionado",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdDescontoIncondicionado",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 366, 3
+        ),
+    )
 
-    
-    DescontoIncondicionado = property(__DescontoIncondicionado.value, __DescontoIncondicionado.set, None, None)
+    DescontoIncondicionado = property(
+        __DescontoIncondicionado.value, __DescontoIncondicionado.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DescontoCondicionado uses Python identifier DescontoCondicionado
-    __DescontoCondicionado = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado'), 'DescontoCondicionado', '__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdDescontoCondicionado', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 367, 3), )
+    __DescontoCondicionado = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado"),
+        "DescontoCondicionado",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcValores_httpwww_ginfes_com_brtipos_v03_xsdDescontoCondicionado",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 367, 3
+        ),
+    )
 
-    
-    DescontoCondicionado = property(__DescontoCondicionado.value, __DescontoCondicionado.set, None, None)
+    DescontoCondicionado = property(
+        __DescontoCondicionado.value, __DescontoCondicionado.set, None, None
+    )
 
-    _ElementMap.update({
-        __ValorServicos.name() : __ValorServicos,
-        __ValorDeducoes.name() : __ValorDeducoes,
-        __ValorPis.name() : __ValorPis,
-        __ValorCofins.name() : __ValorCofins,
-        __ValorInss.name() : __ValorInss,
-        __ValorIr.name() : __ValorIr,
-        __ValorCsll.name() : __ValorCsll,
-        __IssRetido.name() : __IssRetido,
-        __ValorIss.name() : __ValorIss,
-        __ValorIssRetido.name() : __ValorIssRetido,
-        __OutrasRetencoes.name() : __OutrasRetencoes,
-        __BaseCalculo.name() : __BaseCalculo,
-        __Aliquota.name() : __Aliquota,
-        __ValorLiquidoNfse.name() : __ValorLiquidoNfse,
-        __DescontoIncondicionado.name() : __DescontoIncondicionado,
-        __DescontoCondicionado.name() : __DescontoCondicionado
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __ValorServicos.name(): __ValorServicos,
+            __ValorDeducoes.name(): __ValorDeducoes,
+            __ValorPis.name(): __ValorPis,
+            __ValorCofins.name(): __ValorCofins,
+            __ValorInss.name(): __ValorInss,
+            __ValorIr.name(): __ValorIr,
+            __ValorCsll.name(): __ValorCsll,
+            __IssRetido.name(): __IssRetido,
+            __ValorIss.name(): __ValorIss,
+            __ValorIssRetido.name(): __ValorIssRetido,
+            __OutrasRetencoes.name(): __OutrasRetencoes,
+            __BaseCalculo.name(): __BaseCalculo,
+            __Aliquota.name(): __Aliquota,
+            __ValorLiquidoNfse.name(): __ValorLiquidoNfse,
+            __DescontoIncondicionado.name(): __DescontoIncondicionado,
+            __DescontoCondicionado.name(): __DescontoCondicionado,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcValores = tcValores
-Namespace.addCategoryObject('typeBinding', 'tcValores', tcValores)
+Namespace.addCategoryObject("typeBinding", "tcValores", tcValores)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosServico with content type ELEMENT_ONLY
-class tcDadosServico (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosServico(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosServico with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosServico')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 370, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosServico")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 370, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Valores uses Python identifier Valores
-    __Valores = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Valores'), 'Valores', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdValores', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 372, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Valores uses Python identifier Valores
+    __Valores = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Valores"),
+        "Valores",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdValores",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 372, 3
+        ),
+    )
+
     Valores = property(__Valores.value, __Valores.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ItemListaServico uses Python identifier ItemListaServico
-    __ItemListaServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico'), 'ItemListaServico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdItemListaServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 373, 3), )
+    __ItemListaServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ItemListaServico"),
+        "ItemListaServico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdItemListaServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 373, 3
+        ),
+    )
 
-    
     ItemListaServico = property(__ItemListaServico.value, __ItemListaServico.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoCnae uses Python identifier CodigoCnae
-    __CodigoCnae = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae'), 'CodigoCnae', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoCnae', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 374, 3), )
+    __CodigoCnae = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCnae"),
+        "CodigoCnae",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoCnae",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 374, 3
+        ),
+    )
 
-    
     CodigoCnae = property(__CodigoCnae.value, __CodigoCnae.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoTributacaoMunicipio uses Python identifier CodigoTributacaoMunicipio
-    __CodigoTributacaoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio'), 'CodigoTributacaoMunicipio', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoTributacaoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 375, 3), )
+    __CodigoTributacaoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio"),
+        "CodigoTributacaoMunicipio",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoTributacaoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 375, 3
+        ),
+    )
 
-    
-    CodigoTributacaoMunicipio = property(__CodigoTributacaoMunicipio.value, __CodigoTributacaoMunicipio.set, None, None)
+    CodigoTributacaoMunicipio = property(
+        __CodigoTributacaoMunicipio.value, __CodigoTributacaoMunicipio.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Discriminacao uses Python identifier Discriminacao
-    __Discriminacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao'), 'Discriminacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdDiscriminacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 376, 3), )
+    __Discriminacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Discriminacao"),
+        "Discriminacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdDiscriminacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 376, 3
+        ),
+    )
 
-    
     Discriminacao = property(__Discriminacao.value, __Discriminacao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 377, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosServico_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 377, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    _ElementMap.update({
-        __Valores.name() : __Valores,
-        __ItemListaServico.name() : __ItemListaServico,
-        __CodigoCnae.name() : __CodigoCnae,
-        __CodigoTributacaoMunicipio.name() : __CodigoTributacaoMunicipio,
-        __Discriminacao.name() : __Discriminacao,
-        __CodigoMunicipio.name() : __CodigoMunicipio
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Valores.name(): __Valores,
+            __ItemListaServico.name(): __ItemListaServico,
+            __CodigoCnae.name(): __CodigoCnae,
+            __CodigoTributacaoMunicipio.name(): __CodigoTributacaoMunicipio,
+            __Discriminacao.name(): __Discriminacao,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosServico = tcDadosServico
-Namespace.addCategoryObject('typeBinding', 'tcDadosServico', tcDadosServico)
+Namespace.addCategoryObject("typeBinding", "tcDadosServico", tcDadosServico)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosConstrucaoCivil with content type ELEMENT_ONLY
-class tcDadosConstrucaoCivil (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosConstrucaoCivil(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosConstrucaoCivil with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosConstrucaoCivil')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 380, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosConstrucaoCivil")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 380, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoObra uses Python identifier CodigoObra
-    __CodigoObra = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra'), 'CodigoObra', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosConstrucaoCivil_httpwww_ginfes_com_brtipos_v03_xsdCodigoObra', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 382, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoObra uses Python identifier CodigoObra
+    __CodigoObra = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoObra"),
+        "CodigoObra",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosConstrucaoCivil_httpwww_ginfes_com_brtipos_v03_xsdCodigoObra",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 382, 3
+        ),
+    )
+
     CodigoObra = property(__CodigoObra.value, __CodigoObra.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Art uses Python identifier Art
-    __Art = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Art'), 'Art', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosConstrucaoCivil_httpwww_ginfes_com_brtipos_v03_xsdArt', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 383, 3), )
+    __Art = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Art"),
+        "Art",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosConstrucaoCivil_httpwww_ginfes_com_brtipos_v03_xsdArt",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 383, 3
+        ),
+    )
 
-    
     Art = property(__Art.value, __Art.set, None, None)
 
-    _ElementMap.update({
-        __CodigoObra.name() : __CodigoObra,
-        __Art.name() : __Art
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CodigoObra.name(): __CodigoObra, __Art.name(): __Art})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosConstrucaoCivil = tcDadosConstrucaoCivil
-Namespace.addCategoryObject('typeBinding', 'tcDadosConstrucaoCivil', tcDadosConstrucaoCivil)
+Namespace.addCategoryObject("typeBinding", "tcDadosConstrucaoCivil", tcDadosConstrucaoCivil)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosPrestador with content type ELEMENT_ONLY
-class tcDadosPrestador (pyxb.binding.basis.complexTypeDefinition):
+class tcDadosPrestador(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcDadosPrestador with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcDadosPrestador')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 386, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcDadosPrestador")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 386, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoPrestador uses Python identifier IdentificacaoPrestador
-    __IdentificacaoPrestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador'), 'IdentificacaoPrestador', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 388, 3), )
+    __IdentificacaoPrestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador"),
+        "IdentificacaoPrestador",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 388, 3
+        ),
+    )
 
-    
-    IdentificacaoPrestador = property(__IdentificacaoPrestador.value, __IdentificacaoPrestador.set, None, None)
+    IdentificacaoPrestador = property(
+        __IdentificacaoPrestador.value, __IdentificacaoPrestador.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}RazaoSocial uses Python identifier RazaoSocial
-    __RazaoSocial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), 'RazaoSocial', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 389, 3), )
+    __RazaoSocial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        "RazaoSocial",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdRazaoSocial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 389, 3
+        ),
+    )
 
-    
     RazaoSocial = property(__RazaoSocial.value, __RazaoSocial.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NomeFantasia uses Python identifier NomeFantasia
-    __NomeFantasia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia'), 'NomeFantasia', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdNomeFantasia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 390, 3), )
+    __NomeFantasia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NomeFantasia"),
+        "NomeFantasia",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdNomeFantasia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 390, 3
+        ),
+    )
 
-    
     NomeFantasia = property(__NomeFantasia.value, __NomeFantasia.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Endereco uses Python identifier Endereco
-    __Endereco = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), 'Endereco', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdEndereco', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 391, 3), )
+    __Endereco = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        "Endereco",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdEndereco",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 391, 3
+        ),
+    )
 
-    
     Endereco = property(__Endereco.value, __Endereco.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Contato uses Python identifier Contato
-    __Contato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Contato'), 'Contato', '__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdContato', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 392, 3), )
+    __Contato = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        "Contato",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcDadosPrestador_httpwww_ginfes_com_brtipos_v03_xsdContato",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 392, 3
+        ),
+    )
 
-    
     Contato = property(__Contato.value, __Contato.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoPrestador.name() : __IdentificacaoPrestador,
-        __RazaoSocial.name() : __RazaoSocial,
-        __NomeFantasia.name() : __NomeFantasia,
-        __Endereco.name() : __Endereco,
-        __Contato.name() : __Contato
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoPrestador.name(): __IdentificacaoPrestador,
+            __RazaoSocial.name(): __RazaoSocial,
+            __NomeFantasia.name(): __NomeFantasia,
+            __Endereco.name(): __Endereco,
+            __Contato.name(): __Contato,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcDadosPrestador = tcDadosPrestador
-Namespace.addCategoryObject('typeBinding', 'tcDadosPrestador', tcDadosPrestador)
+Namespace.addCategoryObject("typeBinding", "tcDadosPrestador", tcDadosPrestador)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcRps with content type ELEMENT_ONLY
-class tcRps (pyxb.binding.basis.complexTypeDefinition):
+class tcRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 413, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 413, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfRps uses Python identifier InfRps
-    __InfRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfRps'), 'InfRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcRps_httpwww_ginfes_com_brtipos_v03_xsdInfRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 415, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfRps uses Python identifier InfRps
+    __InfRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfRps"),
+        "InfRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcRps_httpwww_ginfes_com_brtipos_v03_xsdInfRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 415, 3
+        ),
+    )
+
     InfRps = property(__InfRps.value, __InfRps.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brtipos_v03_xsd_tcRps_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcRps_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __InfRps.name() : __InfRps,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__InfRps.name(): __InfRps, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcRps = tcRps
-Namespace.addCategoryObject('typeBinding', 'tcRps', tcRps)
+Namespace.addCategoryObject("typeBinding", "tcRps", tcRps)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoNfse with content type ELEMENT_ONLY
-class tcIdentificacaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcIdentificacaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcIdentificacaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcIdentificacaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 419, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcIdentificacaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 419, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 421, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 421, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cnpj uses Python identifier Cnpj
-    __Cnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), 'Cnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 422, 3), )
+    __Cnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        "Cnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 422, 3
+        ),
+    )
 
-    
     Cnpj = property(__Cnpj.value, __Cnpj.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 423, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 423, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoMunicipio uses Python identifier CodigoMunicipio
-    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), 'CodigoMunicipio', '__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 424, 3), )
+    __CodigoMunicipio = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        "CodigoMunicipio",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcIdentificacaoNfse_httpwww_ginfes_com_brtipos_v03_xsdCodigoMunicipio",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 424, 3
+        ),
+    )
 
-    
     CodigoMunicipio = property(__CodigoMunicipio.value, __CodigoMunicipio.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __Cnpj.name() : __Cnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal,
-        __CodigoMunicipio.name() : __CodigoMunicipio
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Numero.name(): __Numero,
+            __Cnpj.name(): __Cnpj,
+            __InscricaoMunicipal.name(): __InscricaoMunicipal,
+            __CodigoMunicipio.name(): __CodigoMunicipio,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcIdentificacaoNfse = tcIdentificacaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcIdentificacaoNfse', tcIdentificacaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcIdentificacaoNfse", tcIdentificacaoNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcNfse with content type ELEMENT_ONLY
-class tcNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 451, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 451, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfNfse uses Python identifier InfNfse
-    __InfNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfNfse'), 'InfNfse', '__httpwww_ginfes_com_brtipos_v03_xsd_tcNfse_httpwww_ginfes_com_brtipos_v03_xsdInfNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 453, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfNfse uses Python identifier InfNfse
+    __InfNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfNfse"),
+        "InfNfse",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcNfse_httpwww_ginfes_com_brtipos_v03_xsdInfNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 453, 3
+        ),
+    )
+
     InfNfse = property(__InfNfse.value, __InfNfse.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brtipos_v03_xsd_tcNfse_httpwww_w3_org200009xmldsigSignature', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcNfse_httpwww_w3_org200009xmldsigSignature",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __InfNfse.name() : __InfNfse,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__InfNfse.name(): __InfNfse, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcNfse = tcNfse
-Namespace.addCategoryObject('typeBinding', 'tcNfse', tcNfse)
+Namespace.addCategoryObject("typeBinding", "tcNfse", tcNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcPedidoCancelamento with content type ELEMENT_ONLY
-class tcPedidoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcPedidoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcPedidoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcPedidoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 464, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcPedidoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 464, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
+
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfPedidoCancelamento uses Python identifier InfPedidoCancelamento
-    __InfPedidoCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento'), 'InfPedidoCancelamento', '__httpwww_ginfes_com_brtipos_v03_xsd_tcPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdInfPedidoCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 466, 3), )
+    __InfPedidoCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento"),
+        "InfPedidoCancelamento",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdInfPedidoCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 466, 3
+        ),
+    )
 
-    
-    InfPedidoCancelamento = property(__InfPedidoCancelamento.value, __InfPedidoCancelamento.set, None, None)
+    InfPedidoCancelamento = property(
+        __InfPedidoCancelamento.value, __InfPedidoCancelamento.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brtipos_v03_xsd_tcPedidoCancelamento_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcPedidoCancelamento_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __InfPedidoCancelamento.name() : __InfPedidoCancelamento,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__InfPedidoCancelamento.name(): __InfPedidoCancelamento, __Signature.name(): __Signature}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcPedidoCancelamento = tcPedidoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcPedidoCancelamento', tcPedidoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcPedidoCancelamento", tcPedidoCancelamento)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfConfirmacaoCancelamento with content type ELEMENT_ONLY
-class tcInfConfirmacaoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcInfConfirmacaoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfConfirmacaoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfConfirmacaoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 470, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfConfirmacaoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 470, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Sucesso uses Python identifier Sucesso
-    __Sucesso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Sucesso'), 'Sucesso', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdSucesso', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 472, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Sucesso uses Python identifier Sucesso
+    __Sucesso = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Sucesso"),
+        "Sucesso",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdSucesso",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 472, 3
+        ),
+    )
+
     Sucesso = property(__Sucesso.value, __Sucesso.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DataHora uses Python identifier DataHora
-    __DataHora = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataHora'), 'DataHora', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdDataHora', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 473, 3), )
+    __DataHora = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataHora"),
+        "DataHora",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdDataHora",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 473, 3
+        ),
+    )
 
-    
     DataHora = property(__DataHora.value, __DataHora.set, None, None)
 
-    _ElementMap.update({
-        __Sucesso.name() : __Sucesso,
-        __DataHora.name() : __DataHora
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Sucesso.name(): __Sucesso, __DataHora.name(): __DataHora})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcInfConfirmacaoCancelamento = tcInfConfirmacaoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcInfConfirmacaoCancelamento', tcInfConfirmacaoCancelamento)
+Namespace.addCategoryObject(
+    "typeBinding", "tcInfConfirmacaoCancelamento", tcInfConfirmacaoCancelamento
+)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCancelamentoNfse with content type ELEMENT_ONLY
-class tcCancelamentoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcCancelamentoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCancelamentoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCancelamentoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 483, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCancelamentoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 483, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Confirmacao uses Python identifier Confirmacao
-    __Confirmacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao'), 'Confirmacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCancelamentoNfse_httpwww_ginfes_com_brtipos_v03_xsdConfirmacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 485, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Confirmacao uses Python identifier Confirmacao
+    __Confirmacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Confirmacao"),
+        "Confirmacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCancelamentoNfse_httpwww_ginfes_com_brtipos_v03_xsdConfirmacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 485, 3
+        ),
+    )
+
     Confirmacao = property(__Confirmacao.value, __Confirmacao.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCancelamentoNfse_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCancelamentoNfse_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __Confirmacao.name() : __Confirmacao,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Confirmacao.name(): __Confirmacao, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcCancelamentoNfse = tcCancelamentoNfse
-Namespace.addCategoryObject('typeBinding', 'tcCancelamentoNfse', tcCancelamentoNfse)
+Namespace.addCategoryObject("typeBinding", "tcCancelamentoNfse", tcCancelamentoNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcSubstituicaoNfse with content type ELEMENT_ONLY
-class tcSubstituicaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcSubstituicaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcSubstituicaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcSubstituicaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 495, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcSubstituicaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 495, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}SubstituicaoNfse uses Python identifier SubstituicaoNfse
-    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), 'SubstituicaoNfse', '__httpwww_ginfes_com_brtipos_v03_xsd_tcSubstituicaoNfse_httpwww_ginfes_com_brtipos_v03_xsdSubstituicaoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 497, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}SubstituicaoNfse uses Python identifier SubstituicaoNfse
+    __SubstituicaoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        "SubstituicaoNfse",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcSubstituicaoNfse_httpwww_ginfes_com_brtipos_v03_xsdSubstituicaoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 497, 3
+        ),
+    )
+
     SubstituicaoNfse = property(__SubstituicaoNfse.value, __SubstituicaoNfse.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brtipos_v03_xsd_tcSubstituicaoNfse_httpwww_w3_org200009xmldsigSignature', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcSubstituicaoNfse_httpwww_w3_org200009xmldsigSignature",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __SubstituicaoNfse.name() : __SubstituicaoNfse,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__SubstituicaoNfse.name(): __SubstituicaoNfse, __Signature.name(): __Signature}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcSubstituicaoNfse = tcSubstituicaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcSubstituicaoNfse', tcSubstituicaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcSubstituicaoNfse", tcSubstituicaoNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCompNfse with content type ELEMENT_ONLY
-class tcCompNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcCompNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcCompNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcCompNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 501, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcCompNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 501, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Nfse uses Python identifier Nfse
-    __Nfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Nfse'), 'Nfse', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 503, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Nfse uses Python identifier Nfse
+    __Nfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Nfse"),
+        "Nfse",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 503, 3
+        ),
+    )
+
     Nfse = property(__Nfse.value, __Nfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NfseCancelamento uses Python identifier NfseCancelamento
-    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), 'NfseCancelamento', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 504, 3), )
+    __NfseCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        "NfseCancelamento",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 504, 3
+        ),
+    )
 
-    
     NfseCancelamento = property(__NfseCancelamento.value, __NfseCancelamento.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NfseSubstituicao uses Python identifier NfseSubstituicao
-    __NfseSubstituicao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao'), 'NfseSubstituicao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituicao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 505, 3), )
+    __NfseSubstituicao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao"),
+        "NfseSubstituicao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcCompNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituicao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 505, 3
+        ),
+    )
 
-    
     NfseSubstituicao = property(__NfseSubstituicao.value, __NfseSubstituicao.set, None, None)
 
-    _ElementMap.update({
-        __Nfse.name() : __Nfse,
-        __NfseCancelamento.name() : __NfseCancelamento,
-        __NfseSubstituicao.name() : __NfseSubstituicao
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Nfse.name(): __Nfse,
+            __NfseCancelamento.name(): __NfseCancelamento,
+            __NfseSubstituicao.name(): __NfseSubstituicao,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcCompNfse = tcCompNfse
-Namespace.addCategoryObject('typeBinding', 'tcCompNfse', tcCompNfse)
+Namespace.addCategoryObject("typeBinding", "tcCompNfse", tcCompNfse)
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 509, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 509, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}MensagemRetorno uses Python identifier MensagemRetorno
-    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), 'MensagemRetorno', '__httpwww_ginfes_com_brtipos_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdMensagemRetorno', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 511, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}MensagemRetorno uses Python identifier MensagemRetorno
+    __MensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        "MensagemRetorno",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdMensagemRetorno",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 511, 4
+        ),
+    )
+
     MensagemRetorno = property(__MensagemRetorno.value, __MensagemRetorno.set, None, None)
 
-    _ElementMap.update({
-        __MensagemRetorno.name() : __MensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__MensagemRetorno.name(): __MensagemRetorno})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcMensagemRetorno with content type ELEMENT_ONLY
-class tcMensagemRetorno (pyxb.binding.basis.complexTypeDefinition):
+class tcMensagemRetorno(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcMensagemRetorno with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcMensagemRetorno')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 515, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcMensagemRetorno")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 515, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Codigo uses Python identifier Codigo
-    __Codigo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), 'Codigo', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdCodigo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 517, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Codigo uses Python identifier Codigo
+    __Codigo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        "Codigo",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdCodigo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 517, 3
+        ),
+    )
+
     Codigo = property(__Codigo.value, __Codigo.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Mensagem uses Python identifier Mensagem
-    __Mensagem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), 'Mensagem', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdMensagem', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 518, 3), )
+    __Mensagem = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        "Mensagem",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdMensagem",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 518, 3
+        ),
+    )
 
-    
     Mensagem = property(__Mensagem.value, __Mensagem.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Correcao uses Python identifier Correcao
-    __Correcao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Correcao'), 'Correcao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdCorrecao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 519, 3), )
+    __Correcao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Correcao"),
+        "Correcao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetorno_httpwww_ginfes_com_brtipos_v03_xsdCorrecao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 519, 3
+        ),
+    )
 
-    
     Correcao = property(__Correcao.value, __Correcao.set, None, None)
 
-    _ElementMap.update({
-        __Codigo.name() : __Codigo,
-        __Mensagem.name() : __Mensagem,
-        __Correcao.name() : __Correcao
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__Codigo.name(): __Codigo, __Mensagem.name(): __Mensagem, __Correcao.name(): __Correcao}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcMensagemRetorno = tcMensagemRetorno
-Namespace.addCategoryObject('typeBinding', 'tcMensagemRetorno', tcMensagemRetorno)
+Namespace.addCategoryObject("typeBinding", "tcMensagemRetorno", tcMensagemRetorno)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcMensagemRetornoLote with content type ELEMENT_ONLY
-class tcMensagemRetornoLote (pyxb.binding.basis.complexTypeDefinition):
+class tcMensagemRetornoLote(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcMensagemRetornoLote with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcMensagemRetornoLote')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 522, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcMensagemRetornoLote")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 522, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 524, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 524, 3
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Codigo uses Python identifier Codigo
-    __Codigo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), 'Codigo', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdCodigo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 525, 3), )
+    __Codigo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        "Codigo",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdCodigo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 525, 3
+        ),
+    )
 
-    
     Codigo = property(__Codigo.value, __Codigo.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Mensagem uses Python identifier Mensagem
-    __Mensagem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), 'Mensagem', '__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdMensagem', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 526, 3), )
+    __Mensagem = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        "Mensagem",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcMensagemRetornoLote_httpwww_ginfes_com_brtipos_v03_xsdMensagem",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 526, 3
+        ),
+    )
 
-    
     Mensagem = property(__Mensagem.value, __Mensagem.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __Codigo.name() : __Codigo,
-        __Mensagem.name() : __Mensagem
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __Codigo.name(): __Codigo,
+            __Mensagem.name(): __Mensagem,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.tcMensagemRetornoLote = tcMensagemRetornoLote
-Namespace.addCategoryObject('typeBinding', 'tcMensagemRetornoLote', tcMensagemRetornoLote)
+Namespace.addCategoryObject("typeBinding", "tcMensagemRetornoLote", tcMensagemRetornoLote)
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_ (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 536, 4)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 536, 4
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Rps uses Python identifier Rps
-    __Rps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Rps'), 'Rps', '__httpwww_ginfes_com_brtipos_v03_xsd_CTD_ANON__httpwww_ginfes_com_brtipos_v03_xsdRps', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 538, 6), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Rps uses Python identifier Rps
+    __Rps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        "Rps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_CTD_ANON__httpwww_ginfes_com_brtipos_v03_xsdRps",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 538, 6
+        ),
+    )
+
     Rps = property(__Rps.value, __Rps.set, None, None)
 
-    _ElementMap.update({
-        __Rps.name() : __Rps
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Rps.name(): __Rps})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_ = CTD_ANON_
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfRps with content type ELEMENT_ONLY
-class tcInfRps (pyxb.binding.basis.complexTypeDefinition):
+class tcInfRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 395, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 395, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 397, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 397, 3
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DataEmissao uses Python identifier DataEmissao
-    __DataEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), 'DataEmissao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdDataEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 398, 3), )
+    __DataEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        "DataEmissao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdDataEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 398, 3
+        ),
+    )
 
-    
     DataEmissao = property(__DataEmissao.value, __DataEmissao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NaturezaOperacao uses Python identifier NaturezaOperacao
-    __NaturezaOperacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao'), 'NaturezaOperacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdNaturezaOperacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 399, 3), )
+    __NaturezaOperacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao"),
+        "NaturezaOperacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdNaturezaOperacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 399, 3
+        ),
+    )
 
-    
     NaturezaOperacao = property(__NaturezaOperacao.value, __NaturezaOperacao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}RegimeEspecialTributacao uses Python identifier RegimeEspecialTributacao
-    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), 'RegimeEspecialTributacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdRegimeEspecialTributacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 400, 3), )
+    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        "RegimeEspecialTributacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdRegimeEspecialTributacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 400, 3
+        ),
+    )
 
-    
-    RegimeEspecialTributacao = property(__RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None)
+    RegimeEspecialTributacao = property(
+        __RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}OptanteSimplesNacional uses Python identifier OptanteSimplesNacional
-    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), 'OptanteSimplesNacional', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdOptanteSimplesNacional', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 401, 3), )
+    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        "OptanteSimplesNacional",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdOptanteSimplesNacional",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 401, 3
+        ),
+    )
 
-    
-    OptanteSimplesNacional = property(__OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None)
+    OptanteSimplesNacional = property(
+        __OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IncentivadorCultural uses Python identifier IncentivadorCultural
-    __IncentivadorCultural = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural'), 'IncentivadorCultural', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIncentivadorCultural', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 402, 3), )
+    __IncentivadorCultural = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural"),
+        "IncentivadorCultural",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIncentivadorCultural",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 402, 3
+        ),
+    )
 
-    
-    IncentivadorCultural = property(__IncentivadorCultural.value, __IncentivadorCultural.set, None, None)
+    IncentivadorCultural = property(
+        __IncentivadorCultural.value, __IncentivadorCultural.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Status uses Python identifier Status
-    __Status = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Status'), 'Status', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdStatus', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 403, 3), )
+    __Status = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Status"),
+        "Status",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdStatus",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 403, 3
+        ),
+    )
 
-    
     Status = property(__Status.value, __Status.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}RpsSubstituido uses Python identifier RpsSubstituido
-    __RpsSubstituido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido'), 'RpsSubstituido', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdRpsSubstituido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 404, 3), )
+    __RpsSubstituido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido"),
+        "RpsSubstituido",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdRpsSubstituido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 404, 3
+        ),
+    )
 
-    
     RpsSubstituido = property(__RpsSubstituido.value, __RpsSubstituido.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Servico uses Python identifier Servico
-    __Servico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Servico'), 'Servico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 405, 3), )
+    __Servico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        "Servico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 405, 3
+        ),
+    )
 
-    
     Servico = property(__Servico.value, __Servico.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 406, 3), )
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 406, 3
+        ),
+    )
 
-    
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Tomador uses Python identifier Tomador
-    __Tomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), 'Tomador', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 407, 3), )
+    __Tomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        "Tomador",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 407, 3
+        ),
+    )
 
-    
     Tomador = property(__Tomador.value, __Tomador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IntermediarioServico uses Python identifier IntermediarioServico
-    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), 'IntermediarioServico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIntermediarioServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 408, 3), )
+    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        "IntermediarioServico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdIntermediarioServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 408, 3
+        ),
+    )
 
-    
-    IntermediarioServico = property(__IntermediarioServico.value, __IntermediarioServico.set, None, None)
+    IntermediarioServico = property(
+        __IntermediarioServico.value, __IntermediarioServico.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ConstrucaoCivil uses Python identifier ConstrucaoCivil
-    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), 'ConstrucaoCivil', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdConstrucaoCivil', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 409, 3), )
+    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        "ConstrucaoCivil",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_httpwww_ginfes_com_brtipos_v03_xsdConstrucaoCivil",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 409, 3
+        ),
+    )
 
-    
     ConstrucaoCivil = property(__ConstrucaoCivil.value, __ConstrucaoCivil.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 411, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 411, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfRps_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 411, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 411, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __DataEmissao.name() : __DataEmissao,
-        __NaturezaOperacao.name() : __NaturezaOperacao,
-        __RegimeEspecialTributacao.name() : __RegimeEspecialTributacao,
-        __OptanteSimplesNacional.name() : __OptanteSimplesNacional,
-        __IncentivadorCultural.name() : __IncentivadorCultural,
-        __Status.name() : __Status,
-        __RpsSubstituido.name() : __RpsSubstituido,
-        __Servico.name() : __Servico,
-        __Prestador.name() : __Prestador,
-        __Tomador.name() : __Tomador,
-        __IntermediarioServico.name() : __IntermediarioServico,
-        __ConstrucaoCivil.name() : __ConstrucaoCivil
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __DataEmissao.name(): __DataEmissao,
+            __NaturezaOperacao.name(): __NaturezaOperacao,
+            __RegimeEspecialTributacao.name(): __RegimeEspecialTributacao,
+            __OptanteSimplesNacional.name(): __OptanteSimplesNacional,
+            __IncentivadorCultural.name(): __IncentivadorCultural,
+            __Status.name(): __Status,
+            __RpsSubstituido.name(): __RpsSubstituido,
+            __Servico.name(): __Servico,
+            __Prestador.name(): __Prestador,
+            __Tomador.name(): __Tomador,
+            __IntermediarioServico.name(): __IntermediarioServico,
+            __ConstrucaoCivil.name(): __ConstrucaoCivil,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfRps = tcInfRps
-Namespace.addCategoryObject('typeBinding', 'tcInfRps', tcInfRps)
+Namespace.addCategoryObject("typeBinding", "tcInfRps", tcInfRps)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfNfse with content type ELEMENT_ONLY
-class tcInfNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcInfNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 427, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 427, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Numero'), 'Numero', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNumero', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 429, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Numero uses Python identifier Numero
+    __Numero = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        "Numero",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNumero",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 429, 3
+        ),
+    )
+
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoVerificacao uses Python identifier CodigoVerificacao
-    __CodigoVerificacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao'), 'CodigoVerificacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdCodigoVerificacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 430, 3), )
+    __CodigoVerificacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao"),
+        "CodigoVerificacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdCodigoVerificacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 430, 3
+        ),
+    )
 
-    
     CodigoVerificacao = property(__CodigoVerificacao.value, __CodigoVerificacao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DataEmissao uses Python identifier DataEmissao
-    __DataEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), 'DataEmissao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdDataEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 431, 3), )
+    __DataEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        "DataEmissao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdDataEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 431, 3
+        ),
+    )
 
-    
     DataEmissao = property(__DataEmissao.value, __DataEmissao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 432, 3), )
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 432, 3
+        ),
+    )
 
-    
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}DataEmissaoRps uses Python identifier DataEmissaoRps
-    __DataEmissaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataEmissaoRps'), 'DataEmissaoRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdDataEmissaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 433, 3), )
+    __DataEmissaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissaoRps"),
+        "DataEmissaoRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdDataEmissaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 433, 3
+        ),
+    )
 
-    
     DataEmissaoRps = property(__DataEmissaoRps.value, __DataEmissaoRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NaturezaOperacao uses Python identifier NaturezaOperacao
-    __NaturezaOperacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao'), 'NaturezaOperacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNaturezaOperacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 434, 3), )
+    __NaturezaOperacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao"),
+        "NaturezaOperacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNaturezaOperacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 434, 3
+        ),
+    )
 
-    
     NaturezaOperacao = property(__NaturezaOperacao.value, __NaturezaOperacao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}RegimeEspecialTributacao uses Python identifier RegimeEspecialTributacao
-    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), 'RegimeEspecialTributacao', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdRegimeEspecialTributacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 435, 3), )
+    __RegimeEspecialTributacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        "RegimeEspecialTributacao",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdRegimeEspecialTributacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 435, 3
+        ),
+    )
 
-    
-    RegimeEspecialTributacao = property(__RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None)
+    RegimeEspecialTributacao = property(
+        __RegimeEspecialTributacao.value, __RegimeEspecialTributacao.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}OptanteSimplesNacional uses Python identifier OptanteSimplesNacional
-    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), 'OptanteSimplesNacional', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOptanteSimplesNacional', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 436, 3), )
+    __OptanteSimplesNacional = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        "OptanteSimplesNacional",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOptanteSimplesNacional",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 436, 3
+        ),
+    )
 
-    
-    OptanteSimplesNacional = property(__OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None)
+    OptanteSimplesNacional = property(
+        __OptanteSimplesNacional.value, __OptanteSimplesNacional.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IncentivadorCultural uses Python identifier IncentivadorCultural
-    __IncentivadorCultural = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural'), 'IncentivadorCultural', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIncentivadorCultural', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 437, 3), )
+    __IncentivadorCultural = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural"),
+        "IncentivadorCultural",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIncentivadorCultural",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 437, 3
+        ),
+    )
 
-    
-    IncentivadorCultural = property(__IncentivadorCultural.value, __IncentivadorCultural.set, None, None)
+    IncentivadorCultural = property(
+        __IncentivadorCultural.value, __IncentivadorCultural.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Competencia uses Python identifier Competencia
-    __Competencia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Competencia'), 'Competencia', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdCompetencia', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 438, 3), )
+    __Competencia = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Competencia"),
+        "Competencia",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdCompetencia",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 438, 3
+        ),
+    )
 
-    
     Competencia = property(__Competencia.value, __Competencia.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}NfseSubstituida uses Python identifier NfseSubstituida
-    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), 'NfseSubstituida', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituida', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 439, 3), )
+    __NfseSubstituida = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        "NfseSubstituida",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituida",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 439, 3
+        ),
+    )
 
-    
     NfseSubstituida = property(__NfseSubstituida.value, __NfseSubstituida.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}OutrasInformacoes uses Python identifier OutrasInformacoes
-    __OutrasInformacoes = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes'), 'OutrasInformacoes', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOutrasInformacoes', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 440, 3), )
+    __OutrasInformacoes = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes"),
+        "OutrasInformacoes",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOutrasInformacoes",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 440, 3
+        ),
+    )
 
-    
     OutrasInformacoes = property(__OutrasInformacoes.value, __OutrasInformacoes.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Servico uses Python identifier Servico
-    __Servico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Servico'), 'Servico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 441, 3), )
+    __Servico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        "Servico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 441, 3
+        ),
+    )
 
-    
     Servico = property(__Servico.value, __Servico.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ValorCredito uses Python identifier ValorCredito
-    __ValorCredito = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito'), 'ValorCredito', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdValorCredito', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 442, 3), )
+    __ValorCredito = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCredito"),
+        "ValorCredito",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdValorCredito",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 442, 3
+        ),
+    )
 
-    
     ValorCredito = property(__ValorCredito.value, __ValorCredito.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}PrestadorServico uses Python identifier PrestadorServico
-    __PrestadorServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico'), 'PrestadorServico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdPrestadorServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 443, 3), )
+    __PrestadorServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PrestadorServico"),
+        "PrestadorServico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdPrestadorServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 443, 3
+        ),
+    )
 
-    
     PrestadorServico = property(__PrestadorServico.value, __PrestadorServico.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}TomadorServico uses Python identifier TomadorServico
-    __TomadorServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'TomadorServico'), 'TomadorServico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdTomadorServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 444, 3), )
+    __TomadorServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "TomadorServico"),
+        "TomadorServico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdTomadorServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 444, 3
+        ),
+    )
 
-    
     TomadorServico = property(__TomadorServico.value, __TomadorServico.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}IntermediarioServico uses Python identifier IntermediarioServico
-    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), 'IntermediarioServico', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIntermediarioServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 445, 3), )
+    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        "IntermediarioServico",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdIntermediarioServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 445, 3
+        ),
+    )
 
-    
-    IntermediarioServico = property(__IntermediarioServico.value, __IntermediarioServico.set, None, None)
+    IntermediarioServico = property(
+        __IntermediarioServico.value, __IntermediarioServico.set, None, None
+    )
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}OrgaoGerador uses Python identifier OrgaoGerador
-    __OrgaoGerador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador'), 'OrgaoGerador', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOrgaoGerador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 446, 3), )
+    __OrgaoGerador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador"),
+        "OrgaoGerador",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdOrgaoGerador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 446, 3
+        ),
+    )
 
-    
     OrgaoGerador = property(__OrgaoGerador.value, __OrgaoGerador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ConstrucaoCivil uses Python identifier ConstrucaoCivil
-    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), 'ConstrucaoCivil', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdConstrucaoCivil', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 447, 3), )
+    __ConstrucaoCivil = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        "ConstrucaoCivil",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_httpwww_ginfes_com_brtipos_v03_xsdConstrucaoCivil",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 447, 3
+        ),
+    )
 
-    
     ConstrucaoCivil = property(__ConstrucaoCivil.value, __ConstrucaoCivil.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 449, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 449, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfNfse_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 449, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 449, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Numero.name() : __Numero,
-        __CodigoVerificacao.name() : __CodigoVerificacao,
-        __DataEmissao.name() : __DataEmissao,
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __DataEmissaoRps.name() : __DataEmissaoRps,
-        __NaturezaOperacao.name() : __NaturezaOperacao,
-        __RegimeEspecialTributacao.name() : __RegimeEspecialTributacao,
-        __OptanteSimplesNacional.name() : __OptanteSimplesNacional,
-        __IncentivadorCultural.name() : __IncentivadorCultural,
-        __Competencia.name() : __Competencia,
-        __NfseSubstituida.name() : __NfseSubstituida,
-        __OutrasInformacoes.name() : __OutrasInformacoes,
-        __Servico.name() : __Servico,
-        __ValorCredito.name() : __ValorCredito,
-        __PrestadorServico.name() : __PrestadorServico,
-        __TomadorServico.name() : __TomadorServico,
-        __IntermediarioServico.name() : __IntermediarioServico,
-        __OrgaoGerador.name() : __OrgaoGerador,
-        __ConstrucaoCivil.name() : __ConstrucaoCivil
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __Numero.name(): __Numero,
+            __CodigoVerificacao.name(): __CodigoVerificacao,
+            __DataEmissao.name(): __DataEmissao,
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __DataEmissaoRps.name(): __DataEmissaoRps,
+            __NaturezaOperacao.name(): __NaturezaOperacao,
+            __RegimeEspecialTributacao.name(): __RegimeEspecialTributacao,
+            __OptanteSimplesNacional.name(): __OptanteSimplesNacional,
+            __IncentivadorCultural.name(): __IncentivadorCultural,
+            __Competencia.name(): __Competencia,
+            __NfseSubstituida.name(): __NfseSubstituida,
+            __OutrasInformacoes.name(): __OutrasInformacoes,
+            __Servico.name(): __Servico,
+            __ValorCredito.name(): __ValorCredito,
+            __PrestadorServico.name(): __PrestadorServico,
+            __TomadorServico.name(): __TomadorServico,
+            __IntermediarioServico.name(): __IntermediarioServico,
+            __OrgaoGerador.name(): __OrgaoGerador,
+            __ConstrucaoCivil.name(): __ConstrucaoCivil,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfNfse = tcInfNfse
-Namespace.addCategoryObject('typeBinding', 'tcInfNfse', tcInfNfse)
+Namespace.addCategoryObject("typeBinding", "tcInfNfse", tcInfNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfPedidoCancelamento with content type ELEMENT_ONLY
-class tcInfPedidoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcInfPedidoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfPedidoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfPedidoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 457, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfPedidoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 457, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoNfse uses Python identifier IdentificacaoNfse
-    __IdentificacaoNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse'), 'IdentificacaoNfse', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 459, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}IdentificacaoNfse uses Python identifier IdentificacaoNfse
+    __IdentificacaoNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse"),
+        "IdentificacaoNfse",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdIdentificacaoNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 459, 3
+        ),
+    )
+
     IdentificacaoNfse = property(__IdentificacaoNfse.value, __IdentificacaoNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}CodigoCancelamento uses Python identifier CodigoCancelamento
-    __CodigoCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento'), 'CodigoCancelamento', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdCodigoCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 460, 3), )
+    __CodigoCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento"),
+        "CodigoCancelamento",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdCodigoCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 460, 3
+        ),
+    )
 
-    
     CodigoCancelamento = property(__CodigoCancelamento.value, __CodigoCancelamento.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 462, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 462, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfPedidoCancelamento_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 462, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 462, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoNfse.name() : __IdentificacaoNfse,
-        __CodigoCancelamento.name() : __CodigoCancelamento
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoNfse.name(): __IdentificacaoNfse,
+            __CodigoCancelamento.name(): __CodigoCancelamento,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfPedidoCancelamento = tcInfPedidoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcInfPedidoCancelamento', tcInfPedidoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcInfPedidoCancelamento", tcInfPedidoCancelamento)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcConfirmacaoCancelamento with content type ELEMENT_ONLY
-class tcConfirmacaoCancelamento (pyxb.binding.basis.complexTypeDefinition):
+class tcConfirmacaoCancelamento(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcConfirmacaoCancelamento with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcConfirmacaoCancelamento')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 476, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcConfirmacaoCancelamento")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 476, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Pedido uses Python identifier Pedido
-    __Pedido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), 'Pedido', '__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdPedido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 478, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}Pedido uses Python identifier Pedido
+    __Pedido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        "Pedido",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdPedido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 478, 3
+        ),
+    )
+
     Pedido = property(__Pedido.value, __Pedido.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InfConfirmacaoCancelamento uses Python identifier InfConfirmacaoCancelamento
-    __InfConfirmacaoCancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InfConfirmacaoCancelamento'), 'InfConfirmacaoCancelamento', '__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdInfConfirmacaoCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 479, 3), )
+    __InfConfirmacaoCancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InfConfirmacaoCancelamento"),
+        "InfConfirmacaoCancelamento",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_httpwww_ginfes_com_brtipos_v03_xsdInfConfirmacaoCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 479, 3
+        ),
+    )
 
-    
-    InfConfirmacaoCancelamento = property(__InfConfirmacaoCancelamento.value, __InfConfirmacaoCancelamento.set, None, None)
+    InfConfirmacaoCancelamento = property(
+        __InfConfirmacaoCancelamento.value, __InfConfirmacaoCancelamento.set, None, None
+    )
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 481, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 481, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcConfirmacaoCancelamento_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 481, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 481, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __Pedido.name() : __Pedido,
-        __InfConfirmacaoCancelamento.name() : __InfConfirmacaoCancelamento
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __Pedido.name(): __Pedido,
+            __InfConfirmacaoCancelamento.name(): __InfConfirmacaoCancelamento,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcConfirmacaoCancelamento = tcConfirmacaoCancelamento
-Namespace.addCategoryObject('typeBinding', 'tcConfirmacaoCancelamento', tcConfirmacaoCancelamento)
+Namespace.addCategoryObject("typeBinding", "tcConfirmacaoCancelamento", tcConfirmacaoCancelamento)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfSubstituicaoNfse with content type ELEMENT_ONLY
-class tcInfSubstituicaoNfse (pyxb.binding.basis.complexTypeDefinition):
+class tcInfSubstituicaoNfse(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcInfSubstituicaoNfse with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcInfSubstituicaoNfse')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 489, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcInfSubstituicaoNfse")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 489, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}NfseSubstituidora uses Python identifier NfseSubstituidora
-    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), 'NfseSubstituidora', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfSubstituicaoNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituidora', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 491, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}NfseSubstituidora uses Python identifier NfseSubstituidora
+    __NfseSubstituidora = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        "NfseSubstituidora",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfSubstituicaoNfse_httpwww_ginfes_com_brtipos_v03_xsdNfseSubstituidora",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 491, 3
+        ),
+    )
+
     NfseSubstituidora = property(__NfseSubstituidora.value, __NfseSubstituidora.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcInfSubstituicaoNfse_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 493, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 493, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcInfSubstituicaoNfse_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 493, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 493, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __NfseSubstituidora.name() : __NfseSubstituidora
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update({__NfseSubstituidora.name(): __NfseSubstituidora})
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcInfSubstituicaoNfse = tcInfSubstituicaoNfse
-Namespace.addCategoryObject('typeBinding', 'tcInfSubstituicaoNfse', tcInfSubstituicaoNfse)
+Namespace.addCategoryObject("typeBinding", "tcInfSubstituicaoNfse", tcInfSubstituicaoNfse)
 
 
 # Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcLoteRps with content type ELEMENT_ONLY
-class tcLoteRps (pyxb.binding.basis.complexTypeDefinition):
+class tcLoteRps(pyxb.binding.basis.complexTypeDefinition):
     """Complex type {http://www.ginfes.com.br/tipos_v03.xsd}tcLoteRps with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
-    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'tcLoteRps')
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 529, 1)
+    _ExpandedName = pyxb.namespace.ExpandedName(Namespace, "tcLoteRps")
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 529, 1
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/tipos_v03.xsd}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 531, 3), )
 
-    
+    # Element {http://www.ginfes.com.br/tipos_v03.xsd}NumeroLote uses Python identifier NumeroLote
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 531, 3
+        ),
+    )
+
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}Cnpj uses Python identifier Cnpj
-    __Cnpj = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), 'Cnpj', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdCnpj', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 532, 3), )
+    __Cnpj = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        "Cnpj",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdCnpj",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 532, 3
+        ),
+    )
 
-    
     Cnpj = property(__Cnpj.value, __Cnpj.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}InscricaoMunicipal uses Python identifier InscricaoMunicipal
-    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), 'InscricaoMunicipal', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 533, 3), )
+    __InscricaoMunicipal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        "InscricaoMunicipal",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdInscricaoMunicipal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 533, 3
+        ),
+    )
 
-    
     InscricaoMunicipal = property(__InscricaoMunicipal.value, __InscricaoMunicipal.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}QuantidadeRps uses Python identifier QuantidadeRps
-    __QuantidadeRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps'), 'QuantidadeRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdQuantidadeRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 534, 3), )
+    __QuantidadeRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps"),
+        "QuantidadeRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdQuantidadeRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 534, 3
+        ),
+    )
 
-    
     QuantidadeRps = property(__QuantidadeRps.value, __QuantidadeRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaRps uses Python identifier ListaRps
-    __ListaRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaRps'), 'ListaRps', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdListaRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 535, 3), )
+    __ListaRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaRps"),
+        "ListaRps",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_httpwww_ginfes_com_brtipos_v03_xsdListaRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 535, 3
+        ),
+    )
 
-    
     ListaRps = property(__ListaRps.value, __ListaRps.set, None, None)
 
-    
     # Attribute Id uses Python identifier Id
-    __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_Id', _module_typeBindings.tsIdTag)
-    __Id._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 543, 2)
-    __Id._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 543, 2)
-    
+    __Id = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "Id"),
+        "Id",
+        "__httpwww_ginfes_com_brtipos_v03_xsd_tcLoteRps_Id",
+        _module_typeBindings.tsIdTag,
+    )
+    __Id._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 543, 2
+    )
+    __Id._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 543, 2
+    )
+
     Id = property(__Id.value, __Id.set, None, None)
 
-    _ElementMap.update({
-        __NumeroLote.name() : __NumeroLote,
-        __Cnpj.name() : __Cnpj,
-        __InscricaoMunicipal.name() : __InscricaoMunicipal,
-        __QuantidadeRps.name() : __QuantidadeRps,
-        __ListaRps.name() : __ListaRps
-    })
-    _AttributeMap.update({
-        __Id.name() : __Id
-    })
+    _ElementMap.update(
+        {
+            __NumeroLote.name(): __NumeroLote,
+            __Cnpj.name(): __Cnpj,
+            __InscricaoMunicipal.name(): __InscricaoMunicipal,
+            __QuantidadeRps.name(): __QuantidadeRps,
+            __ListaRps.name(): __ListaRps,
+        }
+    )
+    _AttributeMap.update({__Id.name(): __Id})
+
+
 _module_typeBindings.tcLoteRps = tcLoteRps
-Namespace.addCategoryObject('typeBinding', 'tcLoteRps', tcLoteRps)
+Namespace.addCategoryObject("typeBinding", "tcLoteRps", tcLoteRps)
 
 
-ListaMensagemRetorno = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaMensagemRetorno'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1))
-Namespace.addCategoryObject('elementBinding', ListaMensagemRetorno.name().localName(), ListaMensagemRetorno)
+ListaMensagemRetorno = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ListaMensagemRetorno"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ListaMensagemRetorno.name().localName(), ListaMensagemRetorno
+)
 
 
+tcCpfCnpj._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cpf"),
+        tsCpf,
+        scope=tcCpfCnpj,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 289, 3
+        ),
+    )
+)
 
-tcCpfCnpj._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cpf'), tsCpf, scope=tcCpfCnpj, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 289, 3)))
+tcCpfCnpj._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        tsCnpj,
+        scope=tcCpfCnpj,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 290, 3
+        ),
+    )
+)
 
-tcCpfCnpj._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), tsCnpj, scope=tcCpfCnpj, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 290, 3)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -2472,217 +3844,419 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cpf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 289, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cpf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 289, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 290, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCpfCnpj._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 290, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCpfCnpj._Automaton = _BuildAutomaton()
 
 
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tsEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 295, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 296, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Complemento"),
+        tsComplementoEndereco,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 297, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Bairro"),
+        tsBairro,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 298, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 299, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        tsUf,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 300, 3
+        ),
+    )
+)
+
+tcEndereco._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cep"),
+        tsCep,
+        scope=tcEndereco,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 301, 3
+        ),
+    )
+)
 
 
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tsEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 295, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 296, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Complemento'), tsComplementoEndereco, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 297, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Bairro'), tsBairro, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 298, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 299, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Uf'), tsUf, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 300, 3)))
-
-tcEndereco._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cep'), tsCep, scope=tcEndereco, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 301, 3)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 295, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 295, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 296, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 296, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 297, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 297, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 298, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 298, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 299, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 299, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 300, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 300, 3
+        ),
+    )
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 301, 3))
+    cc_6 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 301, 3
+        ),
+    )
     counters.add(cc_6)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 295, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 295, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 296, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 296, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Complemento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 297, 3))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Complemento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 297, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Bairro')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 298, 3))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Bairro")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 298, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 299, 3))
-    st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 299, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Uf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 300, 3))
-    st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Uf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 300, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cep')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 301, 3))
-    st_6 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcEndereco._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cep")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 301, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_5, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_6, True) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_6, True)]))
     st_6._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcEndereco._Automaton = _BuildAutomaton_()
 
 
+tcContato._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Telefone"),
+        tsTelefone,
+        scope=tcContato,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 306, 3
+        ),
+    )
+)
+
+tcContato._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Email"),
+        tsEmail,
+        scope=tcContato,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 307, 3
+        ),
+    )
+)
 
 
-tcContato._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Telefone'), tsTelefone, scope=tcContato, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 306, 3)))
-
-tcContato._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Email'), tsEmail, scope=tcContato, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 307, 3)))
-
-def _BuildAutomaton_2 ():
+def _BuildAutomaton_2():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_2
     del _BuildAutomaton_2
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 306, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 306, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 307, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 307, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Telefone')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 306, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Telefone")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 306, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Email')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 307, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcContato._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Email")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 307, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcContato._Automaton = _BuildAutomaton_2()
 
 
+tcIdentificacaoOrgaoGerador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcIdentificacaoOrgaoGerador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 312, 3
+        ),
+    )
+)
+
+tcIdentificacaoOrgaoGerador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Uf"),
+        tsUf,
+        scope=tcIdentificacaoOrgaoGerador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 313, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoOrgaoGerador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcIdentificacaoOrgaoGerador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 312, 3)))
-
-tcIdentificacaoOrgaoGerador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Uf'), tsUf, scope=tcIdentificacaoOrgaoGerador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 313, 3)))
-
-def _BuildAutomaton_3 ():
+def _BuildAutomaton_3():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_3
     del _BuildAutomaton_3
@@ -2691,32 +4265,75 @@ def _BuildAutomaton_3 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 312, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoOrgaoGerador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 312, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Uf')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 313, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoOrgaoGerador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Uf")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 313, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoOrgaoGerador._Automaton = _BuildAutomaton_3()
 
 
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 318, 3
+        ),
+    )
+)
+
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Serie"),
+        tsSerieRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 319, 3
+        ),
+    )
+)
+
+tcIdentificacaoRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tipo"),
+        tsTipoRps,
+        scope=tcIdentificacaoRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 320, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 318, 3)))
-
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Serie'), tsSerieRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 319, 3)))
-
-tcIdentificacaoRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tipo'), tsTipoRps, scope=tcIdentificacaoRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 320, 3)))
-
-def _BuildAutomaton_4 ():
+def _BuildAutomaton_4():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_4
     del _BuildAutomaton_4
@@ -2725,662 +4342,1284 @@ def _BuildAutomaton_4 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 318, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 318, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Serie')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 319, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Serie")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 319, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tipo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 320, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tipo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 320, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoRps._Automaton = _BuildAutomaton_4()
 
 
+tcIdentificacaoPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        tsCnpj,
+        scope=tcIdentificacaoPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 325, 3
+        ),
+    )
+)
+
+tcIdentificacaoPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 326, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), tsCnpj, scope=tcIdentificacaoPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 325, 3)))
-
-tcIdentificacaoPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 326, 3)))
-
-def _BuildAutomaton_5 ():
+def _BuildAutomaton_5():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_5
     del _BuildAutomaton_5
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 326, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 326, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 325, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 325, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 326, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoPrestador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 326, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoPrestador._Automaton = _BuildAutomaton_5()
 
 
+tcIdentificacaoTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 331, 3
+        ),
+    )
+)
+
+tcIdentificacaoTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 332, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 331, 3)))
-
-tcIdentificacaoTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 332, 3)))
-
-def _BuildAutomaton_6 ():
+def _BuildAutomaton_6():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_6
     del _BuildAutomaton_6
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 331, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 331, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 332, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 332, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 331, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 331, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 332, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoTomador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 332, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcIdentificacaoTomador._Automaton = _BuildAutomaton_6()
 
 
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador"),
+        tcIdentificacaoTomador,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 337, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 338, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tcEndereco,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 339, 3
+        ),
+    )
+)
+
+tcDadosTomador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        tcContato,
+        scope=tcDadosTomador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 340, 3
+        ),
+    )
+)
 
 
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador'), tcIdentificacaoTomador, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 337, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 338, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tcEndereco, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 339, 3)))
-
-tcDadosTomador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Contato'), tcContato, scope=tcDadosTomador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 340, 3)))
-
-def _BuildAutomaton_7 ():
+def _BuildAutomaton_7():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_7
     del _BuildAutomaton_7
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 337, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 337, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 338, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 338, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 339, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 339, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 340, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 340, 3
+        ),
+    )
     counters.add(cc_3)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoTomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 337, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoTomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 337, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 338, 3))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 338, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 339, 3))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 339, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Contato')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 340, 3))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosTomador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Contato")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 340, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_3, True) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_3, True)]))
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
+
+
 tcDadosTomador._Automaton = _BuildAutomaton_7()
 
 
+tcIdentificacaoIntermediarioServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcIdentificacaoIntermediarioServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 345, 3
+        ),
+    )
+)
+
+tcIdentificacaoIntermediarioServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CpfCnpj"),
+        tcCpfCnpj,
+        scope=tcIdentificacaoIntermediarioServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 346, 3
+        ),
+    )
+)
+
+tcIdentificacaoIntermediarioServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoIntermediarioServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 347, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoIntermediarioServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcIdentificacaoIntermediarioServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 345, 3)))
-
-tcIdentificacaoIntermediarioServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj'), tcCpfCnpj, scope=tcIdentificacaoIntermediarioServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 346, 3)))
-
-tcIdentificacaoIntermediarioServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoIntermediarioServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 347, 3)))
-
-def _BuildAutomaton_8 ():
+def _BuildAutomaton_8():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_8
     del _BuildAutomaton_8
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 347, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 347, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoIntermediarioServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 345, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoIntermediarioServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 345, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoIntermediarioServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CpfCnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 346, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoIntermediarioServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CpfCnpj")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 346, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoIntermediarioServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 347, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoIntermediarioServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 347, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoIntermediarioServico._Automaton = _BuildAutomaton_8()
 
 
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorServicos"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 352, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 353, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorPis"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 354, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCofins"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 355, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorInss"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 356, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIr"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 357, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCsll"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 358, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IssRetido"),
+        tsSimNao,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 359, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIss"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 360, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorIssRetido"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 361, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 362, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "BaseCalculo"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 363, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Aliquota"),
+        tsAliquota,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 364, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 365, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 366, 3
+        ),
+    )
+)
+
+tcValores._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado"),
+        tsValor,
+        scope=tcValores,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 367, 3
+        ),
+    )
+)
 
 
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 352, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 353, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorPis'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 354, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 355, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorInss'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 356, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIr'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 357, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 358, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IssRetido'), tsSimNao, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 359, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIss'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 360, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorIssRetido'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 361, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 362, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 363, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Aliquota'), tsAliquota, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 364, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 365, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 366, 3)))
-
-tcValores._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado'), tsValor, scope=tcValores, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 367, 3)))
-
-def _BuildAutomaton_9 ():
+def _BuildAutomaton_9():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_9
     del _BuildAutomaton_9
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 353, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 353, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 354, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 354, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 355, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 355, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 356, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 356, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 357, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 357, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 358, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 358, 3
+        ),
+    )
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 360, 3))
+    cc_6 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 360, 3
+        ),
+    )
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 361, 3))
+    cc_7 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 361, 3
+        ),
+    )
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 362, 3))
+    cc_8 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 362, 3
+        ),
+    )
     counters.add(cc_8)
-    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 363, 3))
+    cc_9 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 363, 3
+        ),
+    )
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 364, 3))
+    cc_10 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 364, 3
+        ),
+    )
     counters.add(cc_10)
-    cc_11 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 365, 3))
+    cc_11 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 365, 3
+        ),
+    )
     counters.add(cc_11)
-    cc_12 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 366, 3))
+    cc_12 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 366, 3
+        ),
+    )
     counters.add(cc_12)
-    cc_13 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 367, 3))
+    cc_13 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 367, 3
+        ),
+    )
     counters.add(cc_13)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorServicos')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 352, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorServicos")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 352, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorDeducoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 353, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorDeducoes")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 353, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorPis')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 354, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorPis")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 354, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCofins')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 355, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorCofins")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 355, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorInss')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 356, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorInss")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 356, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIr')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 357, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIr")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 357, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCsll')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 358, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorCsll")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 358, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IssRetido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 359, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IssRetido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 359, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIss')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 360, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIss")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 360, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorIssRetido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 361, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorIssRetido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 361, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OutrasRetencoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 362, 3))
-    st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OutrasRetencoes")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 362, 3
+        ),
+    )
+    st_10 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_9, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'BaseCalculo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 363, 3))
-    st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "BaseCalculo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 363, 3
+        ),
+    )
+    st_11 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_11)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_10, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Aliquota')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 364, 3))
-    st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Aliquota")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 364, 3
+        ),
+    )
+    st_12 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_12)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_11, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorLiquidoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 365, 3))
-    st_13 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorLiquidoNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 365, 3
+        ),
+    )
+    st_13 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_13)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_12, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DescontoIncondicionado')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 366, 3))
-    st_14 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DescontoIncondicionado")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 366, 3
+        ),
+    )
+    st_14 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_14)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_13, False))
-    symbol = pyxb.binding.content.ElementUse(tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DescontoCondicionado')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 367, 3))
-    st_15 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcValores._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DescontoCondicionado")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 367, 3
+        ),
+    )
+    st_15 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_15)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_3, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_4, False) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_4, False)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_4, False)]))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_5, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-         ]))
-    transitions.append(fac.Transition(st_9, [
-         ]))
-    transitions.append(fac.Transition(st_10, [
-         ]))
-    transitions.append(fac.Transition(st_11, [
-         ]))
-    transitions.append(fac.Transition(st_12, [
-         ]))
-    transitions.append(fac.Transition(st_13, [
-         ]))
-    transitions.append(fac.Transition(st_14, [
-         ]))
-    transitions.append(fac.Transition(st_15, [
-         ]))
+    transitions.append(fac.Transition(st_8, []))
+    transitions.append(fac.Transition(st_9, []))
+    transitions.append(fac.Transition(st_10, []))
+    transitions.append(fac.Transition(st_11, []))
+    transitions.append(fac.Transition(st_12, []))
+    transitions.append(fac.Transition(st_13, []))
+    transitions.append(fac.Transition(st_14, []))
+    transitions.append(fac.Transition(st_15, []))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_6, True) ]))
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_6, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_6, False) ]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_6, True)]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_6, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_6, False)]))
     st_8._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-        fac.UpdateInstruction(cc_7, True) ]))
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_7, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_7, False) ]))
+    transitions.append(fac.Transition(st_9, [fac.UpdateInstruction(cc_7, True)]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_7, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_7, False)]))
     st_9._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_8, True) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_8, False) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_8, False) ]))
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_8, False) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_8, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_8, False) ]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_8, True)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_8, False)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_8, False)]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_8, False)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_8, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_8, False)]))
     st_10._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_9, True) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_9, False) ]))
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_9, False) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_9, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_9, False) ]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_9, True)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_9, False)]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_9, False)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_9, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_9, False)]))
     st_11._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_10, True) ]))
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_10, False) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_10, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_10, False) ]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_10, True)]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_10, False)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_10, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_10, False)]))
     st_12._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_11, True) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_11, False) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_11, False) ]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_11, True)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_11, False)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_11, False)]))
     st_13._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_12, True) ]))
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_12, False) ]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_12, True)]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_12, False)]))
     st_14._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_15, [
-        fac.UpdateInstruction(cc_13, True) ]))
+    transitions.append(fac.Transition(st_15, [fac.UpdateInstruction(cc_13, True)]))
     st_15._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcValores._Automaton = _BuildAutomaton_9()
 
 
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Valores"),
+        tcValores,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 372, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ItemListaServico"),
+        tsItemListaServico,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 373, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCnae"),
+        tsCodigoCnae,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 374, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio"),
+        tsCodigoTributacao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 375, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Discriminacao"),
+        tsDiscriminacao,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 376, 3
+        ),
+    )
+)
+
+tcDadosServico._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcDadosServico,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 377, 3
+        ),
+    )
+)
 
 
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Valores'), tcValores, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 372, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico'), tsItemListaServico, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 373, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae'), tsCodigoCnae, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 374, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio'), tsCodigoTributacao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 375, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao'), tsDiscriminacao, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 376, 3)))
-
-tcDadosServico._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcDadosServico, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 377, 3)))
-
-def _BuildAutomaton_10 ():
+def _BuildAutomaton_10():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_10
     del _BuildAutomaton_10
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 374, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 374, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 375, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 375, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Valores')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 372, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Valores")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 372, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ItemListaServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 373, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ItemListaServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 373, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoCnae')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 374, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoCnae")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 374, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoTributacaoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 375, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoTributacaoMunicipio")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 375, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Discriminacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 376, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Discriminacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 376, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 377, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosServico._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 377, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_5, []))
     st_4._set_transitionSet(transitions)
     transitions = []
     st_5._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosServico._Automaton = _BuildAutomaton_10()
 
 
+tcDadosConstrucaoCivil._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoObra"),
+        tsCodigoObra,
+        scope=tcDadosConstrucaoCivil,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 382, 3
+        ),
+    )
+)
+
+tcDadosConstrucaoCivil._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Art"),
+        tsArt,
+        scope=tcDadosConstrucaoCivil,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 383, 3
+        ),
+    )
+)
 
 
-tcDadosConstrucaoCivil._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra'), tsCodigoObra, scope=tcDadosConstrucaoCivil, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 382, 3)))
-
-tcDadosConstrucaoCivil._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Art'), tsArt, scope=tcDadosConstrucaoCivil, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 383, 3)))
-
-def _BuildAutomaton_11 ():
+def _BuildAutomaton_11():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_11
     del _BuildAutomaton_11
@@ -3389,272 +5628,579 @@ def _BuildAutomaton_11 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoObra')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 382, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoObra")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 382, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Art')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 383, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosConstrucaoCivil._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Art")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 383, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosConstrucaoCivil._Automaton = _BuildAutomaton_11()
 
 
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador"),
+        tcIdentificacaoPrestador,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 388, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RazaoSocial"),
+        tsRazaoSocial,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 389, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NomeFantasia"),
+        tsNomeFantasia,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 390, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Endereco"),
+        tcEndereco,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 391, 3
+        ),
+    )
+)
+
+tcDadosPrestador._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Contato"),
+        tcContato,
+        scope=tcDadosPrestador,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 392, 3
+        ),
+    )
+)
 
 
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador'), tcIdentificacaoPrestador, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 388, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial'), tsRazaoSocial, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 389, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia'), tsNomeFantasia, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 390, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Endereco'), tcEndereco, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 391, 3)))
-
-tcDadosPrestador._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Contato'), tcContato, scope=tcDadosPrestador, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 392, 3)))
-
-def _BuildAutomaton_12 ():
+def _BuildAutomaton_12():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_12
     del _BuildAutomaton_12
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 390, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 390, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 392, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 392, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoPrestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 388, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoPrestador")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 388, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RazaoSocial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 389, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RazaoSocial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 389, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NomeFantasia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 390, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NomeFantasia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 390, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Endereco')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 391, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Endereco")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 391, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Contato')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 392, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcDadosPrestador._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Contato")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 392, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcDadosPrestador._Automaton = _BuildAutomaton_12()
 
 
+tcRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfRps"),
+        tcInfRps,
+        scope=tcRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 415, 3
+        ),
+    )
+)
+
+tcRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
 
-tcRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfRps'), tcInfRps, scope=tcRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 415, 3)))
-
-tcRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
-
-def _BuildAutomaton_13 ():
+def _BuildAutomaton_13():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_13
     del _BuildAutomaton_13
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 416, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 416, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 415, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "InfRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 415, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcRps._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 416, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcRps._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 416, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcRps._Automaton = _BuildAutomaton_13()
 
 
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroNfse,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 421, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        tsCnpj,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 422, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 423, 3
+        ),
+    )
+)
+
+tcIdentificacaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio"),
+        tsCodigoMunicipioIbge,
+        scope=tcIdentificacaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 424, 3
+        ),
+    )
+)
 
 
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroNfse, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 421, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), tsCnpj, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 422, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 423, 3)))
-
-tcIdentificacaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio'), tsCodigoMunicipioIbge, scope=tcIdentificacaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 424, 3)))
-
-def _BuildAutomaton_14 ():
+def _BuildAutomaton_14():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_14
     del _BuildAutomaton_14
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 423, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 423, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 421, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 421, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 422, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 422, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 423, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 423, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoMunicipio')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 424, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcIdentificacaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoMunicipio")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 424, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcIdentificacaoNfse._Automaton = _BuildAutomaton_14()
 
 
+tcNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfNfse"),
+        tcInfNfse,
+        scope=tcNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 453, 3
+        ),
+    )
+)
+
+tcNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
 
-tcNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfNfse'), tcInfNfse, scope=tcNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 453, 3)))
-
-tcNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
-
-def _BuildAutomaton_15 ():
+def _BuildAutomaton_15():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_15
     del _BuildAutomaton_15
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=2, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 454, 3))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=2,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 454, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 453, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "InfNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 453, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 454, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 454, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcNfse._Automaton = _BuildAutomaton_15()
 
 
+tcPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento"),
+        tcInfPedidoCancelamento,
+        scope=tcPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 466, 3
+        ),
+    )
+)
+
+tcPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
 
-tcPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento'), tcInfPedidoCancelamento, scope=tcPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 466, 3)))
-
-tcPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
-
-def _BuildAutomaton_16 ():
+def _BuildAutomaton_16():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_16
     del _BuildAutomaton_16
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 467, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 467, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfPedidoCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 466, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InfPedidoCancelamento")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 466, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 467, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 467, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcPedidoCancelamento._Automaton = _BuildAutomaton_16()
 
 
+tcInfConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Sucesso"),
+        pyxb.binding.datatypes.boolean,
+        scope=tcInfConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 472, 3
+        ),
+    )
+)
+
+tcInfConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataHora"),
+        pyxb.binding.datatypes.dateTime,
+        scope=tcInfConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 473, 3
+        ),
+    )
+)
 
 
-tcInfConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Sucesso'), pyxb.binding.datatypes.boolean, scope=tcInfConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 472, 3)))
-
-tcInfConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataHora'), pyxb.binding.datatypes.dateTime, scope=tcInfConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 473, 3)))
-
-def _BuildAutomaton_17 ():
+def _BuildAutomaton_17():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_17
     del _BuildAutomaton_17
@@ -3663,30 +6209,64 @@ def _BuildAutomaton_17 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Sucesso')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 472, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Sucesso")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 472, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataHora')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 473, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataHora")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 473, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfConfirmacaoCancelamento._Automaton = _BuildAutomaton_17()
 
 
+tcCancelamentoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Confirmacao"),
+        tcConfirmacaoCancelamento,
+        scope=tcCancelamentoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 485, 3
+        ),
+    )
+)
+
+tcCancelamentoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcCancelamentoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
 
-tcCancelamentoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao'), tcConfirmacaoCancelamento, scope=tcCancelamentoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 485, 3)))
-
-tcCancelamentoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcCancelamentoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
-
-def _BuildAutomaton_18 ():
+def _BuildAutomaton_18():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_18
     del _BuildAutomaton_18
@@ -3695,119 +6275,237 @@ def _BuildAutomaton_18 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Confirmacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 485, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Confirmacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 485, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 486, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCancelamentoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 486, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCancelamentoNfse._Automaton = _BuildAutomaton_18()
 
 
+tcSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse"),
+        tcInfSubstituicaoNfse,
+        scope=tcSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 497, 3
+        ),
+    )
+)
+
+tcSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=tcSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
 
-tcSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse'), tcInfSubstituicaoNfse, scope=tcSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 497, 3)))
-
-tcSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=tcSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
-
-def _BuildAutomaton_19 ():
+def _BuildAutomaton_19():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_19
     del _BuildAutomaton_19
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=1, max=2, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 498, 3))
+    cc_0 = fac.CounterCondition(
+        min=1,
+        max=2,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 498, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'SubstituicaoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 497, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "SubstituicaoNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 497, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 498, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 498, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcSubstituicaoNfse._Automaton = _BuildAutomaton_19()
 
 
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Nfse"),
+        tcNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 503, 3
+        ),
+    )
+)
+
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento"),
+        tcCancelamentoNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 504, 3
+        ),
+    )
+)
+
+tcCompNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao"),
+        tcSubstituicaoNfse,
+        scope=tcCompNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 505, 3
+        ),
+    )
+)
 
 
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Nfse'), tcNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 503, 3)))
-
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento'), tcCancelamentoNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 504, 3)))
-
-tcCompNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao'), tcSubstituicaoNfse, scope=tcCompNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 505, 3)))
-
-def _BuildAutomaton_20 ():
+def _BuildAutomaton_20():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_20
     del _BuildAutomaton_20
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 504, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 504, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 505, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 505, 3
+        ),
+    )
     counters.add(cc_1)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Nfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 503, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Nfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 503, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 504, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseCancelamento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 504, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituicao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 505, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcCompNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituicao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 505, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcCompNfse._Automaton = _BuildAutomaton_20()
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno"),
+        tcMensagemRetorno,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 511, 4
+        ),
+    )
+)
 
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno'), tcMensagemRetorno, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 511, 4)))
-
-def _BuildAutomaton_21 ():
+def _BuildAutomaton_21():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_21
     del _BuildAutomaton_21
@@ -3816,73 +6514,159 @@ def _BuildAutomaton_21 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'MensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 511, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "MensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 511, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON._Automaton = _BuildAutomaton_21()
 
 
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        tsCodigoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 517, 3
+        ),
+    )
+)
+
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 518, 3
+        ),
+    )
+)
+
+tcMensagemRetorno._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Correcao"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetorno,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 519, 3
+        ),
+    )
+)
 
 
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), tsCodigoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 517, 3)))
-
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), tsDescricaoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 518, 3)))
-
-tcMensagemRetorno._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Correcao'), tsDescricaoMensagemAlerta, scope=tcMensagemRetorno, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 519, 3)))
-
-def _BuildAutomaton_22 ():
+def _BuildAutomaton_22():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_22
     del _BuildAutomaton_22
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 519, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 519, 3
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Codigo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 517, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Codigo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 517, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Mensagem')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 518, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Mensagem")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 518, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Correcao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 519, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetorno._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Correcao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 519, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcMensagemRetorno._Automaton = _BuildAutomaton_22()
 
 
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 524, 3
+        ),
+    )
+)
+
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Codigo"),
+        tsCodigoMensagemAlerta,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 525, 3
+        ),
+    )
+)
+
+tcMensagemRetornoLote._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Mensagem"),
+        tsDescricaoMensagemAlerta,
+        scope=tcMensagemRetornoLote,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 526, 3
+        ),
+    )
+)
 
 
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 524, 3)))
-
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Codigo'), tsCodigoMensagemAlerta, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 525, 3)))
-
-tcMensagemRetornoLote._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Mensagem'), tsDescricaoMensagemAlerta, scope=tcMensagemRetornoLote, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 526, 3)))
-
-def _BuildAutomaton_23 ():
+def _BuildAutomaton_23():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_23
     del _BuildAutomaton_23
@@ -3891,36 +6675,67 @@ def _BuildAutomaton_23 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 524, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 524, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Codigo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 525, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Codigo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 525, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Mensagem')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 526, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcMensagemRetornoLote._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Mensagem")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 526, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcMensagemRetornoLote._Automaton = _BuildAutomaton_23()
 
 
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Rps"),
+        tcRps,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 538, 6
+        ),
+    )
+)
 
 
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Rps'), tcRps, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 538, 6)))
-
-def _BuildAutomaton_24 ():
+def _BuildAutomaton_24():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_24
     del _BuildAutomaton_24
@@ -3929,443 +6744,1000 @@ def _BuildAutomaton_24 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Rps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 538, 6))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Rps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 538, 6
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON_._Automaton = _BuildAutomaton_24()
 
 
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 397, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        pyxb.binding.datatypes.dateTime,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 398, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao"),
+        tsNaturezaOperacao,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 399, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        tsRegimeEspecialTributacao,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 400, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        tsSimNao,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 401, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural"),
+        tsSimNao,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 402, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Status"),
+        tsStatusRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 403, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido"),
+        tcIdentificacaoRps,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 404, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        tcDadosServico,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 405, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        tcIdentificacaoPrestador,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 406, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        tcDadosTomador,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 407, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        tcIdentificacaoIntermediarioServico,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 408, 3
+        ),
+    )
+)
+
+tcInfRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        tcDadosConstrucaoCivil,
+        scope=tcInfRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 409, 3
+        ),
+    )
+)
 
 
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 397, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), pyxb.binding.datatypes.dateTime, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 398, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao'), tsNaturezaOperacao, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 399, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), tsRegimeEspecialTributacao, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 400, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), tsSimNao, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 401, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural'), tsSimNao, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 402, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Status'), tsStatusRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 403, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido'), tcIdentificacaoRps, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 404, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Servico'), tcDadosServico, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 405, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), tcIdentificacaoPrestador, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 406, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), tcDadosTomador, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 407, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), tcIdentificacaoIntermediarioServico, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 408, 3)))
-
-tcInfRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), tcDadosConstrucaoCivil, scope=tcInfRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 409, 3)))
-
-def _BuildAutomaton_25 ():
+def _BuildAutomaton_25():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_25
     del _BuildAutomaton_25
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 400, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 400, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 404, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 404, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 408, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 408, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 409, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 409, 3
+        ),
+    )
     counters.add(cc_3)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 397, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 397, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 398, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 398, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 399, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 399, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 400, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 400, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 401, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 401, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 402, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 402, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Status')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 403, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Status")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 403, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RpsSubstituido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 404, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RpsSubstituido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 404, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Servico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 405, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Servico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 405, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 406, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 406, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 407, 3))
-    st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 407, 3
+        ),
+    )
+    st_10 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 408, 3))
-    st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 408, 3
+        ),
+    )
+    st_11 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_11)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 409, 3))
-    st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 409, 3
+        ),
+    )
+    st_12 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_12)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_5, []))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-         ]))
+    transitions.append(fac.Transition(st_6, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-         ]))
-    transitions.append(fac.Transition(st_8, [
-         ]))
+    transitions.append(fac.Transition(st_7, []))
+    transitions.append(fac.Transition(st_8, []))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_8, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_8, [fac.UpdateInstruction(cc_1, False)]))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-         ]))
+    transitions.append(fac.Transition(st_9, []))
     st_8._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-         ]))
+    transitions.append(fac.Transition(st_10, []))
     st_9._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-         ]))
-    transitions.append(fac.Transition(st_12, [
-         ]))
+    transitions.append(fac.Transition(st_11, []))
+    transitions.append(fac.Transition(st_12, []))
     st_10._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_2, False)]))
     st_11._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_3, True) ]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_3, True)]))
     st_12._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfRps._Automaton = _BuildAutomaton_25()
 
 
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Numero"),
+        tsNumeroNfse,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 429, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao"),
+        tsCodigoVerificacao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 430, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissao"),
+        pyxb.binding.datatypes.dateTime,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 431, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        tcIdentificacaoRps,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 432, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataEmissaoRps"),
+        pyxb.binding.datatypes.date,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 433, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao"),
+        tsNaturezaOperacao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 434, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao"),
+        tsRegimeEspecialTributacao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 435, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional"),
+        tsSimNao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 436, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural"),
+        tsSimNao,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 437, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Competencia"),
+        pyxb.binding.datatypes.date,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 438, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida"),
+        tsNumeroNfse,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 439, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes"),
+        tsOutrasInformacoes,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 440, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Servico"),
+        tcDadosServico,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 441, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ValorCredito"),
+        tsValor,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 442, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PrestadorServico"),
+        tcDadosPrestador,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 443, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "TomadorServico"),
+        tcDadosTomador,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 444, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        tcIdentificacaoIntermediarioServico,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 445, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador"),
+        tcIdentificacaoOrgaoGerador,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 446, 3
+        ),
+    )
+)
+
+tcInfNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil"),
+        tcDadosConstrucaoCivil,
+        scope=tcInfNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 447, 3
+        ),
+    )
+)
 
 
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Numero'), tsNumeroNfse, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 429, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao'), tsCodigoVerificacao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 430, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao'), pyxb.binding.datatypes.dateTime, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 431, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), tcIdentificacaoRps, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 432, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataEmissaoRps'), pyxb.binding.datatypes.date, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 433, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao'), tsNaturezaOperacao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 434, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao'), tsRegimeEspecialTributacao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 435, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional'), tsSimNao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 436, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural'), tsSimNao, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 437, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Competencia'), pyxb.binding.datatypes.date, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 438, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida'), tsNumeroNfse, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 439, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes'), tsOutrasInformacoes, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 440, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Servico'), tcDadosServico, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 441, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito'), tsValor, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 442, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico'), tcDadosPrestador, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 443, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'TomadorServico'), tcDadosTomador, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 444, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), tcIdentificacaoIntermediarioServico, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 445, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador'), tcIdentificacaoOrgaoGerador, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 446, 3)))
-
-tcInfNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil'), tcDadosConstrucaoCivil, scope=tcInfNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 447, 3)))
-
-def _BuildAutomaton_26 ():
+def _BuildAutomaton_26():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_26
     del _BuildAutomaton_26
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 432, 3))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 432, 3
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 433, 3))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 433, 3
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 435, 3))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 435, 3
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 439, 3))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 439, 3
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 440, 3))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 440, 3
+        ),
+    )
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 442, 3))
+    cc_5 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 442, 3
+        ),
+    )
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 445, 3))
+    cc_6 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 445, 3
+        ),
+    )
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 447, 3))
+    cc_7 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 447, 3
+        ),
+    )
     counters.add(cc_7)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Numero')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 429, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Numero")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 429, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoVerificacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 430, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CodigoVerificacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 430, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 431, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 431, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 432, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 432, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataEmissaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 433, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataEmissaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 433, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NaturezaOperacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 434, 3))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NaturezaOperacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 434, 3
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'RegimeEspecialTributacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 435, 3))
-    st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "RegimeEspecialTributacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 435, 3
+        ),
+    )
+    st_6 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OptanteSimplesNacional')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 436, 3))
-    st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OptanteSimplesNacional")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 436, 3
+        ),
+    )
+    st_7 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IncentivadorCultural')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 437, 3))
-    st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IncentivadorCultural")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 437, 3
+        ),
+    )
+    st_8 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_8)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Competencia')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 438, 3))
-    st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Competencia")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 438, 3
+        ),
+    )
+    st_9 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_9)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituida')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 439, 3))
-    st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NfseSubstituida")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 439, 3
+        ),
+    )
+    st_10 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_10)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OutrasInformacoes')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 440, 3))
-    st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OutrasInformacoes")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 440, 3
+        ),
+    )
+    st_11 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_11)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Servico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 441, 3))
-    st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Servico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 441, 3
+        ),
+    )
+    st_12 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_12)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ValorCredito')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 442, 3))
-    st_13 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ValorCredito")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 442, 3
+        ),
+    )
+    st_13 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_13)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PrestadorServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 443, 3))
-    st_14 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PrestadorServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 443, 3
+        ),
+    )
+    st_14 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_14)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'TomadorServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 444, 3))
-    st_15 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "TomadorServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 444, 3
+        ),
+    )
+    st_15 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_15)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 445, 3))
-    st_16 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 445, 3
+        ),
+    )
+    st_16 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_16)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'OrgaoGerador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 446, 3))
-    st_17 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "OrgaoGerador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 446, 3
+        ),
+    )
+    st_17 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_17)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ConstrucaoCivil')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 447, 3))
-    st_18 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ConstrucaoCivil")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 447, 3
+        ),
+    )
+    st_18 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_18)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-         ]))
-    transitions.append(fac.Transition(st_7, [
-         ]))
+    transitions.append(fac.Transition(st_6, []))
+    transitions.append(fac.Transition(st_7, []))
     st_5._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_6, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_7, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_6, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_7, [fac.UpdateInstruction(cc_2, False)]))
     st_6._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_8, [
-         ]))
+    transitions.append(fac.Transition(st_8, []))
     st_7._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_9, [
-         ]))
+    transitions.append(fac.Transition(st_9, []))
     st_8._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-         ]))
-    transitions.append(fac.Transition(st_11, [
-         ]))
-    transitions.append(fac.Transition(st_12, [
-         ]))
+    transitions.append(fac.Transition(st_10, []))
+    transitions.append(fac.Transition(st_11, []))
+    transitions.append(fac.Transition(st_12, []))
     st_9._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_10, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_3, False) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_10, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_3, False)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_3, False)]))
     st_10._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_11, [
-        fac.UpdateInstruction(cc_4, True) ]))
-    transitions.append(fac.Transition(st_12, [
-        fac.UpdateInstruction(cc_4, False) ]))
+    transitions.append(fac.Transition(st_11, [fac.UpdateInstruction(cc_4, True)]))
+    transitions.append(fac.Transition(st_12, [fac.UpdateInstruction(cc_4, False)]))
     st_11._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_13, [
-         ]))
-    transitions.append(fac.Transition(st_14, [
-         ]))
+    transitions.append(fac.Transition(st_13, []))
+    transitions.append(fac.Transition(st_14, []))
     st_12._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_13, [
-        fac.UpdateInstruction(cc_5, True) ]))
-    transitions.append(fac.Transition(st_14, [
-        fac.UpdateInstruction(cc_5, False) ]))
+    transitions.append(fac.Transition(st_13, [fac.UpdateInstruction(cc_5, True)]))
+    transitions.append(fac.Transition(st_14, [fac.UpdateInstruction(cc_5, False)]))
     st_13._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_15, [
-         ]))
+    transitions.append(fac.Transition(st_15, []))
     st_14._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_16, [
-         ]))
-    transitions.append(fac.Transition(st_17, [
-         ]))
+    transitions.append(fac.Transition(st_16, []))
+    transitions.append(fac.Transition(st_17, []))
     st_15._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_16, [
-        fac.UpdateInstruction(cc_6, True) ]))
-    transitions.append(fac.Transition(st_17, [
-        fac.UpdateInstruction(cc_6, False) ]))
+    transitions.append(fac.Transition(st_16, [fac.UpdateInstruction(cc_6, True)]))
+    transitions.append(fac.Transition(st_17, [fac.UpdateInstruction(cc_6, False)]))
     st_16._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_18, [
-         ]))
+    transitions.append(fac.Transition(st_18, []))
     st_17._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_18, [
-        fac.UpdateInstruction(cc_7, True) ]))
+    transitions.append(fac.Transition(st_18, [fac.UpdateInstruction(cc_7, True)]))
     st_18._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfNfse._Automaton = _BuildAutomaton_26()
 
 
+tcInfPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse"),
+        tcIdentificacaoNfse,
+        scope=tcInfPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 459, 3
+        ),
+    )
+)
+
+tcInfPedidoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento"),
+        tsCodigoCancelamentoNfse,
+        scope=tcInfPedidoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 460, 3
+        ),
+    )
+)
 
 
-tcInfPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse'), tcIdentificacaoNfse, scope=tcInfPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 459, 3)))
-
-tcInfPedidoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento'), tsCodigoCancelamentoNfse, scope=tcInfPedidoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 460, 3)))
-
-def _BuildAutomaton_27 ():
+def _BuildAutomaton_27():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_27
     del _BuildAutomaton_27
@@ -4374,30 +7746,66 @@ def _BuildAutomaton_27 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcInfPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 459, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "IdentificacaoNfse")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 459, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfPedidoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CodigoCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 460, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfPedidoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "CodigoCancelamento")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 460, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfPedidoCancelamento._Automaton = _BuildAutomaton_27()
 
 
+tcConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Pedido"),
+        tcPedidoCancelamento,
+        scope=tcConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 478, 3
+        ),
+    )
+)
+
+tcConfirmacaoCancelamento._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InfConfirmacaoCancelamento"),
+        tcInfConfirmacaoCancelamento,
+        scope=tcConfirmacaoCancelamento,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 479, 3
+        ),
+    )
+)
 
 
-tcConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Pedido'), tcPedidoCancelamento, scope=tcConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 478, 3)))
-
-tcConfirmacaoCancelamento._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InfConfirmacaoCancelamento'), tcInfConfirmacaoCancelamento, scope=tcConfirmacaoCancelamento, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 479, 3)))
-
-def _BuildAutomaton_28 ():
+def _BuildAutomaton_28():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_28
     del _BuildAutomaton_28
@@ -4406,28 +7814,53 @@ def _BuildAutomaton_28 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Pedido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 478, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Pedido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 478, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcConfirmacaoCancelamento._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InfConfirmacaoCancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 479, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcConfirmacaoCancelamento._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "InfConfirmacaoCancelamento")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 479, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcConfirmacaoCancelamento._Automaton = _BuildAutomaton_28()
 
 
+tcInfSubstituicaoNfse._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora"),
+        tsNumeroNfse,
+        scope=tcInfSubstituicaoNfse,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 491, 3
+        ),
+    )
+)
 
 
-tcInfSubstituicaoNfse._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora'), tsNumeroNfse, scope=tcInfSubstituicaoNfse, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 491, 3)))
-
-def _BuildAutomaton_29 ():
+def _BuildAutomaton_29():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_29
     del _BuildAutomaton_29
@@ -4436,28 +7869,83 @@ def _BuildAutomaton_29 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcInfSubstituicaoNfse._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NfseSubstituidora')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 491, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcInfSubstituicaoNfse._UseForTag(
+            pyxb.namespace.ExpandedName(Namespace, "NfseSubstituidora")
+        ),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 491, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 tcInfSubstituicaoNfse._Automaton = _BuildAutomaton_29()
 
 
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        tsNumeroLote,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 531, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cnpj"),
+        tsCnpj,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 532, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal"),
+        tsInscricaoMunicipal,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 533, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps"),
+        tsQuantidadeRps,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 534, 3
+        ),
+    )
+)
+
+tcLoteRps._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaRps"),
+        CTD_ANON_,
+        scope=tcLoteRps,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 535, 3
+        ),
+    )
+)
 
 
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), tsNumeroLote, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 531, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cnpj'), tsCnpj, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 532, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal'), tsInscricaoMunicipal, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 533, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps'), tsQuantidadeRps, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 534, 3)))
-
-tcLoteRps._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaRps'), CTD_ANON_, scope=tcLoteRps, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 535, 3)))
-
-def _BuildAutomaton_30 ():
+def _BuildAutomaton_30():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_30
     del _BuildAutomaton_30
@@ -4466,43 +7954,75 @@ def _BuildAutomaton_30 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 531, 3))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 531, 3
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cnpj')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 532, 3))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cnpj")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 532, 3
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'InscricaoMunicipal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 533, 3))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "InscricaoMunicipal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 533, 3
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'QuantidadeRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 534, 3))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "QuantidadeRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 534, 3
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 535, 3))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        tcLoteRps._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 535, 3
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-         ]))
+    transitions.append(fac.Transition(st_3, []))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-         ]))
+    transitions.append(fac.Transition(st_4, []))
     st_3._set_transitionSet(transitions)
     transitions = []
     st_4._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-tcLoteRps._Automaton = _BuildAutomaton_30()
 
+
+tcLoteRps._Automaton = _BuildAutomaton_30()

--- a/pynfe/utils/nfse/ginfes/cabecalho_v03.py
+++ b/pynfe/utils/nfse/ginfes/cabecalho_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0e2620f4-a7e2-497f-ac67-2bf21c9dfe3d')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:0e2620f4-a7e2-497f-ac67-2bf21c9dfe3d"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,10 +32,15 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/cabecalho_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/cabecalho_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -63,7 +71,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -72,7 +82,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -85,48 +96,80 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 8, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 8, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element versaoDados uses Python identifier versaoDados
-    __versaoDados = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'versaoDados'), 'versaoDados', '__httpwww_ginfes_com_brcabecalho_v03_xsd_CTD_ANON_versaoDados', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 10, 4), )
 
-    
+    # Element versaoDados uses Python identifier versaoDados
+    __versaoDados = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(None, "versaoDados"),
+        "versaoDados",
+        "__httpwww_ginfes_com_brcabecalho_v03_xsd_CTD_ANON_versaoDados",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 10, 4
+        ),
+    )
+
     versaoDados = property(__versaoDados.value, __versaoDados.set, None, None)
 
-    
     # Attribute versao uses Python identifier versao
-    __versao = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versao'), 'versao', '__httpwww_ginfes_com_brcabecalho_v03_xsd_CTD_ANON_versao', _ImportedBinding__tipos.tsVersao, required=True)
-    __versao._DeclarationLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 13, 3)
-    __versao._UseLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 13, 3)
-    
+    __versao = pyxb.binding.content.AttributeUse(
+        pyxb.namespace.ExpandedName(None, "versao"),
+        "versao",
+        "__httpwww_ginfes_com_brcabecalho_v03_xsd_CTD_ANON_versao",
+        _ImportedBinding__tipos.tsVersao,
+        required=True,
+    )
+    __versao._DeclarationLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 13, 3
+    )
+    __versao._UseLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 13, 3
+    )
+
     versao = property(__versao.value, __versao.set, None, None)
 
-    _ElementMap.update({
-        __versaoDados.name() : __versaoDados
-    })
-    _AttributeMap.update({
-        __versao.name() : __versao
-    })
+    _ElementMap.update({__versaoDados.name(): __versaoDados})
+    _AttributeMap.update({__versao.name(): __versao})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-cabecalho = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'cabecalho'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 7, 1))
-Namespace.addCategoryObject('elementBinding', cabecalho.name().localName(), cabecalho)
+cabecalho = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "cabecalho"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 7, 1
+    ),
+)
+Namespace.addCategoryObject("elementBinding", cabecalho.name().localName(), cabecalho)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(None, "versaoDados"),
+        _ImportedBinding__tipos.tsVersao,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 10, 4
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'versaoDados'), _ImportedBinding__tipos.tsVersao, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 10, 4)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -135,11 +178,19 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(None, 'versaoDados')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd', 10, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(None, "versaoDados")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/cabecalho_v03.xsd", 10, 4
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_cancelar_nfse_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_cancelar_nfse_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0b395592-75a5-46a8-bd6b-7734be3db123')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:0b395592-75a5-46a8-bd6b-7734be3db123"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_cancelar_nfse_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_cancelar_nfse_envio_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,76 +99,148 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 12, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd", 12, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element Pedido uses Python identifier Pedido
-    __Pedido = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Pedido'), 'Pedido', '__httpwww_ginfes_com_brservico_cancelar_nfse_envio_v03_xsd_CTD_ANON_Pedido', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 14, 4), )
 
-    
+    # Element Pedido uses Python identifier Pedido
+    __Pedido = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(None, "Pedido"),
+        "Pedido",
+        "__httpwww_ginfes_com_brservico_cancelar_nfse_envio_v03_xsd_CTD_ANON_Pedido",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+
     Pedido = property(__Pedido.value, __Pedido.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_cancelar_nfse_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_cancelar_nfse_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __Pedido.name() : __Pedido,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__Pedido.name(): __Pedido, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-CancelarNfseEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CancelarNfseEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 11, 1))
-Namespace.addCategoryObject('elementBinding', CancelarNfseEnvio.name().localName(), CancelarNfseEnvio)
+CancelarNfseEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CancelarNfseEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd", 11, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CancelarNfseEnvio.name().localName(), CancelarNfseEnvio
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(None, "Pedido"),
+        _ImportedBinding__tipos.tcPedidoCancelamento,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Pedido'), _ImportedBinding__tipos.tcPedidoCancelamento, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 14, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 15, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd",
+            15,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(None, 'Pedido')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 14, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(None, "Pedido")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd', 15, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_envio_v03.xsd",
+            15,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_cancelar_nfse_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_cancelar_nfse_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:50cd1234-0b69-4102-a0d6-2a59b44785d5')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:50cd1234-0b69-4102-a0d6-2a59b44785d5"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_cancelar_nfse_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_cancelar_nfse_resposta_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,50 +98,104 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 6, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+        6,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_cancelar_nfse_resposta_v03.xsd}Cancelamento uses Python identifier Cancelamento
-    __Cancelamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Cancelamento'), 'Cancelamento', '__httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsdCancelamento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 8, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_cancelar_nfse_resposta_v03.xsd}Cancelamento uses Python identifier Cancelamento
+    __Cancelamento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Cancelamento"),
+        "Cancelamento",
+        "__httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsdCancelamento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+
     Cancelamento = property(__Cancelamento.value, __Cancelamento.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_cancelar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __Cancelamento.name() : __Cancelamento,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Cancelamento.name(): __Cancelamento,
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-CancelarNfseResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CancelarNfseResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 5, 1))
-Namespace.addCategoryObject('elementBinding', CancelarNfseResposta.name().localName(), CancelarNfseResposta)
+CancelarNfseResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "CancelarNfseResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+        5,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", CancelarNfseResposta.name().localName(), CancelarNfseResposta
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Cancelamento"),
+        _ImportedBinding__tipos.tcCancelamentoNfse,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Cancelamento'), _ImportedBinding__tipos.tcCancelamentoNfse, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 8, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -139,17 +204,36 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Cancelamento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 8, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Cancelamento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd', 9, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_cancelar_nfse_resposta_v03.xsd",
+            9,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:8faa8e87-188a-474a-adad-a45cc65aa6c8')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:8faa8e87-188a-474a-adad-a45cc65aa6c8"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_lote_rps_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_lote_rps_envio_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,94 +99,202 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 12, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+        12,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_envio_v03.xsd}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsdPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 14, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_envio_v03.xsd}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsdPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_envio_v03.xsd}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsdProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 16, 4), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsdProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            16,
+            4,
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __Protocolo.name() : __Protocolo,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Prestador.name(): __Prestador,
+            __Protocolo.name(): __Protocolo,
+            __Signature.name(): __Signature,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-ConsultarLoteRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarLoteRpsEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 11, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarLoteRpsEnvio.name().localName(), ConsultarLoteRpsEnvio)
+ConsultarLoteRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarLoteRpsEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+        11,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarLoteRpsEnvio.name().localName(), ConsultarLoteRpsEnvio
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        _ImportedBinding__tipos.tcIdentificacaoPrestador,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), _ImportedBinding__tipos.tcIdentificacaoPrestador, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 14, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        _ImportedBinding__tipos.tsNumeroProtocolo,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            16,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), _ImportedBinding__tipos.tsNumeroProtocolo, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 16, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 18, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            18,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 14, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            14,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 16, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            16,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd', 18, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_envio_v03.xsd",
+            18,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_lote_rps_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:b8cc56ef-9353-4115-a42e-c645db82e87d')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:b8cc56ef-9353-4115-a42e-c645db82e87d"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,77 +98,140 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 5, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+        5,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsdListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 7, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd}ListaNfse uses Python identifier ListaNfse
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsdListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            7,
+            4,
+        ),
+    )
+
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __ListaNfse.name() : __ListaNfse,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaNfse.name(): __ListaNfse, __ListaMensagemRetorno.name(): __ListaMensagemRetorno}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_ (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 8, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+        8,
+        5,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsdCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 10, 7), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_lote_rps_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_lote_rps_resposta_v03_xsdCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            10,
+            7,
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_ = CTD_ANON_
 
 
-ConsultarLoteRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarLoteRpsResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 4, 98))
-Namespace.addCategoryObject('elementBinding', ConsultarLoteRpsResposta.name().localName(), ConsultarLoteRpsResposta)
+ConsultarLoteRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarLoteRpsResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+        4,
+        98,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarLoteRpsResposta.name().localName(), ConsultarLoteRpsResposta
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            7,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 7, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -166,26 +240,56 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 7, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            7,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 14, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            14,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON._Automaton = _BuildAutomaton()
 
 
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        _ImportedBinding__tipos.tcCompNfse,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            10,
+            7,
+        ),
+    )
+)
 
 
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), _ImportedBinding__tipos.tcCompNfse, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 10, 7)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
@@ -194,13 +298,22 @@ def _BuildAutomaton_ ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd', 10, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_lote_rps_resposta_v03.xsd",
+            10,
+            7,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-         ]))
+    transitions.append(fac.Transition(st_0, []))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON_._Automaton = _BuildAutomaton_()
 
+
+CTD_ANON_._Automaton = _BuildAutomaton_()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_nfse_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_nfse_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:1d569424-9c64-46db-9660-da8ad559cf6e')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:1d569424-9c64-46db-9660-da8ad559cf6e"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,234 +99,478 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 7, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd", 7, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 9, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}NumeroNfse uses Python identifier NumeroNfse
-    __NumeroNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), 'NumeroNfse', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdNumeroNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 10, 4), )
+    __NumeroNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        "NumeroNfse",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdNumeroNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
 
-    
     NumeroNfse = property(__NumeroNfse.value, __NumeroNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}PeriodoEmissao uses Python identifier PeriodoEmissao
-    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), 'PeriodoEmissao', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdPeriodoEmissao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 11, 4), )
+    __PeriodoEmissao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        "PeriodoEmissao",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdPeriodoEmissao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
 
-    
     PeriodoEmissao = property(__PeriodoEmissao.value, __PeriodoEmissao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}Tomador uses Python identifier Tomador
-    __Tomador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), 'Tomador', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdTomador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 19, 4), )
+    __Tomador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        "Tomador",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdTomador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
 
-    
     Tomador = property(__Tomador.value, __Tomador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}IntermediarioServico uses Python identifier IntermediarioServico
-    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), 'IntermediarioServico', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdIntermediarioServico', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 20, 4), )
+    __IntermediarioServico = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        "IntermediarioServico",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdIntermediarioServico",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            20,
+            4,
+        ),
+    )
 
-    
-    IntermediarioServico = property(__IntermediarioServico.value, __IntermediarioServico.set, None, None)
+    IntermediarioServico = property(
+        __IntermediarioServico.value, __IntermediarioServico.set, None, None
+    )
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __NumeroNfse.name() : __NumeroNfse,
-        __PeriodoEmissao.name() : __PeriodoEmissao,
-        __Tomador.name() : __Tomador,
-        __IntermediarioServico.name() : __IntermediarioServico,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Prestador.name(): __Prestador,
+            __NumeroNfse.name(): __NumeroNfse,
+            __PeriodoEmissao.name(): __PeriodoEmissao,
+            __Tomador.name(): __Tomador,
+            __IntermediarioServico.name(): __IntermediarioServico,
+            __Signature.name(): __Signature,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_ (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 12, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd", 12, 5
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}DataInicial uses Python identifier DataInicial
-    __DataInicial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), 'DataInicial', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdDataInicial', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 14, 7), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}DataInicial uses Python identifier DataInicial
+    __DataInicial = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        "DataInicial",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdDataInicial",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            14,
+            7,
+        ),
+    )
+
     DataInicial = property(__DataInicial.value, __DataInicial.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_envio_v03.xsd}DataFinal uses Python identifier DataFinal
-    __DataFinal = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), 'DataFinal', '__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdDataFinal', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 15, 7), )
+    __DataFinal = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        "DataFinal",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_envio_v03_xsdDataFinal",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            15,
+            7,
+        ),
+    )
 
-    
     DataFinal = property(__DataFinal.value, __DataFinal.set, None, None)
 
-    _ElementMap.update({
-        __DataInicial.name() : __DataInicial,
-        __DataFinal.name() : __DataFinal
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__DataInicial.name(): __DataInicial, __DataFinal.name(): __DataFinal})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_ = CTD_ANON_
 
 
-ConsultarNfseEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 6, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseEnvio.name().localName(), ConsultarNfseEnvio)
+ConsultarNfseEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd", 6, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseEnvio.name().localName(), ConsultarNfseEnvio
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        _ImportedBinding__tipos.tcIdentificacaoPrestador,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), _ImportedBinding__tipos.tcIdentificacaoPrestador, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 9, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroNfse"),
+        _ImportedBinding__tipos.tsNumeroNfse,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse'), _ImportedBinding__tipos.tsNumeroNfse, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 10, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao"),
+        CTD_ANON_,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao'), CTD_ANON_, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 11, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Tomador"),
+        _ImportedBinding__tipos.tcIdentificacaoTomador,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Tomador'), _ImportedBinding__tipos.tcIdentificacaoTomador, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 19, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico"),
+        _ImportedBinding__tipos.tcIdentificacaoIntermediarioServico,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            20,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico'), _ImportedBinding__tipos.tcIdentificacaoIntermediarioServico, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 20, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 10, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 11, 4))
+    cc_1 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 19, 4))
+    cc_2 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 20, 4))
+    cc_3 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            20,
+            4,
+        ),
+    )
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 21, 4))
+    cc_4 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            21,
+            4,
+        ),
+    )
     counters.add(cc_4)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 9, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 10, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'PeriodoEmissao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 11, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "PeriodoEmissao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Tomador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 19, 4))
-    st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Tomador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IntermediarioServico')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 20, 4))
-    st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IntermediarioServico")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            20,
+            4,
+        ),
+    )
+    st_4 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 21, 4))
-    st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            21,
+            4,
+        ),
+    )
+    st_5 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_5)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
-    transitions.append(fac.Transition(st_2, [
-         ]))
-    transitions.append(fac.Transition(st_3, [
-         ]))
-    transitions.append(fac.Transition(st_4, [
-         ]))
-    transitions.append(fac.Transition(st_5, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
+    transitions.append(fac.Transition(st_2, []))
+    transitions.append(fac.Transition(st_3, []))
+    transitions.append(fac.Transition(st_4, []))
+    transitions.append(fac.Transition(st_5, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_0, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_0, False) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_0, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_0, False)]))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_1, True) ]))
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_1, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_1, False) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_1, True)]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_1, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_1, False)]))
     st_2._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_3, [
-        fac.UpdateInstruction(cc_2, True) ]))
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_2, False) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_2, False) ]))
+    transitions.append(fac.Transition(st_3, [fac.UpdateInstruction(cc_2, True)]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_2, False)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_2, False)]))
     st_3._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_4, [
-        fac.UpdateInstruction(cc_3, True) ]))
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_3, False) ]))
+    transitions.append(fac.Transition(st_4, [fac.UpdateInstruction(cc_3, True)]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_3, False)]))
     st_4._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_5, [
-        fac.UpdateInstruction(cc_4, True) ]))
+    transitions.append(fac.Transition(st_5, [fac.UpdateInstruction(cc_4, True)]))
     st_5._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON._Automaton = _BuildAutomaton()
 
 
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataInicial"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            14,
+            7,
+        ),
+    )
+)
+
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataFinal"),
+        pyxb.binding.datatypes.date,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            15,
+            7,
+        ),
+    )
+)
 
 
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataInicial'), pyxb.binding.datatypes.date, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 14, 7)))
-
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataFinal'), pyxb.binding.datatypes.date, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 15, 7)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
@@ -324,19 +579,37 @@ def _BuildAutomaton_ ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataInicial')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 14, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataInicial")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            14,
+            7,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataFinal')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd', 15, 7))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataFinal")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_envio_v03.xsd",
+            15,
+            7,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON_._Automaton = _BuildAutomaton_()
 
+
+CTD_ANON_._Automaton = _BuildAutomaton_()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_nfse_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_nfse_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:e3d45443-0779-4b8b-874d-cb68c0035c59')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:e3d45443-0779-4b8b-874d-cb68c0035c59"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,77 +98,140 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 6, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+        6,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd}ListaNfse uses Python identifier ListaNfse
-    __ListaNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), 'ListaNfse', '__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsdListaNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 8, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd}ListaNfse uses Python identifier ListaNfse
+    __ListaNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        "ListaNfse",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsdListaNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+
     ListaNfse = property(__ListaNfse.value, __ListaNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __ListaNfse.name() : __ListaNfse,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__ListaNfse.name(): __ListaNfse, __ListaMensagemRetorno.name(): __ListaMensagemRetorno}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON_ (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON_(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 9, 5)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+        9,
+        5,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsdCompNfse', True, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 11, 7), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsd_CTD_ANON__httpwww_ginfes_com_brservico_consultar_nfse_resposta_v03_xsdCompNfse",
+        True,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            11,
+            7,
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__CompNfse.name(): __CompNfse})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON_ = CTD_ANON_
 
 
-ConsultarNfseResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 5, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseResposta.name().localName(), ConsultarNfseResposta)
+ConsultarNfseResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+        5,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseResposta.name().localName(), ConsultarNfseResposta
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "ListaNfse"),
+        CTD_ANON_,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse'), CTD_ANON_, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 8, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -166,44 +240,91 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'ListaNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 8, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "ListaNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 15, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            15,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
+
+
 CTD_ANON._Automaton = _BuildAutomaton()
 
 
+CTD_ANON_._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        _ImportedBinding__tipos.tcCompNfse,
+        scope=CTD_ANON_,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            11,
+            7,
+        ),
+    )
+)
 
 
-CTD_ANON_._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), _ImportedBinding__tipos.tcCompNfse, scope=CTD_ANON_, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 11, 7)))
-
-def _BuildAutomaton_ ():
+def _BuildAutomaton_():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton_
     del _BuildAutomaton_
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 11, 7))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=None,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            11,
+            7,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd', 11, 7))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON_._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_resposta_v03.xsd",
+            11,
+            7,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     transitions = []
-    transitions.append(fac.Transition(st_0, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_0, [fac.UpdateInstruction(cc_0, True)]))
     st_0._set_transitionSet(transitions)
     return fac.Automaton(states, counters, True, containing_state=None)
-CTD_ANON_._Automaton = _BuildAutomaton_()
 
+
+CTD_ANON_._Automaton = _BuildAutomaton_()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_nfse_rps_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_nfse_rps_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:a4a61edf-1679-4da7-8bba-d795129be900')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:a4a61edf-1679-4da7-8bba-d795129be900"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_nfse_rps_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_nfse_rps_envio_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,94 +99,202 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 13, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+        13,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_rps_envio_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
-    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), 'IdentificacaoRps', '__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsdIdentificacaoRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 15, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_rps_envio_v03.xsd}IdentificacaoRps uses Python identifier IdentificacaoRps
+    __IdentificacaoRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        "IdentificacaoRps",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsdIdentificacaoRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            15,
+            4,
+        ),
+    )
+
     IdentificacaoRps = property(__IdentificacaoRps.value, __IdentificacaoRps.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_nfse_rps_envio_v03.xsd}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsdPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 17, 4), )
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsdPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            17,
+            4,
+        ),
+    )
 
-    
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __IdentificacaoRps.name() : __IdentificacaoRps,
-        __Prestador.name() : __Prestador,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __IdentificacaoRps.name(): __IdentificacaoRps,
+            __Prestador.name(): __Prestador,
+            __Signature.name(): __Signature,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-ConsultarNfseRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseRpsEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 12, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseRpsEnvio.name().localName(), ConsultarNfseRpsEnvio)
+ConsultarNfseRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseRpsEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+        12,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseRpsEnvio.name().localName(), ConsultarNfseRpsEnvio
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps"),
+        _ImportedBinding__tipos.tcIdentificacaoRps,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            15,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps'), _ImportedBinding__tipos.tcIdentificacaoRps, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 15, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        _ImportedBinding__tipos.tcIdentificacaoPrestador,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            17,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), _ImportedBinding__tipos.tcIdentificacaoPrestador, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 17, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 19, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'IdentificacaoRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 15, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "IdentificacaoRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            15,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 17, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            17,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd', 19, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_envio_v03.xsd",
+            19,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_nfse_rps_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_nfse_rps_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:235876ac-3889-4e8d-a9c2-93e46837978b')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:235876ac-3889-4e8d-a9c2-93e46837978b"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_nfse_rps_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_nfse_rps_resposta_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,50 +98,101 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 6, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+        6,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_nfse_rps_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
-    __CompNfse = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), 'CompNfse', '__httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsdCompNfse', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 8, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_nfse_rps_resposta_v03.xsd}CompNfse uses Python identifier CompNfse
+    __CompNfse = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        "CompNfse",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsdCompNfse",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+
     CompNfse = property(__CompNfse.value, __CompNfse.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_consultar_nfse_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __CompNfse.name() : __CompNfse,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {__CompNfse.name(): __CompNfse, __ListaMensagemRetorno.name(): __ListaMensagemRetorno}
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-ConsultarNfseRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarNfseRpsResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 5, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarNfseRpsResposta.name().localName(), ConsultarNfseRpsResposta)
+ConsultarNfseRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarNfseRpsResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+        5,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", ConsultarNfseRpsResposta.name().localName(), ConsultarNfseRpsResposta
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "CompNfse"),
+        _ImportedBinding__tipos.tcCompNfse,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'CompNfse'), _ImportedBinding__tipos.tcCompNfse, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 8, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -139,17 +201,36 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'CompNfse')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 8, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "CompNfse")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+            8,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd', 9, 4))
-    st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_nfse_rps_resposta_v03.xsd",
+            9,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_situacao_lote_rps_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_situacao_lote_rps_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:f51a6737-8f0b-448f-9a7f-24418e7efbb2')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:f51a6737-8f0b-448f-9a7f-24418e7efbb2"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,18 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+    create_if_missing=True,
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +75,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +86,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,94 +100,204 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 8, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+        8,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_envio_v03.xsd}Prestador uses Python identifier Prestador
-    __Prestador = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), 'Prestador', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsdPrestador', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 10, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_envio_v03.xsd}Prestador uses Python identifier Prestador
+    __Prestador = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        "Prestador",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsdPrestador",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+
     Prestador = property(__Prestador.value, __Prestador.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_envio_v03.xsd}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsdProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 11, 4), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsdProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __Prestador.name() : __Prestador,
-        __Protocolo.name() : __Protocolo,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __Prestador.name(): __Prestador,
+            __Protocolo.name(): __Protocolo,
+            __Signature.name(): __Signature,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-ConsultarSituacaoLoteRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarSituacaoLoteRpsEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 7, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarSituacaoLoteRpsEnvio.name().localName(), ConsultarSituacaoLoteRpsEnvio)
+ConsultarSituacaoLoteRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarSituacaoLoteRpsEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+        7,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarSituacaoLoteRpsEnvio.name().localName(),
+    ConsultarSituacaoLoteRpsEnvio,
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Prestador"),
+        _ImportedBinding__tipos.tcIdentificacaoPrestador,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Prestador'), _ImportedBinding__tipos.tcIdentificacaoPrestador, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 10, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        _ImportedBinding__tipos.tsNumeroProtocolo,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), _ImportedBinding__tipos.tsNumeroProtocolo, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 11, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 12, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            12,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Prestador')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 10, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Prestador")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 11, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            11,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd', 12, 4))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_envio_v03.xsd",
+            12,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_2, [fac.UpdateInstruction(cc_0, True)]))
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_consultar_situacao_lote_rps_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_consultar_situacao_lote_rps_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:fbc5e3c4-ae85-46e7-94d3-4eb6e03e8f0c')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:fbc5e3c4-ae85-46e7-94d3-4eb6e03e8f0c"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,18 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+    create_if_missing=True,
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,60 +99,135 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 6, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+        6,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_resposta_v03.xsd}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsdNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 9, 5), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_resposta_v03.xsd}NumeroLote uses Python identifier NumeroLote
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsdNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            9,
+            5,
+        ),
+    )
+
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_consultar_situacao_lote_rps_resposta_v03.xsd}Situacao uses Python identifier Situacao
-    __Situacao = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Situacao'), 'Situacao', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsdSituacao', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 10, 5), )
+    __Situacao = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Situacao"),
+        "Situacao",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsdSituacao",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            10,
+            5,
+        ),
+    )
 
-    
     Situacao = property(__Situacao.value, __Situacao.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_consultar_situacao_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __NumeroLote.name() : __NumeroLote,
-        __Situacao.name() : __Situacao,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __NumeroLote.name(): __NumeroLote,
+            __Situacao.name(): __Situacao,
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-ConsultarSituacaoLoteRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'ConsultarSituacaoLoteRpsResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 5, 1))
-Namespace.addCategoryObject('elementBinding', ConsultarSituacaoLoteRpsResposta.name().localName(), ConsultarSituacaoLoteRpsResposta)
+ConsultarSituacaoLoteRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "ConsultarSituacaoLoteRpsResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+        5,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding",
+    ConsultarSituacaoLoteRpsResposta.name().localName(),
+    ConsultarSituacaoLoteRpsResposta,
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        _ImportedBinding__tipos.tsNumeroLote,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            9,
+            5,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), _ImportedBinding__tipos.tsNumeroLote, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 9, 5)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Situacao"),
+        _ImportedBinding__tipos.tsSituacaoLoteRps,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            10,
+            5,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Situacao'), _ImportedBinding__tipos.tsSituacaoLoteRps, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 10, 5)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -149,25 +236,52 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 9, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            9,
+            5,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Situacao')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 10, 5))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Situacao")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            10,
+            5,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd', 12, 4))
-    st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_consultar_situacao_lote_rps_resposta_v03.xsd",
+            12,
+            4,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_enviar_lote_rps_envio_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_enviar_lote_rps_envio_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:39de2bfc-9ae4-40e1-bb37-494b66bc6a8d')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:39de2bfc-9ae4-40e1-bb37-494b66bc6a8d"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -30,12 +33,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_dsig = _ImportedBinding__dsig.Namespace
-_Namespace_dsig.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_dsig.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -66,7 +74,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -75,7 +85,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -88,76 +99,148 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 7, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd", 7, 2
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd}LoteRps uses Python identifier LoteRps
-    __LoteRps = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), 'LoteRps', '__httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsdLoteRps', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 9, 4), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_envio_v03.xsd}LoteRps uses Python identifier LoteRps
+    __LoteRps = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        "LoteRps",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsdLoteRps",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+
     LoteRps = property(__LoteRps.value, __LoteRps.set, None, None)
 
-    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
-    __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), 'Signature', '__httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0), )
+    __Signature = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        "Signature",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_envio_v03_xsd_CTD_ANON_httpwww_w3_org200009xmldsigSignature",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
 
-    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-    _ElementMap.update({
-        __LoteRps.name() : __LoteRps,
-        __Signature.name() : __Signature
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update({__LoteRps.name(): __LoteRps, __Signature.name(): __Signature})
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-EnviarLoteRpsEnvio = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsEnvio'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 6, 1))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsEnvio.name().localName(), EnviarLoteRpsEnvio)
+EnviarLoteRpsEnvio = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsEnvio"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd", 6, 1
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", EnviarLoteRpsEnvio.name().localName(), EnviarLoteRpsEnvio
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "LoteRps"),
+        _ImportedBinding__tipos.tcLoteRps,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'LoteRps'), _ImportedBinding__tipos.tcLoteRps, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 9, 4)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature"),
+        _ImportedBinding__dsig.SignatureType,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd",
+            41,
+            0,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature'), _ImportedBinding__dsig.SignatureType, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/xmldsig-core-schema20020212_v03.xsd', 41, 0)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 10, 4))
+    cc_0 = fac.CounterCondition(
+        min=0,
+        max=1,
+        metadata=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'LoteRps')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 9, 4))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "LoteRps")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd",
+            9,
+            4,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, 'Signature')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd', 10, 4))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_dsig, "Signature")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_envio_v03.xsd",
+            10,
+            4,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-        fac.UpdateInstruction(cc_0, True) ]))
+    transitions.append(fac.Transition(st_1, [fac.UpdateInstruction(cc_0, True)]))
     st_1._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/nfse/ginfes/servico_enviar_lote_rps_resposta_v03.py
+++ b/pynfe/utils/nfse/ginfes/servico_enviar_lote_rps_resposta_v03.py
@@ -14,11 +14,14 @@ import pyxb.utils.utility
 import pyxb.utils.domutils
 import sys
 import pyxb.utils.six as _six
+
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:9559ba2f-ca50-4313-910d-fe9d437f0e44')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier(
+    "urn:uuid:9559ba2f-ca50-4313-910d-fe9d437f0e44"
+)
 
 # Version of PyXB used to generate the bindings
-_PyXBVersion = '1.2.6'
+_PyXBVersion = "1.2.6"
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
@@ -29,12 +32,17 @@ from pynfe.utils.nfse.ginfes import _tipos as _ImportedBinding__tipos
 import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
-Namespace = pyxb.namespace.NamespaceForURI('http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd', create_if_missing=True)
-Namespace.configureCategories(['typeBinding', 'elementBinding'])
+Namespace = pyxb.namespace.NamespaceForURI(
+    "http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd", create_if_missing=True
+)
+Namespace.configureCategories(["typeBinding", "elementBinding"])
 _Namespace_tipos = _ImportedBinding__tipos.Namespace
-_Namespace_tipos.configureCategories(['typeBinding', 'elementBinding'])
+_Namespace_tipos.configureCategories(["typeBinding", "elementBinding"])
 
-def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, default_namespace=None):
+
+def CreateFromDocument(
+    xml_text, fallback_namespace=None, location_base=None, default_namespace=None
+):
     """Parse the given XML and use the document element to create a
     Python instance.
 
@@ -65,7 +73,9 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
         fallback_namespace = default_namespace
     if fallback_namespace is None:
         fallback_namespace = Namespace.fallbackNamespace()
-    saxer = pyxb.binding.saxer.make_parser(fallback_namespace=fallback_namespace, location_base=location_base)
+    saxer = pyxb.binding.saxer.make_parser(
+        fallback_namespace=fallback_namespace, location_base=location_base
+    )
     handler = saxer.getContentHandler()
     xmld = xml_text
     if isinstance(xmld, _six.text_type):
@@ -74,7 +84,8 @@ def CreateFromDocument (xml_text, fallback_namespace=None, location_base=None, d
     instance = handler.rootObject()
     return instance
 
-def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
+
+def CreateFromDOM(node, fallback_namespace=None, default_namespace=None):
     """Create a Python instance from the given DOM node.
     The node tag must correspond to an element declaration in this module.
 
@@ -87,70 +98,162 @@ def CreateFromDOM (node, fallback_namespace=None, default_namespace=None):
 
 
 # Complex type [anonymous] with content type ELEMENT_ONLY
-class CTD_ANON (pyxb.binding.basis.complexTypeDefinition):
+class CTD_ANON(pyxb.binding.basis.complexTypeDefinition):
     """Complex type [anonymous] with content type ELEMENT_ONLY"""
+
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = None
-    _XSDLocation = pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 10, 2)
+    _XSDLocation = pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+        10,
+        2,
+    )
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-    
-    # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd}NumeroLote uses Python identifier NumeroLote
-    __NumeroLote = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), 'NumeroLote', '__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdNumeroLote', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 13, 5), )
 
-    
+    # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd}NumeroLote uses Python identifier NumeroLote
+    __NumeroLote = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        "NumeroLote",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdNumeroLote",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            13,
+            5,
+        ),
+    )
+
     NumeroLote = property(__NumeroLote.value, __NumeroLote.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd}DataRecebimento uses Python identifier DataRecebimento
-    __DataRecebimento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), 'DataRecebimento', '__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdDataRecebimento', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 15, 5), )
+    __DataRecebimento = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        "DataRecebimento",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdDataRecebimento",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            15,
+            5,
+        ),
+    )
 
-    
     DataRecebimento = property(__DataRecebimento.value, __DataRecebimento.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/servico_enviar_lote_rps_resposta_v03.xsd}Protocolo uses Python identifier Protocolo
-    __Protocolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), 'Protocolo', '__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdProtocolo', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 17, 5), )
+    __Protocolo = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        "Protocolo",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsdProtocolo",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            17,
+            5,
+        ),
+    )
 
-    
     Protocolo = property(__Protocolo.value, __Protocolo.set, None, None)
 
-    
     # Element {http://www.ginfes.com.br/tipos_v03.xsd}ListaMensagemRetorno uses Python identifier ListaMensagemRetorno
-    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), 'ListaMensagemRetorno', '__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno', False, pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1), )
+    __ListaMensagemRetorno = pyxb.binding.content.ElementDeclaration(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        "ListaMensagemRetorno",
+        "__httpwww_ginfes_com_brservico_enviar_lote_rps_resposta_v03_xsd_CTD_ANON_httpwww_ginfes_com_brtipos_v03_xsdListaMensagemRetorno",
+        False,
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
 
-    
-    ListaMensagemRetorno = property(__ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None)
+    ListaMensagemRetorno = property(
+        __ListaMensagemRetorno.value, __ListaMensagemRetorno.set, None, None
+    )
 
-    _ElementMap.update({
-        __NumeroLote.name() : __NumeroLote,
-        __DataRecebimento.name() : __DataRecebimento,
-        __Protocolo.name() : __Protocolo,
-        __ListaMensagemRetorno.name() : __ListaMensagemRetorno
-    })
-    _AttributeMap.update({
-        
-    })
+    _ElementMap.update(
+        {
+            __NumeroLote.name(): __NumeroLote,
+            __DataRecebimento.name(): __DataRecebimento,
+            __Protocolo.name(): __Protocolo,
+            __ListaMensagemRetorno.name(): __ListaMensagemRetorno,
+        }
+    )
+    _AttributeMap.update({})
+
+
 _module_typeBindings.CTD_ANON = CTD_ANON
 
 
-EnviarLoteRpsResposta = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'EnviarLoteRpsResposta'), CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 9, 1))
-Namespace.addCategoryObject('elementBinding', EnviarLoteRpsResposta.name().localName(), EnviarLoteRpsResposta)
+EnviarLoteRpsResposta = pyxb.binding.basis.element(
+    pyxb.namespace.ExpandedName(Namespace, "EnviarLoteRpsResposta"),
+    CTD_ANON,
+    location=pyxb.utils.utility.Location(
+        "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+        9,
+        1,
+    ),
+)
+Namespace.addCategoryObject(
+    "elementBinding", EnviarLoteRpsResposta.name().localName(), EnviarLoteRpsResposta
+)
 
 
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "NumeroLote"),
+        _ImportedBinding__tipos.tsNumeroLote,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            13,
+            5,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote'), _ImportedBinding__tipos.tsNumeroLote, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 13, 5)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "DataRecebimento"),
+        pyxb.binding.datatypes.dateTime,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            15,
+            5,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento'), pyxb.binding.datatypes.dateTime, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 15, 5)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(Namespace, "Protocolo"),
+        _ImportedBinding__tipos.tsNumeroProtocolo,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            17,
+            5,
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'Protocolo'), _ImportedBinding__tipos.tsNumeroProtocolo, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 17, 5)))
+CTD_ANON._AddElement(
+    pyxb.binding.basis.element(
+        pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno"),
+        _ImportedBinding__tipos.CTD_ANON,
+        scope=CTD_ANON,
+        location=pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd", 508, 1
+        ),
+    )
+)
 
-CTD_ANON._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno'), _ImportedBinding__tipos.CTD_ANON, scope=CTD_ANON, location=pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/tipos_v03.xsd', 508, 1)))
 
-def _BuildAutomaton ():
+def _BuildAutomaton():
     # Remove this helper function from the namespace after it is invoked
     global _BuildAutomaton
     del _BuildAutomaton
@@ -159,33 +262,68 @@ def _BuildAutomaton ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'NumeroLote')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 13, 5))
-    st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "NumeroLote")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            13,
+            5,
+        ),
+    )
+    st_0 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'DataRecebimento')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 15, 5))
-    st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "DataRecebimento")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            15,
+            5,
+        ),
+    )
+    st_1 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, 'Protocolo')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 17, 5))
-    st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(Namespace, "Protocolo")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            17,
+            5,
+        ),
+    )
+    st_2 = fac.State(
+        symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, 'ListaMensagemRetorno')), pyxb.utils.utility.Location('/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd', 20, 4))
-    st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
+    symbol = pyxb.binding.content.ElementUse(
+        CTD_ANON._UseForTag(pyxb.namespace.ExpandedName(_Namespace_tipos, "ListaMensagemRetorno")),
+        pyxb.utils.utility.Location(
+            "/workspaces/PyNFe/pynfe/data/XSDs/NFS-e/Ginfes/servico_enviar_lote_rps_resposta_v03.xsd",
+            20,
+            4,
+        ),
+    )
+    st_3 = fac.State(
+        symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False
+    )
     states.append(st_3)
     transitions = []
-    transitions.append(fac.Transition(st_1, [
-         ]))
+    transitions.append(fac.Transition(st_1, []))
     st_0._set_transitionSet(transitions)
     transitions = []
-    transitions.append(fac.Transition(st_2, [
-         ]))
+    transitions.append(fac.Transition(st_2, []))
     st_1._set_transitionSet(transitions)
     transitions = []
     st_2._set_transitionSet(transitions)
     transitions = []
     st_3._set_transitionSet(transitions)
     return fac.Automaton(states, counters, False, containing_state=None)
-CTD_ANON._Automaton = _BuildAutomaton()
 
+
+CTD_ANON._Automaton = _BuildAutomaton()

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -1,5 +1,5 @@
 """
-    @author: Junior Tada, Leonardo Tada
+@author: Junior Tada, Leonardo Tada
 """
 
 # http://nfce.encat.org/desenvolvedor/qrcode/
@@ -317,11 +317,7 @@ NFE = {
         "HTTPS": "https://",
         "HOMOLOGACAO": "https://hom",
     },
-    "MA": {
-        "CADASTRO": (
-            "https://sistemas.sefaz.ma.gov.br/wscadastro/CadConsultaCadastro2?wsdl"
-        )
-    },
+    "MA": {"CADASTRO": ("https://sistemas.sefaz.ma.gov.br/wscadastro/CadConsultaCadastro2?wsdl")},
     "PE": {
         "STATUS": "sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4",
         "AUTORIZACAO": "sefaz.pe.gov.br/nfe-service/services/NFeAutorizacao4",
@@ -334,24 +330,14 @@ NFE = {
         "HOMOLOGACAO": "https://nfehomolog.",
     },
     "BA": {
-        "STATUS": (
-            "nfe.sefaz.ba.gov.br/webservices/NFeStatusServico4/NFeStatusServico4.asmx"
-        ),
-        "AUTORIZACAO": (
-            "nfe.sefaz.ba.gov.br/webservices/NFeAutorizacao4/NFeAutorizacao4.asmx"
-        ),
-        "RECIBO": (
-            "nfe.sefaz.ba.gov.br/webservices/NFeRetAutorizacao4/NFeRetAutorizacao4.asmx"
-        ),
+        "STATUS": ("nfe.sefaz.ba.gov.br/webservices/NFeStatusServico4/NFeStatusServico4.asmx"),
+        "AUTORIZACAO": ("nfe.sefaz.ba.gov.br/webservices/NFeAutorizacao4/NFeAutorizacao4.asmx"),
+        "RECIBO": ("nfe.sefaz.ba.gov.br/webservices/NFeRetAutorizacao4/NFeRetAutorizacao4.asmx"),
         "CHAVE": (
             "nfe.sefaz.ba.gov.br/webservices/NFeConsultaProtocolo4/NFeConsultaProtocolo4.asmx"
         ),
-        "INUTILIZACAO": (
-            "nfe.sefaz.ba.gov.br/webservices/NFeInutilizacao4/NFeInutilizacao4.asmx"
-        ),
-        "EVENTOS": (
-            "nfe.sefaz.ba.gov.br/webservices/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx"
-        ),
+        "INUTILIZACAO": ("nfe.sefaz.ba.gov.br/webservices/NFeInutilizacao4/NFeInutilizacao4.asmx"),
+        "EVENTOS": ("nfe.sefaz.ba.gov.br/webservices/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx"),
         "CADASTRO": (
             "nfe.sefaz.ba.gov.br/webservices/CadConsultaCadastro4/CadConsultaCadastro4.asmx"
         ),
@@ -381,14 +367,10 @@ NFE = {
         "HOMOLOGACAO": "https://homologacao.",
     },
     "PR": {
-        "STATUS": (
-            "nfe.sefa.pr.gov.br/nfe/NFeStatusServico4"
-        ),  # CONSULTA STATUS DO SERVICO
+        "STATUS": ("nfe.sefa.pr.gov.br/nfe/NFeStatusServico4"),  # CONSULTA STATUS DO SERVICO
         "AUTORIZACAO": "nfe.sefa.pr.gov.br/nfe/NFeAutorizacao4",  # AUTORIZACAO
         "RECIBO": "nfe.sefa.pr.gov.br/nfe/NFeRetAutorizacao4",  # CONSULTA RECIBO
-        "CHAVE": (
-            "nfe.sefa.pr.gov.br/nfe/NFeConsultaProtocolo4"
-        ),  # CONSULTA CHAVE DE ACESSO
+        "CHAVE": ("nfe.sefa.pr.gov.br/nfe/NFeConsultaProtocolo4"),  # CONSULTA CHAVE DE ACESSO
         "INUTILIZACAO": "nfe.sefa.pr.gov.br/nfe/NFeInutilizacao4",  # INUTILIZAÇAO
         "EVENTOS": "nfe.sefa.pr.gov.br/nfe/NFeRecepcaoEvento4",  # REGISTRO DE EVENTOS
         "CADASTRO": "nfe.sefa.pr.gov.br/nfe/CadConsultaCadastro4",  # CONSULTA CADASTRO
@@ -445,22 +427,12 @@ NFE = {
         "HOMOLOGACAO": "https://homolog.",
     },
     "SVAN": {
-        "STATUS": (
-            "sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx"
-        ),
-        "AUTORIZACAO": (
-            "sefazvirtual.fazenda.gov.br/NFeAutorizacao4/NFeAutorizacao4.asmx"
-        ),
-        "RECIBO": (
-            "sefazvirtual.fazenda.gov.br/NFeRetAutorizacao4/NFeRetAutorizacao4.asmx"
-        ),
+        "STATUS": ("sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx"),
+        "AUTORIZACAO": ("sefazvirtual.fazenda.gov.br/NFeAutorizacao4/NFeAutorizacao4.asmx"),
+        "RECIBO": ("sefazvirtual.fazenda.gov.br/NFeRetAutorizacao4/NFeRetAutorizacao4.asmx"),
         "CHAVE": "sefazvirtual.fazenda.gov.br/NFeConsultaProtocolo4/NFeConsultaProtocolo4.asmx",
-        "INUTILIZACAO": (
-            "sefazvirtual.fazenda.gov.br/NFeInutilizacao4/NFeInutilizacao4.asmx"
-        ),
-        "EVENTOS": (
-            "sefazvirtual.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx"
-        ),
+        "INUTILIZACAO": ("sefazvirtual.fazenda.gov.br/NFeInutilizacao4/NFeInutilizacao4.asmx"),
+        "EVENTOS": ("sefazvirtual.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx"),
         "DOWNLOAD": "sefazvirtual.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx",
         "HTTPS": "https://www.",
         "HOMOLOGACAO": "https://hom.",
@@ -509,9 +481,7 @@ NFSE = {
         "CONSULTA_SERVICO_TOMADO": "ConsultarNfseServicoTomado",
         "SUBSTITUIR": "SubstituirNfse",
         "HTTPS": "http://e-gov.betha.com.br/e-nota-contribuinte-ws/nfseWS?wsdl",
-        "HOMOLOGACAO": (
-            "http://e-gov.betha.com.br/e-nota-contribuinte-test-ws/nfseWS?wsdl"
-        ),
+        "HOMOLOGACAO": ("http://e-gov.betha.com.br/e-nota-contribuinte-test-ws/nfseWS?wsdl"),
     },
     #
     "GINFES": {

--- a/pynfe/utils/xml_writer.py
+++ b/pynfe/utils/xml_writer.py
@@ -6,14 +6,15 @@ from typing import Literal, Any
 __MIN_LEN_ERROR = 'Tamanho do campo {} é menor que o mímino permitido "{}"'
 __MAX_LEN_ERROR = 'Tamanho do campo {} é maior que o mímino permitido "{}"'
 
+
 def write_txt(root: etree.ElementTree, tag_name, value: str, required: bool, min_len=0, max_len=0):
     """
-        :param root: XML root
-        :param tag_name: Nome da TAG a ser escrita (str)
-        :param value: Valor a ser escrito na TAG (str)
-        :param min_len: comprimento minimo
-        :param max-len: comprimento maximo
-        :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG
+    :param root: XML root
+    :param tag_name: Nome da TAG a ser escrita (str)
+    :param value: Valor a ser escrito na TAG (str)
+    :param min_len: comprimento minimo
+    :param max-len: comprimento maximo
+    :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG
     """
     tag_value = str(value).strip()
 
@@ -28,39 +29,49 @@ def write_txt(root: etree.ElementTree, tag_name, value: str, required: bool, min
 
     etree.SubElement(root, tag_name).text = tag_value
 
-def write_float(root: etree.ElementTree, tag_name: str, value: Decimal, required: bool, decimal_places = 2, min_decimals = 0, iat: Literal["ROUND", "TRUNC"]="ROUND"):
+
+def write_float(
+    root: etree.ElementTree,
+    tag_name: str,
+    value: Decimal,
+    required: bool,
+    decimal_places=2,
+    min_decimals=0,
+    iat: Literal["ROUND", "TRUNC"] = "ROUND",
+):
     """
-        :param root: XML root
-        :param tag_name: Nome da TAG a ser escrita (str)
-        :param value: Valor a ser escrito na TAG (str)
-        :param decimal_places: casas decimais
-        :param min_decimals: numero minimo de casas decimais
-        :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG (considera 0 como vazio)
-        :param iat: indice de arredondamento/truncamento (default: ROUND)
+    :param root: XML root
+    :param tag_name: Nome da TAG a ser escrita (str)
+    :param value: Valor a ser escrito na TAG (str)
+    :param decimal_places: casas decimais
+    :param min_decimals: numero minimo de casas decimais
+    :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG (considera 0 como vazio)
+    :param iat: indice de arredondamento/truncamento (default: ROUND)
     """
 
     # retorna sem gerar nada se a TAG não é obrigatoria
-    if is_empty(Decimal(value or '0')):
+    if is_empty(Decimal(value or "0")):
         if not required:
             return
         raise Exception(f"{tag_name} - Valor requerido e não informado")
 
     tag_value = ajustar_valor(
-        value=value.__float__(), 
-        decimal_places=decimal_places, 
-        min_decimal_places=min_decimals, 
-        tipo=iat
+        value=value.__float__(),
+        decimal_places=decimal_places,
+        min_decimal_places=min_decimals,
+        tipo=iat,
     )
 
     etree.SubElement(root, tag_name).text = tag_value
 
+
 def write_int(root: etree.ElementTree, tag_name: str, value: int, required: bool):
     """
-        :param root: XML root
-        :param tag_name: Nome da TAG a ser escrita (str)
-        :param value: Valor a ser escrito na TAG (str)
-        :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG (considera 0 como vazio)
-        :param zero_is_empty: se `True` e o valor for zero será tratado como vazio
+    :param root: XML root
+    :param tag_name: Nome da TAG a ser escrita (str)
+    :param value: Valor a ser escrito na TAG (str)
+    :param required: Se `True` e esta vazio, escreve a TAG vazia, do contrario não precisa gerar a TAG (considera 0 como vazio)
+    :param zero_is_empty: se `True` e o valor for zero será tratado como vazio
     """
 
     # retorna sem gerar nada se a TAG não é obrigatoria
@@ -68,7 +79,7 @@ def write_int(root: etree.ElementTree, tag_name: str, value: int, required: bool
         if not required:
             return
         raise Exception(f"{tag_name} - Valor requerido e não informado")
-      
+
     etree.SubElement(root, tag_name).text = int(value)
 
 
@@ -78,5 +89,5 @@ def write_tag(root: etree.ElementTree, tag_name: str, value: Any, required: bool
         if not required:
             return
         raise Exception(f"{tag_name} - Valor requerido e não informado")
-    
+
     etree.SubElement(root, tag_name).text = str(value)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ signxml
 cryptography
 # Opcional para NFS-e
 #-r requirements-nfse.txt
+# Opcional para Desenvolvimento (Pytest, Ruff, MyPy, etc)
+#-r requirements-dev.txt

--- a/tests/processamento/test_comunicacao_cte.py
+++ b/tests/processamento/test_comunicacao_cte.py
@@ -10,29 +10,33 @@ class TestComunicacaoCTe(unittest.TestCase):
     """
 
     def test_consulta(self):
-        chave = '35190912345678000123570010000000011000000018'
-        url_esperada = 'https://url.ficticia/consulta'
-        resposta_mock = '<resposta>ok</resposta>'
-        
+        chave = "35190912345678000123570010000000011000000018"
+        url_esperada = "https://url.ficticia/consulta"
+        resposta_mock = "<resposta>ok</resposta>"
+
         comunicacao = ComunicacaoCTe(
             uf="rs",
             certificado="./tests/certificado.pfx",
             certificado_senha=bytes("123456", "utf-8"),
-            homologacao=True
+            homologacao=True,
         )
         comunicacao._versao = "3.00"
         comunicacao._ambiente = 1
         comunicacao._get_url = MagicMock(return_value=url_esperada)
-        comunicacao._construir_xml_soap = MagicMock(side_effect=lambda metodo, xml: f"<soap>{etree.tostring(xml).decode()}</soap>")
+        comunicacao._construir_xml_soap = MagicMock(
+            side_effect=lambda metodo, xml: f"<soap>{etree.tostring(xml).decode()}</soap>"
+        )
         comunicacao._post = MagicMock(return_value=resposta_mock)
 
         resposta = comunicacao.consulta(chave)
         xml_gerado = comunicacao._construir_xml_soap.call_args[0][1]
         chave_extraida = xml_gerado.find(".//{*}chCTe").text
-        
+
         comunicacao._get_url.assert_called_once_with("CONSULTA")
         comunicacao._construir_xml_soap.assert_called_once()
-        comunicacao._post.assert_called_once_with(url_esperada, f"<soap>{etree.tostring(xml_gerado).decode()}</soap>")
+        comunicacao._post.assert_called_once_with(
+            url_esperada, f"<soap>{etree.tostring(xml_gerado).decode()}</soap>"
+        )
         self.assertEqual(resposta, resposta_mock)
         self.assertEqual(chave_extraida, chave)
         self.assertEqual(xml_gerado.find(".//{*}tpAmb").text, "1")
@@ -41,5 +45,5 @@ class TestComunicacaoCTe(unittest.TestCase):
         self.assertIn("xmlns", xml_gerado.attrib)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_certificadoA1.py
+++ b/tests/test_certificadoA1.py
@@ -15,9 +15,7 @@ class CertificadoTestCase(unittest.TestCase):
 
     def test_assinatura_com_caminho(self):
         self.a1 = CertificadoA1(self.certificado_correto)
-        cert = self.a1.separar_arquivo(
-            senha=self.senha_correto, caminho=self.certificado_correto
-        )
+        cert = self.a1.separar_arquivo(senha=self.senha_correto, caminho=self.certificado_correto)
 
         self.assertTrue(cert[0].startswith("/tmp/"))
         self.assertTrue(cert[1].startswith("/tmp/"))
@@ -27,28 +25,19 @@ class CertificadoTestCase(unittest.TestCase):
     def test_exception_certificado_filenotfounderror(self):
         with self.assertRaises(FileNotFoundError) as context:
             self.a1 = CertificadoA1(self.certificado_incorreto)
-            self.a1.separar_arquivo(
-                senha=self.senha_incorreto, caminho=self.certificado_incorreto
-            )
+            self.a1.separar_arquivo(senha=self.senha_incorreto, caminho=self.certificado_incorreto)
         self.assertEqual(
             str(context.exception),
-            (
-                "Falha ao abrir arquivo do certificado digital A1. Verifique o local do arquivo."
-            ),
+            ("Falha ao abrir arquivo do certificado digital A1. Verifique o local do arquivo."),
         )
 
     def test_exception_certificado_senha_errada(self):
         with self.assertRaises(Exception) as context:
             self.a1 = CertificadoA1(self.certificado_correto)
-            self.a1.separar_arquivo(
-                senha=self.senha_incorreto, caminho=self.certificado_correto
-            )
+            self.a1.separar_arquivo(senha=self.senha_incorreto, caminho=self.certificado_correto)
         self.assertEqual(
             str(context.exception),
-            (
-                "Falha ao carregar certificado digital A1. Verifique a senha do"
-                " certificado."
-            ),
+            ("Falha ao carregar certificado digital A1. Verifique a senha do certificado."),
         )
 
     def test_assinatura_sem_caminho(self):
@@ -64,18 +53,14 @@ class CertificadoTestCase(unittest.TestCase):
 
     def test_verificar_se_arquivos_temporarios_existem(self):
         self.a1 = CertificadoA1(self.certificado_correto)
-        self.a1.separar_arquivo(
-            senha=self.senha_correto, caminho=self.certificado_correto
-        )
+        self.a1.separar_arquivo(senha=self.senha_correto, caminho=self.certificado_correto)
         self.assertTrue(len(self.a1.arquivos_temp) > 0)
 
         self.a1.excluir()
 
     def test_excluir_arquivos_temporarios(self):
         self.a1 = CertificadoA1(self.certificado_correto)
-        self.a1.separar_arquivo(
-            senha=self.senha_correto, caminho=self.certificado_correto
-        )
+        self.a1.separar_arquivo(senha=self.senha_correto, caminho=self.certificado_correto)
         self.a1.excluir()
 
         self.assertTrue(len(self.a1.arquivos_temp) == 0)

--- a/tests/test_mdfe_serializacao.py
+++ b/tests/test_mdfe_serializacao.py
@@ -55,9 +55,7 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         self.xsd_procMDFe = self.validacao.get_xsd(
             xsd_file=XSD_MDFE_PROCESSADA, xsd_folder=XSD_FOLDER_MDFE
         )
-        self.xsd_mdfe = self.validacao.get_xsd(
-            xsd_file=XSD_MDFE, xsd_folder=XSD_FOLDER_MDFE
-        )
+        self.xsd_mdfe = self.validacao.get_xsd(xsd_file=XSD_MDFE, xsd_folder=XSD_FOLDER_MDFE)
 
     def preenche_manifesto(self):
         utc = datetime.timezone.utc
@@ -85,24 +83,16 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         totais = ManifestoTotais(qCTe=0, qNFe=2, vCarga=1000, cUnid="KG", qCarga=5000)
 
         # Municípios de carregamento
-        carregamento_1 = ManifestoMunicipioCarrega(
-            cMunCarrega="5105101", xMunCarrega="JUARA"
-        )
-        carregamento_2 = ManifestoMunicipioCarrega(
-            cMunCarrega="5107925", xMunCarrega="SORRISO"
-        )
+        carregamento_1 = ManifestoMunicipioCarrega(cMunCarrega="5105101", xMunCarrega="JUARA")
+        carregamento_2 = ManifestoMunicipioCarrega(cMunCarrega="5107925", xMunCarrega="SORRISO")
 
         # UFs percurso
         percurso_1 = ManifestoPercurso(UFPer="MS")
         percurso_2 = ManifestoPercurso(UFPer="GO")
 
         # modal Rodo
-        condutor_1 = ManifestoCondutor(
-            nome_motorista="JOAO DA SILVA", cpf_motorista="12345678912"
-        )
-        condutor_2 = ManifestoCondutor(
-            nome_motorista="JOSE DA SILVA", cpf_motorista="12345678911"
-        )
+        condutor_1 = ManifestoCondutor(nome_motorista="JOAO DA SILVA", cpf_motorista="12345678912")
+        condutor_2 = ManifestoCondutor(nome_motorista="JOSE DA SILVA", cpf_motorista="12345678911")
 
         veiculo_tracao = []
         veiculo_tracao.append(
@@ -161,9 +151,7 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
             vContratoGlobal=Decimal("2342.64"),
         )
 
-        contratante_2 = ManifestoContratante(
-            nome="JOSE DA SILVA", cpfcnpj="12345678911"
-        )
+        contratante_2 = ManifestoContratante(nome="JOSE DA SILVA", cpfcnpj="12345678911")
 
         modal_rodoviario = ManifestoRodoviario(
             rntrc="12345678",
@@ -284,17 +272,11 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         totais = ManifestoTotais(qCTe=0, qNFe=2, vCarga=1000, cUnid="KG", qCarga=5000)
 
         # Municípios de carregamento
-        carregamento = ManifestoMunicipioCarrega(
-            cMunCarrega="5105101", xMunCarrega="JUARA"
-        )
+        carregamento = ManifestoMunicipioCarrega(cMunCarrega="5105101", xMunCarrega="JUARA")
 
         # modal Rodo
-        condutor_1 = ManifestoCondutor(
-            nome_motorista="JOAO DA SILVA", cpf_motorista="12345678912"
-        )
-        condutor_2 = ManifestoCondutor(
-            nome_motorista="JOSE DA SILVA", cpf_motorista="12345678911"
-        )
+        condutor_1 = ManifestoCondutor(nome_motorista="JOAO DA SILVA", cpf_motorista="12345678912")
+        condutor_2 = ManifestoCondutor(nome_motorista="JOSE DA SILVA", cpf_motorista="12345678911")
 
         veiculo_tracao = []
         veiculo_tracao.append(
@@ -412,9 +394,7 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
     def grupo_ide_test(self):
         cUF = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
         tpAmb = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
-        tpEmit = self.xml_assinado.xpath("//ns:ide/ns:tpEmit", namespaces=self.ns)[
-            0
-        ].text
+        tpEmit = self.xml_assinado.xpath("//ns:ide/ns:tpEmit", namespaces=self.ns)[0].text
         mod = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
         nMDF = self.xml_assinado.xpath("//ns:ide/ns:nMDF", namespaces=self.ns)[0].text
@@ -422,20 +402,12 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         # cDV = self.xml_assinado.xpath('//ns:ide/ns:cDV', namespaces=self.ns)[0].text
         modal = self.xml_assinado.xpath("//ns:ide/ns:modal", namespaces=self.ns)[0].text
         dhEmi = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
-        tpEmis = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[
-            0
-        ].text
-        procEmi = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
-            0
-        ].text
-        verProc = self.xml_assinado.xpath("//ns:ide/ns:verProc", namespaces=self.ns)[
-            0
-        ].text
+        tpEmis = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        procEmi = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[0].text
+        verProc = self.xml_assinado.xpath("//ns:ide/ns:verProc", namespaces=self.ns)[0].text
         UFIni = self.xml_assinado.xpath("//ns:ide/ns:UFIni", namespaces=self.ns)[0].text
         UFFim = self.xml_assinado.xpath("//ns:ide/ns:UFFim", namespaces=self.ns)[0].text
-        dhIniViagem = self.xml_assinado.xpath(
-            "//ns:ide/ns:dhIniViagem", namespaces=self.ns
-        )[0].text
+        dhIniViagem = self.xml_assinado.xpath("//ns:ide/ns:dhIniViagem", namespaces=self.ns)[0].text
 
         self.assertEqual(cUF, "51")
         self.assertEqual(tpAmb, "2")
@@ -457,28 +429,18 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
     def grupo_ide_sem_rntrc_test(self):
         cUF = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
         tpAmb = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
-        tpEmit = self.xml_assinado.xpath("//ns:ide/ns:tpEmit", namespaces=self.ns)[
-            0
-        ].text
+        tpEmit = self.xml_assinado.xpath("//ns:ide/ns:tpEmit", namespaces=self.ns)[0].text
         mod = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
         nMDF = self.xml_assinado.xpath("//ns:ide/ns:nMDF", namespaces=self.ns)[0].text
         modal = self.xml_assinado.xpath("//ns:ide/ns:modal", namespaces=self.ns)[0].text
         dhEmi = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
-        tpEmis = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[
-            0
-        ].text
-        procEmi = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
-            0
-        ].text
-        verProc = self.xml_assinado.xpath("//ns:ide/ns:verProc", namespaces=self.ns)[
-            0
-        ].text
+        tpEmis = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        procEmi = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[0].text
+        verProc = self.xml_assinado.xpath("//ns:ide/ns:verProc", namespaces=self.ns)[0].text
         UFIni = self.xml_assinado.xpath("//ns:ide/ns:UFIni", namespaces=self.ns)[0].text
         UFFim = self.xml_assinado.xpath("//ns:ide/ns:UFFim", namespaces=self.ns)[0].text
-        dhIniViagem = self.xml_assinado.xpath(
-            "//ns:ide/ns:dhIniViagem", namespaces=self.ns
-        )[0].text
+        dhIniViagem = self.xml_assinado.xpath("//ns:ide/ns:dhIniViagem", namespaces=self.ns)[0].text
 
         self.assertEqual(cUF, "51")
         self.assertEqual(tpAmb, "2")
@@ -528,12 +490,12 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         self.assertEqual(xMunCarrega_1, "JUARA")
 
     def grupo_percurso(self):
-        UFPer_1 = self.xml_assinado.xpath(
-            "//ns:ide/ns:infPercurso/ns:UFPer", namespaces=self.ns
-        )[0].text
-        UFPer_2 = self.xml_assinado.xpath(
-            "//ns:ide/ns:infPercurso/ns:UFPer", namespaces=self.ns
-        )[1].text
+        UFPer_1 = self.xml_assinado.xpath("//ns:ide/ns:infPercurso/ns:UFPer", namespaces=self.ns)[
+            0
+        ].text
+        UFPer_2 = self.xml_assinado.xpath("//ns:ide/ns:infPercurso/ns:UFPer", namespaces=self.ns)[
+            1
+        ].text
 
         self.assertEqual(UFPer_1, "MS")
         self.assertEqual(UFPer_2, "GO")
@@ -541,45 +503,23 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
     def grupo_emitente(self):
         CNPJ = self.xml_assinado.xpath("//ns:emit/ns:CNPJ", namespaces=self.ns)[0].text
         IE = self.xml_assinado.xpath("//ns:emit/ns:IE", namespaces=self.ns)[0].text
-        xNome = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[
+        xNome = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[0].text
+        xFant = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[0].text
+        xLgr = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns)[0].text
+        nro = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:nro", namespaces=self.ns)[0].text
+        xBairro = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:xBairro", namespaces=self.ns)[
             0
         ].text
-        xFant = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[
-            0
-        ].text
-        xLgr = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns
-        )[0].text
-        nro = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:nro", namespaces=self.ns
-        )[0].text
-        xBairro = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:xBairro", namespaces=self.ns
-        )[0].text
-        cMun = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:cMun", namespaces=self.ns
-        )[0].text
-        xMun = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns
-        )[0].text
-        CEP = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns
-        )[0].text
-        UF = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns
-        )[0].text
-        fone = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:fone", namespaces=self.ns
-        )[0].text
-        email = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:email", namespaces=self.ns
-        )
+        cMun = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:cMun", namespaces=self.ns)[0].text
+        xMun = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns)[0].text
+        CEP = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns)[0].text
+        UF = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns)[0].text
+        fone = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:fone", namespaces=self.ns)[0].text
+        email = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:email", namespaces=self.ns)
 
         self.assertEqual(CNPJ, "99999999000199")
         self.assertEqual(IE, "9999999999")
-        self.assertEqual(
-            xNome, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"
-        )
+        self.assertEqual(xNome, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL")
         self.assertEqual(xFant, "Nome Fantasia da Empresa")
         self.assertEqual(xLgr, "RUA UM")
         self.assertEqual(nro, "111")
@@ -876,23 +816,21 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
             "//ns:infMDFe/ns:seg/ns:infResp/ns:CNPJ", namespaces=self.ns
         )[0].text
 
-        xSeg = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:infSeg/ns:xSeg", namespaces=self.ns
-        )[0].text
+        xSeg = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:infSeg/ns:xSeg", namespaces=self.ns)[
+            0
+        ].text
         CNPJ_seg = self.xml_assinado.xpath(
             "//ns:infMDFe/ns:seg/ns:infSeg/ns:CNPJ", namespaces=self.ns
         )[0].text
 
-        nApol = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:nApol", namespaces=self.ns
-        )[0].text
+        nApol = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:nApol", namespaces=self.ns)[0].text
 
-        nAver_1 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns
-        )[0].text
-        nAver_2 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns
-        )[1].text
+        nAver_1 = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns)[
+            0
+        ].text
+        nAver_2 = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns)[
+            1
+        ].text
 
         self.assertEqual(respSeg, "1")
         self.assertEqual(CNPJ_resp, "75512177000176")
@@ -910,19 +848,17 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
             "//ns:infMDFe/ns:seg/ns:infResp/ns:CNPJ", namespaces=self.ns
         )[0].text
 
-        xSeg = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:infSeg/ns:xSeg", namespaces=self.ns
-        )[0].text
+        xSeg = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:infSeg/ns:xSeg", namespaces=self.ns)[
+            0
+        ].text
         CNPJ_seg = self.xml_assinado.xpath(
             "//ns:infMDFe/ns:seg/ns:infSeg/ns:CNPJ", namespaces=self.ns
         )[0].text
 
-        nApol = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:nApol", namespaces=self.ns
-        )[0].text
-        nAver_1 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns
-        )[0].text
+        nApol = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:nApol", namespaces=self.ns)[0].text
+        nAver_1 = self.xml_assinado.xpath("//ns:infMDFe/ns:seg/ns:nAver", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(respSeg, "1")
         self.assertEqual(CNPJ_resp, "75512177000176")
@@ -935,15 +871,13 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         tpCarga = self.xml_assinado.xpath(
             "//ns:infMDFe/ns:prodPred/ns:tpCarga", namespaces=self.ns
         )[0].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:prodPred/ns:xProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:prodPred/ns:cEAN", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:prodPred/ns:NCM", namespaces=self.ns
-        )[0].text
+        xProd = self.xml_assinado.xpath("//ns:infMDFe/ns:prodPred/ns:xProd", namespaces=self.ns)[
+            0
+        ].text
+        cEAN = self.xml_assinado.xpath("//ns:infMDFe/ns:prodPred/ns:cEAN", namespaces=self.ns)[
+            0
+        ].text
+        NCM = self.xml_assinado.xpath("//ns:infMDFe/ns:prodPred/ns:NCM", namespaces=self.ns)[0].text
 
         self.assertEqual(tpCarga, "01")
         self.assertEqual(xProd, "Descricao do Produto")
@@ -951,18 +885,14 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         self.assertEqual(NCM, "01012100")
 
     def grupo_totais(self):
-        qNFe = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:tot/ns:qNFe", namespaces=self.ns
-        )[0].text
-        vCarga = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:tot/ns:vCarga", namespaces=self.ns
-        )[0].text
-        cUnid = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:tot/ns:cUnid", namespaces=self.ns
-        )[0].text
-        qCarga = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:tot/ns:qCarga", namespaces=self.ns
-        )[0].text
+        qNFe = self.xml_assinado.xpath("//ns:infMDFe/ns:tot/ns:qNFe", namespaces=self.ns)[0].text
+        vCarga = self.xml_assinado.xpath("//ns:infMDFe/ns:tot/ns:vCarga", namespaces=self.ns)[
+            0
+        ].text
+        cUnid = self.xml_assinado.xpath("//ns:infMDFe/ns:tot/ns:cUnid", namespaces=self.ns)[0].text
+        qCarga = self.xml_assinado.xpath("//ns:infMDFe/ns:tot/ns:qCarga", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(qNFe, "2")
         self.assertEqual(vCarga, "1000.00")
@@ -970,33 +900,25 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         self.assertEqual(qCarga, "5000.0000")
 
     def grupo_lacres(self):
-        nLacre_1 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns
-        )[0].text
-        nLacre_2 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns
-        )[1].text
-        nLacre_3 = self.xml_assinado.xpath(
-            "//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns
-        )[2].text
+        nLacre_1 = self.xml_assinado.xpath("//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns)[
+            0
+        ].text
+        nLacre_2 = self.xml_assinado.xpath("//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns)[
+            1
+        ].text
+        nLacre_3 = self.xml_assinado.xpath("//ns:infMDFe/ns:lacres/ns:nLacre", namespaces=self.ns)[
+            2
+        ].text
 
         self.assertEqual(nLacre_1, "123")
         self.assertEqual(nLacre_2, "456")
         self.assertEqual(nLacre_3, "789")
 
     def grupo_responsavel_tecnico(self):
-        cnpj = self.xml_assinado.xpath("//ns:infRespTec/ns:CNPJ", namespaces=self.ns)[
-            0
-        ].text
-        contato = self.xml_assinado.xpath(
-            "//ns:infRespTec/ns:xContato", namespaces=self.ns
-        )[0].text
-        email = self.xml_assinado.xpath("//ns:infRespTec/ns:email", namespaces=self.ns)[
-            0
-        ].text
-        fone = self.xml_assinado.xpath("//ns:infRespTec/ns:fone", namespaces=self.ns)[
-            0
-        ].text
+        cnpj = self.xml_assinado.xpath("//ns:infRespTec/ns:CNPJ", namespaces=self.ns)[0].text
+        contato = self.xml_assinado.xpath("//ns:infRespTec/ns:xContato", namespaces=self.ns)[0].text
+        email = self.xml_assinado.xpath("//ns:infRespTec/ns:email", namespaces=self.ns)[0].text
+        fone = self.xml_assinado.xpath("//ns:infRespTec/ns:fone", namespaces=self.ns)[0].text
 
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(contato, "Teste PyNFe")
@@ -1011,9 +933,9 @@ class SerializacaoMDFeTestCase(unittest.TestCase):
         self.assertTrue(len(DigestValue) > 0)
 
     def grupo_qrcode(self):
-        qrCodMDFe = self.xml_assinado.xpath(
-            "//ns:infMDFeSupl/ns:qrCodMDFe", namespaces=self.ns
-        )[0].text
+        qrCodMDFe = self.xml_assinado.xpath("//ns:infMDFeSupl/ns:qrCodMDFe", namespaces=self.ns)[
+            0
+        ].text
         self.assertTrue(len(qrCodMDFe) > 0)
 
     def test_manifesto(self):

--- a/tests/test_nfce_serializacao.py
+++ b/tests/test_nfce_serializacao.py
@@ -41,9 +41,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -107,7 +105,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.24674500'),
+            valor_troco=Decimal("3.24674500"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -165,47 +163,31 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def grupo_ide_test(self):
         uf = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
-        natureza_operacao = self.xml_assinado.xpath(
-            "//ns:ide/ns:natOp", namespaces=self.ns
-        )[0].text
+        natureza_operacao = self.xml_assinado.xpath("//ns:ide/ns:natOp", namespaces=self.ns)[0].text
         modelo = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
-        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[
+        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[0].text
+        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
+        tipo_documento = self.xml_assinado.xpath("//ns:ide/ns:tpNF", namespaces=self.ns)[0].text
+        indicador_destino = self.xml_assinado.xpath("//ns:ide/ns:idDest", namespaces=self.ns)[
             0
         ].text
-        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[
+        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[0].text
+        tipo_impressao_danfe = self.xml_assinado.xpath("//ns:ide/ns:tpImp", namespaces=self.ns)[
             0
         ].text
-        tipo_documento = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpNF", namespaces=self.ns
-        )[0].text
-        indicador_destino = self.xml_assinado.xpath(
-            "//ns:ide/ns:idDest", namespaces=self.ns
-        )[0].text
-        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[
+        forma_emissao = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        tipo_ambiente = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
+        finalidade_emissao = self.xml_assinado.xpath("//ns:ide/ns:finNFe", namespaces=self.ns)[
             0
         ].text
-        tipo_impressao_danfe = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpImp", namespaces=self.ns
-        )[0].text
-        forma_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpEmis", namespaces=self.ns
-        )[0].text
-        tipo_ambiente = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpAmb", namespaces=self.ns
-        )[0].text
-        finalidade_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:finNFe", namespaces=self.ns
-        )[0].text
-        cliente_final = self.xml_assinado.xpath(
-            "//ns:ide/ns:indFinal", namespaces=self.ns
-        )[0].text
-        indicador_presencial = self.xml_assinado.xpath(
-            "//ns:ide/ns:indPres", namespaces=self.ns
-        )[0].text
-        processo_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:procEmi", namespaces=self.ns
-        )[0].text
+        cliente_final = self.xml_assinado.xpath("//ns:ide/ns:indFinal", namespaces=self.ns)[0].text
+        indicador_presencial = self.xml_assinado.xpath("//ns:ide/ns:indPres", namespaces=self.ns)[
+            0
+        ].text
+        processo_emissao = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(uf, "41")
         self.assertEqual(natureza_operacao, "VENDA")
@@ -225,25 +207,15 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(processo_emissao, "0")
 
     def dados_emitente_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:emit/ns:xNome", namespaces=self.ns
-        )[0].text
-        nome_fantasia = self.xml_assinado.xpath(
-            "//ns:emit/ns:xFant", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[0].text
+        nome_fantasia = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[0].text
         cnpj = self.xml_assinado.xpath("//ns:emit/ns:CNPJ", namespaces=self.ns)[0].text
         codigo_de_regime_tributario = self.xml_assinado.xpath(
             "//ns:emit/ns:CRT", namespaces=self.ns
         )[0].text
-        inscricao_estadual = self.xml_assinado.xpath(
-            "//ns:emit/ns:IE", namespaces=self.ns
-        )[0].text
-        inscricao_municipal = self.xml_assinado.xpath(
-            "//ns:emit/ns:IM", namespaces=self.ns
-        )[0].text
-        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[
-            0
-        ].text
+        inscricao_estadual = self.xml_assinado.xpath("//ns:emit/ns:IE", namespaces=self.ns)[0].text
+        inscricao_municipal = self.xml_assinado.xpath("//ns:emit/ns:IM", namespaces=self.ns)[0].text
+        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -256,19 +228,17 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xPais", namespaces=self.ns
         )[0].text
 
-        self.assertEqual(
-            razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"
-        )
+        self.assertEqual(razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL")
         self.assertEqual(nome_fantasia, "Nome Fantasia da Empresa")
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(codigo_de_regime_tributario, "3")
@@ -284,15 +254,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(endereco_pais, "Brasil")
 
     def dados_destinatario_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:dest/ns:xNome", namespaces=self.ns
-        )[0].text
-        numero_documento = self.xml_assinado.xpath(
-            "//ns:dest/ns:CPF", namespaces=self.ns
-        )[0].text
-        indicador_ie = self.xml_assinado.xpath(
-            "//ns:dest/ns:indIEDest", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:dest/ns:xNome", namespaces=self.ns)[0].text
+        numero_documento = self.xml_assinado.xpath("//ns:dest/ns:CPF", namespaces=self.ns)[0].text
+        indicador_ie = self.xml_assinado.xpath("//ns:dest/ns:indIEDest", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -305,12 +269,12 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:dest/ns:enderDest/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:dest/ns:enderDest/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:dest/ns:enderDest/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:dest/ns:enderDest/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xPais", namespaces=self.ns
         )[0].text
@@ -328,51 +292,25 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
-            0
-        ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -424,80 +362,58 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vFCP, None)
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
-        vTroco = self.xml_assinado.xpath(
-            "//ns:pag/ns:vTroco", namespaces=self.ns
-        )[0].text
+        vTroco = self.xml_assinado.xpath("//ns:pag/ns:vTroco", namespaces=self.ns)[0].text
 
-        vPag = self.xml_assinado.xpath(
-            "//ns:pag/ns:detPag/ns:vPag", namespaces=self.ns
-        )[0].text
+        vPag = self.xml_assinado.xpath("//ns:pag/ns:detPag/ns:vPag", namespaces=self.ns)[0].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfce_serializacao_piscofins.py
+++ b/tests/test_nfce_serializacao_piscofins.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -93,7 +91,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.00'),
+            valor_troco=Decimal("3.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -154,7 +152,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.00'),
+            valor_troco=Decimal("3.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -199,8 +197,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
     def validacao_pis_cofins_nao_informado(self):
         try:
             CST_PIS = self.xml_assinado.xpath(
-                "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST",
-                namespaces=self.ns
+                "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST", namespaces=self.ns
             )[0].text
         except BaseException:
             CST_PIS = None
@@ -208,8 +205,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
         try:
             vPIS = self.xml_assinado.xpath(
-                "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:vPIS",
-                namespaces=self.ns
+                "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:vPIS", namespaces=self.ns
             )[0].text
         except BaseException:
             vPIS = None
@@ -218,8 +214,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         # COFINS
         try:
             CST_COFINS = self.xml_assinado.xpath(
-                "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST",
-                namespaces=self.ns
+                "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST", namespaces=self.ns
             )[0].text
         except BaseException:
             CST_COFINS = None
@@ -227,8 +222,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
         try:
             vCOFINS = self.xml_assinado.xpath(
-                "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:vCOFINS",
-                namespaces=self.ns
+                "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:vCOFINS", namespaces=self.ns
             )[0].text
         except BaseException:
             vCOFINS = None
@@ -236,32 +230,27 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def validacao_pis_cofins_informado(self):
         CST_PIS = self.xml_assinado.xpath(
-            "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST",
-            namespaces=self.ns
+            "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST", namespaces=self.ns
         )[0].text
         self.assertEqual(CST_PIS, "51")
 
         vPIS = self.xml_assinado.xpath(
-            "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:vPIS",
-            namespaces=self.ns
+            "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:vPIS", namespaces=self.ns
         )[0].text
         self.assertEqual(vPIS, "0.79")
 
         # COFINS
         CST_COFINS = self.xml_assinado.xpath(
-            "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST",
-            namespaces=self.ns
+            "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST", namespaces=self.ns
         )[0].text
         self.assertEqual(CST_COFINS, "51")
 
         vCOFINS = self.xml_assinado.xpath(
-            "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:vCOFINS",
-            namespaces=self.ns
+            "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:vCOFINS", namespaces=self.ns
         )[0].text
         self.assertEqual(vCOFINS, "3.48")
 
     def test_notafiscal_com_pis_cofins_opcional_sem_informar(self):
-
         # Preenche as classes do pynfe
         self.emitente = self.preenche_emitente()
         self.notafiscal = self.preenche_notafiscal_produto_sem_piscofins()
@@ -275,7 +264,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.validacao_pis_cofins_nao_informado()
 
     def test_notafiscal_com_pis_cofins_informado(self):
-
         # Preenche as classes do pynfe
         self.emitente = self.preenche_emitente()
         self.notafiscal = self.preenche_notafiscal_produto_com_piscofins()

--- a/tests/test_nfce_serializacao_sem_cliente.py
+++ b/tests/test_nfce_serializacao_sem_cliente.py
@@ -41,9 +41,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -92,7 +90,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.00'),
+            valor_troco=Decimal("3.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -152,47 +150,31 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def grupo_ide_test(self):
         uf = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
-        natureza_operacao = self.xml_assinado.xpath(
-            "//ns:ide/ns:natOp", namespaces=self.ns
-        )[0].text
+        natureza_operacao = self.xml_assinado.xpath("//ns:ide/ns:natOp", namespaces=self.ns)[0].text
         modelo = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
-        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[
+        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[0].text
+        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
+        tipo_documento = self.xml_assinado.xpath("//ns:ide/ns:tpNF", namespaces=self.ns)[0].text
+        indicador_destino = self.xml_assinado.xpath("//ns:ide/ns:idDest", namespaces=self.ns)[
             0
         ].text
-        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[
+        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[0].text
+        tipo_impressao_danfe = self.xml_assinado.xpath("//ns:ide/ns:tpImp", namespaces=self.ns)[
             0
         ].text
-        tipo_documento = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpNF", namespaces=self.ns
-        )[0].text
-        indicador_destino = self.xml_assinado.xpath(
-            "//ns:ide/ns:idDest", namespaces=self.ns
-        )[0].text
-        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[
+        forma_emissao = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        tipo_ambiente = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
+        finalidade_emissao = self.xml_assinado.xpath("//ns:ide/ns:finNFe", namespaces=self.ns)[
             0
         ].text
-        tipo_impressao_danfe = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpImp", namespaces=self.ns
-        )[0].text
-        forma_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpEmis", namespaces=self.ns
-        )[0].text
-        tipo_ambiente = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpAmb", namespaces=self.ns
-        )[0].text
-        finalidade_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:finNFe", namespaces=self.ns
-        )[0].text
-        cliente_final = self.xml_assinado.xpath(
-            "//ns:ide/ns:indFinal", namespaces=self.ns
-        )[0].text
-        indicador_presencial = self.xml_assinado.xpath(
-            "//ns:ide/ns:indPres", namespaces=self.ns
-        )[0].text
-        processo_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:procEmi", namespaces=self.ns
-        )[0].text
+        cliente_final = self.xml_assinado.xpath("//ns:ide/ns:indFinal", namespaces=self.ns)[0].text
+        indicador_presencial = self.xml_assinado.xpath("//ns:ide/ns:indPres", namespaces=self.ns)[
+            0
+        ].text
+        processo_emissao = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(uf, "41")
         self.assertEqual(natureza_operacao, "VENDA")
@@ -212,25 +194,15 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(processo_emissao, "0")
 
     def dados_emitente_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:emit/ns:xNome", namespaces=self.ns
-        )[0].text
-        nome_fantasia = self.xml_assinado.xpath(
-            "//ns:emit/ns:xFant", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[0].text
+        nome_fantasia = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[0].text
         cnpj = self.xml_assinado.xpath("//ns:emit/ns:CNPJ", namespaces=self.ns)[0].text
         codigo_de_regime_tributario = self.xml_assinado.xpath(
             "//ns:emit/ns:CRT", namespaces=self.ns
         )[0].text
-        inscricao_estadual = self.xml_assinado.xpath(
-            "//ns:emit/ns:IE", namespaces=self.ns
-        )[0].text
-        inscricao_municipal = self.xml_assinado.xpath(
-            "//ns:emit/ns:IM", namespaces=self.ns
-        )[0].text
-        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[
-            0
-        ].text
+        inscricao_estadual = self.xml_assinado.xpath("//ns:emit/ns:IE", namespaces=self.ns)[0].text
+        inscricao_municipal = self.xml_assinado.xpath("//ns:emit/ns:IM", namespaces=self.ns)[0].text
+        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -243,19 +215,17 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xPais", namespaces=self.ns
         )[0].text
 
-        self.assertEqual(
-            razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"
-        )
+        self.assertEqual(razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL")
         self.assertEqual(nome_fantasia, "Nome Fantasia da Empresa")
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(codigo_de_regime_tributario, "3")
@@ -277,51 +247,25 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
-            0
-        ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -373,72 +317,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vFCP, None)
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfce_serializacao_somente_cpf.py
+++ b/tests/test_nfce_serializacao_somente_cpf.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -101,7 +99,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.00'),
+            valor_troco=Decimal("3.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -161,47 +159,31 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def grupo_ide_test(self):
         uf = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
-        natureza_operacao = self.xml_assinado.xpath(
-            "//ns:ide/ns:natOp", namespaces=self.ns
-        )[0].text
+        natureza_operacao = self.xml_assinado.xpath("//ns:ide/ns:natOp", namespaces=self.ns)[0].text
         modelo = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
-        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[
+        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[0].text
+        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
+        tipo_documento = self.xml_assinado.xpath("//ns:ide/ns:tpNF", namespaces=self.ns)[0].text
+        indicador_destino = self.xml_assinado.xpath("//ns:ide/ns:idDest", namespaces=self.ns)[
             0
         ].text
-        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[
+        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[0].text
+        tipo_impressao_danfe = self.xml_assinado.xpath("//ns:ide/ns:tpImp", namespaces=self.ns)[
             0
         ].text
-        tipo_documento = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpNF", namespaces=self.ns
-        )[0].text
-        indicador_destino = self.xml_assinado.xpath(
-            "//ns:ide/ns:idDest", namespaces=self.ns
-        )[0].text
-        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[
+        forma_emissao = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        tipo_ambiente = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
+        finalidade_emissao = self.xml_assinado.xpath("//ns:ide/ns:finNFe", namespaces=self.ns)[
             0
         ].text
-        tipo_impressao_danfe = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpImp", namespaces=self.ns
-        )[0].text
-        forma_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpEmis", namespaces=self.ns
-        )[0].text
-        tipo_ambiente = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpAmb", namespaces=self.ns
-        )[0].text
-        finalidade_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:finNFe", namespaces=self.ns
-        )[0].text
-        cliente_final = self.xml_assinado.xpath(
-            "//ns:ide/ns:indFinal", namespaces=self.ns
-        )[0].text
-        indicador_presencial = self.xml_assinado.xpath(
-            "//ns:ide/ns:indPres", namespaces=self.ns
-        )[0].text
-        processo_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:procEmi", namespaces=self.ns
-        )[0].text
+        cliente_final = self.xml_assinado.xpath("//ns:ide/ns:indFinal", namespaces=self.ns)[0].text
+        indicador_presencial = self.xml_assinado.xpath("//ns:ide/ns:indPres", namespaces=self.ns)[
+            0
+        ].text
+        processo_emissao = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(uf, "41")
         self.assertEqual(natureza_operacao, "VENDA")
@@ -221,25 +203,15 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(processo_emissao, "0")
 
     def dados_emitente_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:emit/ns:xNome", namespaces=self.ns
-        )[0].text
-        nome_fantasia = self.xml_assinado.xpath(
-            "//ns:emit/ns:xFant", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[0].text
+        nome_fantasia = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[0].text
         cnpj = self.xml_assinado.xpath("//ns:emit/ns:CNPJ", namespaces=self.ns)[0].text
         codigo_de_regime_tributario = self.xml_assinado.xpath(
             "//ns:emit/ns:CRT", namespaces=self.ns
         )[0].text
-        inscricao_estadual = self.xml_assinado.xpath(
-            "//ns:emit/ns:IE", namespaces=self.ns
-        )[0].text
-        inscricao_municipal = self.xml_assinado.xpath(
-            "//ns:emit/ns:IM", namespaces=self.ns
-        )[0].text
-        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[
-            0
-        ].text
+        inscricao_estadual = self.xml_assinado.xpath("//ns:emit/ns:IE", namespaces=self.ns)[0].text
+        inscricao_municipal = self.xml_assinado.xpath("//ns:emit/ns:IM", namespaces=self.ns)[0].text
+        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -252,19 +224,17 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xPais", namespaces=self.ns
         )[0].text
 
-        self.assertEqual(
-            razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"
-        )
+        self.assertEqual(razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL")
         self.assertEqual(nome_fantasia, "Nome Fantasia da Empresa")
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(codigo_de_regime_tributario, "3")
@@ -280,63 +250,33 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(endereco_pais, "Brasil")
 
     def dados_destinatario_test(self):
-        indicador_ie = self.xml_assinado.xpath(
-            "//ns:dest/ns:indIEDest", namespaces=self.ns
-        )[0].text
-        numero_documento = self.xml_assinado.xpath(
-            "//ns:dest/ns:CPF", namespaces=self.ns
-        )[0].text
+        indicador_ie = self.xml_assinado.xpath("//ns:dest/ns:indIEDest", namespaces=self.ns)[0].text
+        numero_documento = self.xml_assinado.xpath("//ns:dest/ns:CPF", namespaces=self.ns)[0].text
         self.assertEqual(indicador_ie, "9")
         self.assertEqual(numero_documento, "12345678900")
         self.assertNotEqual(numero_documento, "123")
 
     def total_e_produto_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
-            0
-        ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -388,72 +328,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vFCP, None)
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfce_serializacao_vnf_vprod_duas_casas_decimais.py
+++ b/tests/test_nfce_serializacao_vnf_vprod_duas_casas_decimais.py
@@ -41,9 +41,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -92,7 +90,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("1.01"),
-            valor_troco=Decimal('3.00'),
+            valor_troco=Decimal("3.00"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -103,9 +101,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             ean="1234567890121",
             cfop="5102",
             unidade_comercial="UN",
-            quantidade_comercial=Decimal(quantidade), 
+            quantidade_comercial=Decimal(quantidade),
             valor_unitario_comercial=Decimal(valorUnitario),
-            valor_total_bruto=Decimal(valorTotal), 
+            valor_total_bruto=Decimal(valorTotal),
             unidade_tributavel="UN",
             quantidade_tributavel=Decimal(quantidade),
             valor_unitario_tributavel=Decimal(valorUnitario),
@@ -141,14 +139,12 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         )
 
     def total_test(self, valorEsperado):
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-       
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-       
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+
         self.assertEqual(vProd, valorEsperado)
         self.assertEqual(vNF, valorEsperado)
 
@@ -167,6 +163,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
         self.assertEqual(valorUnitario * quantidade, valorTotal)
         self.total_test(valorEsperado)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nfe_serializacao_csosn_101.py
+++ b/tests/test_nfe_serializacao_csosn_101.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -169,7 +167,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
-
     def serializa_nfe(self):
         serializador = SerializacaoXML(_fonte_dados, homologacao=self.homologacao)
         return serializador.exportar()
@@ -185,60 +182,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn101_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -294,72 +261,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_102.py
+++ b/tests/test_nfe_serializacao_csosn_102.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -182,60 +180,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn102_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -282,72 +250,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_103.py
+++ b/tests/test_nfe_serializacao_csosn_103.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -182,60 +180,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn102_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -288,72 +256,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_201.py
+++ b/tests/test_nfe_serializacao_csosn_201.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -165,7 +163,6 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=118.17, ind_pag=0)
 
-
     def serializa_nfe(self):
         serializador = SerializacaoXML(_fonte_dados, homologacao=self.homologacao)
         return serializador.exportar()
@@ -181,60 +178,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn201_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -326,72 +293,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_202.py
+++ b/tests/test_nfe_serializacao_csosn_202.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -112,7 +110,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             transporte_modalidade_frete=1,
             informacoes_adicionais_interesse_fisco="Mensagem complementar",
             totais_tributos_aproximado=Decimal("21.06"),
-            valor_troco=Decimal('1.83')
+            valor_troco=Decimal("1.83"),
         )
 
         self.notafiscal.adicionar_produto_servico(
@@ -157,7 +155,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             nfci="12345678-AAAA-FFFF-1234-000000000000",
             informacoes_adicionais="Informações adicionais",
             ipi_valor_ipi_dev=Decimal("0.00"),
-            pdevol=Decimal("0.00")
+            pdevol=Decimal("0.00"),
         )
 
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=120.00, ind_pag=0)
@@ -177,60 +175,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn202_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -313,72 +281,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_203.py
+++ b/tests/test_nfe_serializacao_csosn_203.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -158,7 +156,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             ipi_valor_ipi_dev=Decimal("0.00"),
             pdevol=Decimal("0.00"),
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=118.17, ind_pag=0)
 
     def serializa_nfe(self):
@@ -176,60 +174,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn203_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -312,72 +280,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_300.py
+++ b/tests/test_nfe_serializacao_csosn_300.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -164,7 +162,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -182,60 +180,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn300_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -288,72 +256,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_400.py
+++ b/tests/test_nfe_serializacao_csosn_400.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -164,7 +162,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -182,60 +180,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn400_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -288,72 +256,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_500.py
+++ b/tests/test_nfe_serializacao_csosn_500.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -164,7 +162,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -182,60 +180,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn500_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -282,72 +250,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_csosn_900.py
+++ b/tests/test_nfe_serializacao_csosn_900.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -166,7 +164,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             ipi_valor_ipi_dev=Decimal("0.00"),
             pdevol=Decimal("0.00"),
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=119.34, ind_pag=0)
 
     def serializa_nfe(self):
@@ -184,60 +182,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_csosn900_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -357,72 +325,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "18.67")
         self.assertEqual(vICMS, "3.36")

--- a/tests/test_nfe_serializacao_cst_00.py
+++ b/tests/test_nfe_serializacao_cst_00.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -149,7 +147,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             ipi_valor_ipi_dev=Decimal("10.00"),
             pdevol=Decimal("1.00"),
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=127.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -167,59 +165,29 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst00_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -288,9 +256,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Impostos - IPI Devolução
-        pDevol = self.xml_assinado.xpath(
-            "//ns:det/ns:impostoDevol/ns:pDevol", namespaces=self.ns
-        )[0].text
+        pDevol = self.xml_assinado.xpath("//ns:det/ns:impostoDevol/ns:pDevol", namespaces=self.ns)[
+            0
+        ].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:det/ns:impostoDevol/ns:IPI/ns:vIPIDevol", namespaces=self.ns
         )[0].text
@@ -298,72 +266,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vIPIDevol, "10.00")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_10.py
+++ b/tests/test_nfe_serializacao_cst_10.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -162,7 +160,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -180,59 +178,29 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst10_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -301,72 +269,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_20.py
+++ b/tests/test_nfe_serializacao_cst_20.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -162,7 +160,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -180,59 +178,29 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst20_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -299,72 +267,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_30.py
+++ b/tests/test_nfe_serializacao_cst_30.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -168,7 +166,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -186,60 +184,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst30_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -314,72 +282,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(CST_COFINS, "51")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_40.py
+++ b/tests/test_nfe_serializacao_cst_40.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -157,7 +155,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=107.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -175,60 +173,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst40_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -270,72 +238,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(motDesICMS, "90")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_41.py
+++ b/tests/test_nfe_serializacao_cst_41.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -157,7 +155,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=107.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -175,60 +173,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst41_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -270,72 +238,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(motDesICMS, "90")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_50.py
+++ b/tests/test_nfe_serializacao_cst_50.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -157,7 +155,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=107.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -175,60 +173,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst50_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -270,72 +238,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(motDesICMS, "90")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_51.py
+++ b/tests/test_nfe_serializacao_cst_51.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -155,7 +153,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -173,60 +171,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst51_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -267,72 +235,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         # self.assertEqual(vFCP, '0.00')
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_60.py
+++ b/tests/test_nfe_serializacao_cst_60.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -155,7 +153,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=117.00, ind_pag=0)
 
     def serializa_nfe(self):
@@ -173,60 +171,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst60_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -272,72 +240,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vICMSSTRet, "0.00")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "0.00")
         self.assertEqual(vICMS, "0.00")

--- a/tests/test_nfe_serializacao_cst_70.py
+++ b/tests/test_nfe_serializacao_cst_70.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -172,7 +170,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(
             t_pag="03",
             x_pag="Cartao Credito",
@@ -197,60 +195,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst70_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -354,72 +322,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(vFCPST, "0.02")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totais
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "18.67")
         self.assertEqual(vICMS, "3.36")

--- a/tests/test_nfe_serializacao_cst_90.py
+++ b/tests/test_nfe_serializacao_cst_90.py
@@ -42,9 +42,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -177,14 +175,14 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             email="pynfe@pynfe.io",
             fone="11912341234",
         )
-        
+
         self.notafiscal.adicionar_pagamento(
             t_pag="01",
             x_pag="Dinheiro",
             v_pag=17.00,
             ind_pag=0,
         )
-        
+
         self.notafiscal.adicionar_pagamento(
             t_pag="03",
             x_pag="Cartao Credito",
@@ -209,60 +207,30 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def total_e_produto_cst90_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cProd", namespaces=self.ns
-        )[0].text
-        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[
-            0
-        ].text
-        xProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:xProd", namespaces=self.ns
-        )[0].text
-        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[
-            0
-        ].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
 
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
             0
         ].text
-        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
             0
         ].text
-        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[
-            0
-        ].text
-        vUnCom = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns
-        )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vProd", namespaces=self.ns
-        )[0].text
-        cEANTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns
-        )[0].text
-        uTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:uTrib", namespaces=self.ns
-        )[0].text
-        qTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:qTrib", namespaces=self.ns
-        )[0].text
-        vUnTrib = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns
-        )[0].text
-        indTot = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:indTot", namespaces=self.ns
-        )[0].text
-        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[
-            0
-        ].text
-        nItemPed = self.xml_assinado.xpath(
-            "//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns
-        )[0].text
-        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[
-            0
-        ].text
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
         self.assertEqual(cProd, "000328")
         self.assertEqual(cEAN, "1234567890121")
@@ -320,72 +288,54 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         # self.assertEqual(vFCP, '0.00')
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath(
-            "//ns:det/ns:infAdProd", namespaces=self.ns
-        )[0].text
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
         self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totais
-        vBC = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns
-        )[0].text
-        vICMS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns
-        )[0].text
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text
         vICMSDeson = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
         )[0].text
-        vFCP = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns
-        )[0].text
-        vBCST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns
-        )[0].text
-        vST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns
-        )[0].text
-        vFCPST = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns
-        )[0].text
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text
         vFCPSTRet = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
         )[0].text
-        vProd = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns
-        )[0].text
-        vFrete = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns
-        )[0].text
-        vSeg = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns
-        )[0].text
-        vDesc = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns
-        )[0].text
-        vII = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns
-        )[0].text
-        vIPI = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns
-        )[0].text
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text
         vIPIDevol = self.xml_assinado.xpath(
             "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
         )[0].text
-        vPIS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns
-        )[0].text
-        vCOFINS = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns
-        )[0].text
-        vOutro = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns
-        )[0].text
-        vNF = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns
-        )[0].text
-        vTotTrib = self.xml_assinado.xpath(
-            "//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns
-        )[0].text
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text
 
         self.assertEqual(vBC, "117.00")
         self.assertEqual(vICMS, "11.70")

--- a/tests/test_nfe_serializacao_geral.py
+++ b/tests/test_nfe_serializacao_geral.py
@@ -43,9 +43,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.xsd_procNFe = self.validacao.get_xsd(
             xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
@@ -169,19 +167,19 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         )
 
         self.notafiscal.adicionar_duplicata(
-            numero='1',
+            numero="1",
             data_vencimento=datetime.datetime(2025, 1, 27, 12, 0, 0, tzinfo=utc),
             valor=Decimal("39.00"),
         )
 
         self.notafiscal.adicionar_duplicata(
-            numero='1',
+            numero="1",
             data_vencimento=datetime.datetime(2025, 1, 28, 12, 0, 0, tzinfo=utc),
             valor=Decimal("39.00"),
         )
 
         self.notafiscal.adicionar_duplicata(
-            numero='1',
+            numero="1",
             data_vencimento=datetime.datetime(2025, 1, 29, 12, 0, 0, tzinfo=utc),
             valor=Decimal("39.00"),
         )
@@ -194,7 +192,7 @@ class SerializacaoNFeTestCase(unittest.TestCase):
             tp_integra="2",
             t_band="99",
         )
-        
+
         self.notafiscal.adicionar_pagamento(
             t_pag="03",
             x_pag="Cartao Credito",
@@ -219,50 +217,34 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def grupo_ide_test(self):
         uf = self.xml_assinado.xpath("//ns:ide/ns:cUF", namespaces=self.ns)[0].text
-        natureza_operacao = self.xml_assinado.xpath(
-            "//ns:ide/ns:natOp", namespaces=self.ns
-        )[0].text
+        natureza_operacao = self.xml_assinado.xpath("//ns:ide/ns:natOp", namespaces=self.ns)[0].text
         modelo = self.xml_assinado.xpath("//ns:ide/ns:mod", namespaces=self.ns)[0].text
         serie = self.xml_assinado.xpath("//ns:ide/ns:serie", namespaces=self.ns)[0].text
-        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[
+        numero_nf = self.xml_assinado.xpath("//ns:ide/ns:nNF", namespaces=self.ns)[0].text
+        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[0].text
+        data_saida_entrada = self.xml_assinado.xpath("//ns:ide/ns:dhSaiEnt", namespaces=self.ns)[
             0
         ].text
-        data_emissao = self.xml_assinado.xpath("//ns:ide/ns:dhEmi", namespaces=self.ns)[
+        tipo_documento = self.xml_assinado.xpath("//ns:ide/ns:tpNF", namespaces=self.ns)[0].text
+        indicador_destino = self.xml_assinado.xpath("//ns:ide/ns:idDest", namespaces=self.ns)[
             0
         ].text
-        data_saida_entrada = self.xml_assinado.xpath(
-            "//ns:ide/ns:dhSaiEnt", namespaces=self.ns
-        )[0].text
-        tipo_documento = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpNF", namespaces=self.ns
-        )[0].text
-        indicador_destino = self.xml_assinado.xpath(
-            "//ns:ide/ns:idDest", namespaces=self.ns
-        )[0].text
-        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[
+        municipio = self.xml_assinado.xpath("//ns:ide/ns:cMunFG", namespaces=self.ns)[0].text
+        tipo_impressao_danfe = self.xml_assinado.xpath("//ns:ide/ns:tpImp", namespaces=self.ns)[
             0
         ].text
-        tipo_impressao_danfe = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpImp", namespaces=self.ns
-        )[0].text
-        forma_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpEmis", namespaces=self.ns
-        )[0].text
-        tipo_ambiente = self.xml_assinado.xpath(
-            "//ns:ide/ns:tpAmb", namespaces=self.ns
-        )[0].text
-        finalidade_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:finNFe", namespaces=self.ns
-        )[0].text
-        cliente_final = self.xml_assinado.xpath(
-            "//ns:ide/ns:indFinal", namespaces=self.ns
-        )[0].text
-        indicador_presencial = self.xml_assinado.xpath(
-            "//ns:ide/ns:indPres", namespaces=self.ns
-        )[0].text
-        processo_emissao = self.xml_assinado.xpath(
-            "//ns:ide/ns:procEmi", namespaces=self.ns
-        )[0].text
+        forma_emissao = self.xml_assinado.xpath("//ns:ide/ns:tpEmis", namespaces=self.ns)[0].text
+        tipo_ambiente = self.xml_assinado.xpath("//ns:ide/ns:tpAmb", namespaces=self.ns)[0].text
+        finalidade_emissao = self.xml_assinado.xpath("//ns:ide/ns:finNFe", namespaces=self.ns)[
+            0
+        ].text
+        cliente_final = self.xml_assinado.xpath("//ns:ide/ns:indFinal", namespaces=self.ns)[0].text
+        indicador_presencial = self.xml_assinado.xpath("//ns:ide/ns:indPres", namespaces=self.ns)[
+            0
+        ].text
+        processo_emissao = self.xml_assinado.xpath("//ns:ide/ns:procEmi", namespaces=self.ns)[
+            0
+        ].text
         versao_processo_emissao = self.xml_assinado.xpath(
             "//ns:ide/ns:verProc", namespaces=self.ns
         )[0].text
@@ -284,28 +266,18 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(cliente_final, "1")
         self.assertEqual(indicador_presencial, "1")
         self.assertEqual(processo_emissao, "0")
-        self.assertEqual(versao_processo_emissao, f'PyNFe {get_version()}')
+        self.assertEqual(versao_processo_emissao, f"PyNFe {get_version()}")
 
     def dados_emitente_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:emit/ns:xNome", namespaces=self.ns
-        )[0].text
-        nome_fantasia = self.xml_assinado.xpath(
-            "//ns:emit/ns:xFant", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:emit/ns:xNome", namespaces=self.ns)[0].text
+        nome_fantasia = self.xml_assinado.xpath("//ns:emit/ns:xFant", namespaces=self.ns)[0].text
         cnpj = self.xml_assinado.xpath("//ns:emit/ns:CNPJ", namespaces=self.ns)[0].text
         codigo_de_regime_tributario = self.xml_assinado.xpath(
             "//ns:emit/ns:CRT", namespaces=self.ns
         )[0].text
-        inscricao_estadual = self.xml_assinado.xpath(
-            "//ns:emit/ns:IE", namespaces=self.ns
-        )[0].text
-        inscricao_municipal = self.xml_assinado.xpath(
-            "//ns:emit/ns:IM", namespaces=self.ns
-        )[0].text
-        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[
-            0
-        ].text
+        inscricao_estadual = self.xml_assinado.xpath("//ns:emit/ns:IE", namespaces=self.ns)[0].text
+        inscricao_municipal = self.xml_assinado.xpath("//ns:emit/ns:IM", namespaces=self.ns)[0].text
+        cnae_fiscal = self.xml_assinado.xpath("//ns:emit/ns:CNAE", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -318,19 +290,17 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:emit/ns:enderEmit/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:emit/ns:enderEmit/ns:xPais", namespaces=self.ns
         )[0].text
 
-        self.assertEqual(
-            razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"
-        )
+        self.assertEqual(razao_social, "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL")
         self.assertEqual(nome_fantasia, "Nome Fantasia da Empresa")
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(codigo_de_regime_tributario, "3")
@@ -346,18 +316,10 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(endereco_pais, "Brasil")
 
     def dados_destinatario_test(self):
-        razao_social = self.xml_assinado.xpath(
-            "//ns:dest/ns:xNome", namespaces=self.ns
-        )[0].text
-        email = self.xml_assinado.xpath("//ns:dest/ns:email", namespaces=self.ns)[
-            0
-        ].text
-        numero_documento = self.xml_assinado.xpath(
-            "//ns:dest/ns:CPF", namespaces=self.ns
-        )[0].text
-        indicador_ie = self.xml_assinado.xpath(
-            "//ns:dest/ns:indIEDest", namespaces=self.ns
-        )[0].text
+        razao_social = self.xml_assinado.xpath("//ns:dest/ns:xNome", namespaces=self.ns)[0].text
+        email = self.xml_assinado.xpath("//ns:dest/ns:email", namespaces=self.ns)[0].text
+        numero_documento = self.xml_assinado.xpath("//ns:dest/ns:CPF", namespaces=self.ns)[0].text
+        indicador_ie = self.xml_assinado.xpath("//ns:dest/ns:indIEDest", namespaces=self.ns)[0].text
         endereco_logradouro = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xLgr", namespaces=self.ns
         )[0].text
@@ -373,12 +335,12 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         endereco_municipio = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xMun", namespaces=self.ns
         )[0].text
-        endereco_uf = self.xml_assinado.xpath(
-            "//ns:dest/ns:enderDest/ns:UF", namespaces=self.ns
-        )[0].text
-        endereco_cep = self.xml_assinado.xpath(
-            "//ns:dest/ns:enderDest/ns:CEP", namespaces=self.ns
-        )[0].text
+        endereco_uf = self.xml_assinado.xpath("//ns:dest/ns:enderDest/ns:UF", namespaces=self.ns)[
+            0
+        ].text
+        endereco_cep = self.xml_assinado.xpath("//ns:dest/ns:enderDest/ns:CEP", namespaces=self.ns)[
+            0
+        ].text
         endereco_pais = self.xml_assinado.xpath(
             "//ns:dest/ns:enderDest/ns:xPais", namespaces=self.ns
         )[0].text
@@ -401,23 +363,19 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(endereco_telefone, "11912341234")
 
     def notas_produtor_referenciadas_test(self):
-        ref_1 = self.xml_assinado.xpath(
-            "//ns:ide/ns:NFref/ns:refNFP/ns:nNF", namespaces=self.ns
-        )[0].text
-        ref_2 = self.xml_assinado.xpath(
-            "//ns:ide/ns:NFref/ns:refNFP/ns:nNF", namespaces=self.ns
-        )[1].text
+        ref_1 = self.xml_assinado.xpath("//ns:ide/ns:NFref/ns:refNFP/ns:nNF", namespaces=self.ns)[
+            0
+        ].text
+        ref_2 = self.xml_assinado.xpath("//ns:ide/ns:NFref/ns:refNFP/ns:nNF", namespaces=self.ns)[
+            1
+        ].text
 
         self.assertEqual(ref_1, "999999998")
         self.assertEqual(ref_2, "999999999")
 
     def notas_referenciadas_test(self):
-        chave_1 = self.xml_assinado.xpath(
-            "//ns:ide/ns:NFref/ns:refNFe", namespaces=self.ns
-        )[0].text
-        chave_2 = self.xml_assinado.xpath(
-            "//ns:ide/ns:NFref/ns:refNFe", namespaces=self.ns
-        )[1].text
+        chave_1 = self.xml_assinado.xpath("//ns:ide/ns:NFref/ns:refNFe", namespaces=self.ns)[0].text
+        chave_2 = self.xml_assinado.xpath("//ns:ide/ns:NFref/ns:refNFe", namespaces=self.ns)[1].text
 
         self.assertEqual(chave_1, "12345678901234567890123456789012345678900001")
         self.assertEqual(chave_2, "12345678901234567890123456789012345678900002")
@@ -448,9 +406,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         data_vencimento_1 = self.xml_assinado.xpath(
             "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
         )[0].text
-        valor_duplicata_1 = self.xml_assinado.xpath(
-            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
-        )[0].text
+        valor_duplicata_1 = self.xml_assinado.xpath("//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns)[
+            0
+        ].text
 
         numero_duplicata_2 = self.xml_assinado.xpath(
             "//ns:cobr/ns:dup/ns:nDup", namespaces=self.ns
@@ -458,9 +416,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         data_vencimento_2 = self.xml_assinado.xpath(
             "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
         )[1].text
-        valor_duplicata_2 = self.xml_assinado.xpath(
-            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
-        )[1].text
+        valor_duplicata_2 = self.xml_assinado.xpath("//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns)[
+            1
+        ].text
 
         numero_duplicata_3 = self.xml_assinado.xpath(
             "//ns:cobr/ns:dup/ns:nDup", namespaces=self.ns
@@ -468,9 +426,9 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         data_vencimento_3 = self.xml_assinado.xpath(
             "//ns:cobr/ns:dup/ns:dVenc", namespaces=self.ns
         )[2].text
-        valor_duplicata_3 = self.xml_assinado.xpath(
-            "//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns
-        )[2].text
+        valor_duplicata_3 = self.xml_assinado.xpath("//ns:cobr/ns:dup/ns:vDup", namespaces=self.ns)[
+            2
+        ].text
 
         self.assertEqual(numero_duplicata_1, "1")
         self.assertEqual(data_vencimento_1, "2025-01-27")
@@ -485,18 +443,10 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.assertEqual(valor_duplicata_3, "39.00")
 
     def responsavel_tecnico_test(self):
-        cnpj = self.xml_assinado.xpath("//ns:infRespTec/ns:CNPJ", namespaces=self.ns)[
-            0
-        ].text
-        contato = self.xml_assinado.xpath(
-            "//ns:infRespTec/ns:xContato", namespaces=self.ns
-        )[0].text
-        email = self.xml_assinado.xpath("//ns:infRespTec/ns:email", namespaces=self.ns)[
-            0
-        ].text
-        fone = self.xml_assinado.xpath("//ns:infRespTec/ns:fone", namespaces=self.ns)[
-            0
-        ].text
+        cnpj = self.xml_assinado.xpath("//ns:infRespTec/ns:CNPJ", namespaces=self.ns)[0].text
+        contato = self.xml_assinado.xpath("//ns:infRespTec/ns:xContato", namespaces=self.ns)[0].text
+        email = self.xml_assinado.xpath("//ns:infRespTec/ns:email", namespaces=self.ns)[0].text
+        fone = self.xml_assinado.xpath("//ns:infRespTec/ns:fone", namespaces=self.ns)[0].text
 
         self.assertEqual(cnpj, "99999999000199")
         self.assertEqual(contato, "Teste PyNFe")

--- a/tests/test_nfe_serializacao_ii_di_ipi.py
+++ b/tests/test_nfe_serializacao_ii_di_ipi.py
@@ -8,7 +8,7 @@ from pynfe.entidades.emitente import Emitente
 from pynfe.entidades.notafiscal import (
     NotaFiscal,
     NotaFiscalDeclaracaoImportacaoAdicao,
-    NotaFiscalDeclaracaoImportacao
+    NotaFiscalDeclaracaoImportacao,
 )
 from pynfe.entidades.fonte_dados import _fonte_dados
 from pynfe.processamento.serializacao import SerializacaoXML
@@ -35,63 +35,58 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def setUp(self):
         self.certificado = "./tests/certificado.pfx"
-        self.senha = bytes('123456', 'utf-8')
-        self.uf = 'pr'
+        self.senha = bytes("123456", "utf-8")
+        self.uf = "pr"
         self.homologacao = True
 
-        self.ns = {'ns': NAMESPACE_NFE}
-        self.ns_sig = {'ns': NAMESPACE_SIG}
+        self.ns = {"ns": NAMESPACE_NFE}
+        self.ns_sig = {"ns": NAMESPACE_SIG}
 
         self.validacao = Validacao()
         self.xsd_procNFe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE_PROCESSADA,
-            xsd_folder=XSD_FOLDER_NFE
+            xsd_file=XSD_NFE_PROCESSADA, xsd_folder=XSD_FOLDER_NFE
         )
-        self.xsd_nfe = self.validacao.get_xsd(
-            xsd_file=XSD_NFE,
-            xsd_folder=XSD_FOLDER_NFE
-        )
+        self.xsd_nfe = self.validacao.get_xsd(xsd_file=XSD_NFE, xsd_folder=XSD_FOLDER_NFE)
 
     def preenche_emitente(self):
         self.emitente = Emitente(
-            razao_social='NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL',
-            nome_fantasia='Nome Fantasia da Empresa',
-            cnpj='99999999000199',  # cnpj apenas números
-            codigo_de_regime_tributario='3',  # 1 para simples nacional ou 3 para normal
-            inscricao_estadual='9999999999',  # numero de IE da empresa
-            inscricao_municipal='12345',
-            cnae_fiscal='9999999',  # cnae apenas números
-            endereco_logradouro='Rua da Paz',
-            endereco_numero='666',
-            endereco_bairro='Sossego',
-            endereco_municipio='Paranavaí',
-            endereco_uf='PR',
-            endereco_cep='87704000',
-            endereco_pais=CODIGO_BRASIL
+            razao_social="NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
+            nome_fantasia="Nome Fantasia da Empresa",
+            cnpj="99999999000199",  # cnpj apenas números
+            codigo_de_regime_tributario="3",  # 1 para simples nacional ou 3 para normal
+            inscricao_estadual="9999999999",  # numero de IE da empresa
+            inscricao_municipal="12345",
+            cnae_fiscal="9999999",  # cnae apenas números
+            endereco_logradouro="Rua da Paz",
+            endereco_numero="666",
+            endereco_bairro="Sossego",
+            endereco_municipio="Paranavaí",
+            endereco_uf="PR",
+            endereco_cep="87704000",
+            endereco_pais=CODIGO_BRASIL,
         )
         return self.emitente
 
     def preenche_destinatario(self):
         self.cliente = Cliente(
-            razao_social='JOSE DA SILVA',
-            tipo_documento='CPF',  # CPF ou CNPJ
-            email='email@email.com',
-            numero_documento='12345678900',  # numero do cpf ou cnpj
+            razao_social="JOSE DA SILVA",
+            tipo_documento="CPF",  # CPF ou CNPJ
+            email="email@email.com",
+            numero_documento="12345678900",  # numero do cpf ou cnpj
             indicador_ie=9,  # 9=Não contribuinte
-            endereco_logradouro='Rua dos Bobos',
-            endereco_numero='Zero',
-            endereco_complemento='Ao lado de lugar nenhum',
-            endereco_bairro='Aquele Mesmo',
-            endereco_municipio='Brasilia',
-            endereco_uf='DF',
-            endereco_cep='12345123',
+            endereco_logradouro="Rua dos Bobos",
+            endereco_numero="Zero",
+            endereco_complemento="Ao lado de lugar nenhum",
+            endereco_bairro="Aquele Mesmo",
+            endereco_municipio="Brasilia",
+            endereco_uf="DF",
+            endereco_cep="12345123",
             endereco_pais=CODIGO_BRASIL,
-            endereco_telefone='11912341234',
+            endereco_telefone="11912341234",
         )
         return self.cliente
 
     def preenche_notafiscal_produto_cst00(self):
-
         utc = datetime.timezone.utc
         data_emissao = datetime.datetime(2021, 1, 14, 12, 0, 0, tzinfo=utc)
         data_saida_entrada = datetime.datetime(2021, 1, 14, 13, 10, 20, tzinfo=utc)
@@ -99,26 +94,26 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.notafiscal = NotaFiscal(
             emitente=self.emitente,
             cliente=self.cliente,
-            uf='PR',
-            natureza_operacao='VENDA',  # venda, compra, transferência, devolução, etc
+            uf="PR",
+            natureza_operacao="VENDA",  # venda, compra, transferência, devolução, etc
             forma_pagamento=0,  # 0=Pagamento à vista; 1=Pagamento a prazo; 2=Outros.
             modelo=55,  # 55=NF-e; 65=NFC-e
-            serie='1',
-            numero_nf='111',  # Número do Documento Fiscal.
+            serie="1",
+            numero_nf="111",  # Número do Documento Fiscal.
             data_emissao=data_emissao,
             data_saida_entrada=data_saida_entrada,
             tipo_documento=1,  # 0=entrada; 1=saida
-            municipio='4118402',  # Código IBGE do Município
+            municipio="4118402",  # Código IBGE do Município
             tipo_impressao_danfe=1,  # 0=Sem geração de DANFE;1=DANFE normal, Retrato;2=DANFE normal Paisagem;3=DANFE Simplificado;4=DANFE NFC-e;  # NOQA
-            forma_emissao='1',  # 1=Emissão normal (não em contingência);
+            forma_emissao="1",  # 1=Emissão normal (não em contingência);
             cliente_final=1,  # 0=Normal;1=Consumidor final;
             indicador_destino=1,
             indicador_presencial=1,
-            finalidade_emissao='1',  # 1=NF-e normal;2=NF-e complementar;3=NF-e de ajuste;4=Devolução de mercadoria.  # NOQA
-            processo_emissao='0',  # 0=Emissão de NF-e com aplicativo do contribuinte;
+            finalidade_emissao="1",  # 1=NF-e normal;2=NF-e complementar;3=NF-e de ajuste;4=Devolução de mercadoria.  # NOQA
+            processo_emissao="0",  # 0=Emissão de NF-e com aplicativo do contribuinte;
             transporte_modalidade_frete=1,
-            informacoes_adicionais_interesse_fisco='Mensagem complementar',
-            totais_tributos_aproximado=Decimal('21.06'),
+            informacoes_adicionais_interesse_fisco="Mensagem complementar",
+            totais_tributos_aproximado=Decimal("21.06"),
         )
 
         # Adicionar informações da Declaração de Importação
@@ -126,80 +121,80 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         di_adicoes = []
         di_adicoes.append(
             NotaFiscalDeclaracaoImportacaoAdicao(
-                numero='1',
-                sequencia='1',
-                codigo_fabricante='1',
-                desconto=Decimal('0'),
-                numero_drawback='12345678',
+                numero="1",
+                sequencia="1",
+                codigo_fabricante="1",
+                desconto=Decimal("0"),
+                numero_drawback="12345678",
             )
         )
 
         declaracao_importacao.append(
             NotaFiscalDeclaracaoImportacao(
-                numero_di_dsi_da='123456789',
+                numero_di_dsi_da="123456789",
                 data_registro=data_emissao,
-                desembaraco_aduaneiro_local='Santos',
-                desembaraco_aduaneiro_uf='SP',
+                desembaraco_aduaneiro_local="Santos",
+                desembaraco_aduaneiro_uf="SP",
                 desembaraco_aduaneiro_data=data_emissao,
                 tipo_via_transporte=1,
-                valor_afrmm=Decimal('0'),
+                valor_afrmm=Decimal("0"),
                 tipo_intermediacao=1,
-                cnpj_adquirente='00111711999900',
-                uf_terceiro='',
-                codigo_exportador='1',
+                cnpj_adquirente="00111711999900",
+                uf_terceiro="",
+                codigo_exportador="1",
                 adicoes=di_adicoes,
             )
         )
 
         self.notafiscal.adicionar_produto_servico(
-            codigo='000328',  # id do produto
-            descricao='Produto teste',
-            ncm='99999999',
+            codigo="000328",  # id do produto
+            descricao="Produto teste",
+            ncm="99999999",
             # cest='0100100',  # NT2015/003
-            ean='1234567890121',
-            cfop='3102',
-            unidade_comercial='UN',
-            quantidade_comercial=Decimal('12'),  # 12 unidades
-            valor_unitario_comercial=Decimal('9.75'),  # preço unitário
-            valor_total_bruto=Decimal('117.00'),  # preço total
-            unidade_tributavel='UN',
-            quantidade_tributavel=Decimal('12'),
-            valor_unitario_tributavel=Decimal('9.75'),
-            ean_tributavel='SEM GTIN',
+            ean="1234567890121",
+            cfop="3102",
+            unidade_comercial="UN",
+            quantidade_comercial=Decimal("12"),  # 12 unidades
+            valor_unitario_comercial=Decimal("9.75"),  # preço unitário
+            valor_total_bruto=Decimal("117.00"),  # preço total
+            unidade_tributavel="UN",
+            quantidade_tributavel=Decimal("12"),
+            valor_unitario_tributavel=Decimal("9.75"),
+            ean_tributavel="SEM GTIN",
             ind_total=1,
-            icms_modalidade='00',
+            icms_modalidade="00",
             icms_origem=0,
-            icms_csosn='',
-            pis_modalidade='51',
-            cofins_modalidade='51',
-            pis_valor_base_calculo=Decimal('117.00'),
-            pis_aliquota_percentual=Decimal('0.65'),
-            pis_valor=Decimal('0.76'),
-            cofins_valor_base_calculo=Decimal('117.00'),
-            cofins_aliquota_percentual=Decimal('3.00'),
-            cofins_valor=Decimal('3.51'),
-            valor_tributos_aprox='21.06',
-            numero_pedido='12345',
-            numero_item='1',
-            nfci='12345678-AAAA-FFFF-1234-000000000000',
-            informacoes_adicionais='Informações adicionais',
-            ipi_valor_ipi_dev=Decimal('10.00'),
-            pdevol=Decimal('1.00'),
+            icms_csosn="",
+            pis_modalidade="51",
+            cofins_modalidade="51",
+            pis_valor_base_calculo=Decimal("117.00"),
+            pis_aliquota_percentual=Decimal("0.65"),
+            pis_valor=Decimal("0.76"),
+            cofins_valor_base_calculo=Decimal("117.00"),
+            cofins_aliquota_percentual=Decimal("3.00"),
+            cofins_valor=Decimal("3.51"),
+            valor_tributos_aprox="21.06",
+            numero_pedido="12345",
+            numero_item="1",
+            nfci="12345678-AAAA-FFFF-1234-000000000000",
+            informacoes_adicionais="Informações adicionais",
+            ipi_valor_ipi_dev=Decimal("10.00"),
+            pdevol=Decimal("1.00"),
             # declaração de importação
             declaracoes_importacao=declaracao_importacao,
             # ipi
-            ipi_classe_enquadramento='999',
-            ipi_codigo_enquadramento='00',
-            ipi_valor_base_calculo=Decimal('117.00'),
-            ipi_aliquota=Decimal('10.00'),
-            ipi_valor_ipi=Decimal('11.70'),
+            ipi_classe_enquadramento="999",
+            ipi_codigo_enquadramento="00",
+            ipi_valor_base_calculo=Decimal("117.00"),
+            ipi_aliquota=Decimal("10.00"),
+            ipi_valor_ipi=Decimal("11.70"),
             # ii
-            imposto_importacao_valor_base_calculo=Decimal('117.00'),
-            imposto_importacao_valor_despesas_aduaneiras=Decimal('0.00'),
-            imposto_importacao_valor=Decimal('0.00'),
-            imposto_importacao_valor_iof=Decimal('1.11'),
+            imposto_importacao_valor_base_calculo=Decimal("117.00"),
+            imposto_importacao_valor_despesas_aduaneiras=Decimal("0.00"),
+            imposto_importacao_valor=Decimal("0.00"),
+            imposto_importacao_valor_iof=Decimal("1.11"),
         )
-        
+
         self.notafiscal.adicionar_pagamento(
             t_pag="03",
             x_pag="Cartao Credito",
@@ -219,196 +214,284 @@ class SerializacaoNFeTestCase(unittest.TestCase):
 
     def validacao_com_xsd_do_xml_gerado_sem_processar(self):
         self.validacao.validar_etree(
-            xml_doc=self.xml_assinado,
-            xsd_file=self.xsd_nfe,
-            use_assert=True
+            xml_doc=self.xml_assinado, xsd_file=self.xsd_nfe, use_assert=True
         )
 
     def total_e_produto_cst00_test(self):
         # Produto
-        cProd = self.xml_assinado.xpath('//ns:det/ns:prod/ns:cProd', namespaces=self.ns)[0].text
-        cEAN = self.xml_assinado.xpath('//ns:det/ns:prod/ns:cEAN', namespaces=self.ns)[0].text
-        xProd = self.xml_assinado.xpath('//ns:det/ns:prod/ns:xProd', namespaces=self.ns)[0].text
-        NCM = self.xml_assinado.xpath('//ns:det/ns:prod/ns:NCM', namespaces=self.ns)[0].text
+        cProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cProd", namespaces=self.ns)[0].text
+        cEAN = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEAN", namespaces=self.ns)[0].text
+        xProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xProd", namespaces=self.ns)[0].text
+        NCM = self.xml_assinado.xpath("//ns:det/ns:prod/ns:NCM", namespaces=self.ns)[0].text
         # CEST = self.xml_assinado.xpath('//ns:det/ns:prod/ns:CEST', namespaces=self.ns)[0].text
         # indEscala = self.xml_assinado.xpath('//ns:det/ns:prod/ns:indEscala', namespaces=self.ns)[0].text  # NOQA
         CEST = None
         indEscala = None
-        CFOP = self.xml_assinado.xpath('//ns:det/ns:prod/ns:CFOP', namespaces=self.ns)[0].text
-        uCom = self.xml_assinado.xpath('//ns:det/ns:prod/ns:uCom', namespaces=self.ns)[0].text
-        qCom = self.xml_assinado.xpath('//ns:det/ns:prod/ns:qCom', namespaces=self.ns)[0].text
-        vUnCom = self.xml_assinado.xpath('//ns:det/ns:prod/ns:vUnCom', namespaces=self.ns)[0].text
-        vProd = self.xml_assinado.xpath('//ns:det/ns:prod/ns:vProd', namespaces=self.ns)[0].text
-        cEANTrib = self.xml_assinado.xpath('//ns:det/ns:prod/ns:cEANTrib', namespaces=self.ns)[0].text  # NOQA
-        uTrib = self.xml_assinado.xpath('//ns:det/ns:prod/ns:uTrib', namespaces=self.ns)[0].text
-        qTrib = self.xml_assinado.xpath('//ns:det/ns:prod/ns:qTrib', namespaces=self.ns)[0].text
-        vUnTrib = self.xml_assinado.xpath('//ns:det/ns:prod/ns:vUnTrib', namespaces=self.ns)[0].text
-        indTot = self.xml_assinado.xpath('//ns:det/ns:prod/ns:indTot', namespaces=self.ns)[0].text
-        xPed = self.xml_assinado.xpath('//ns:det/ns:prod/ns:xPed', namespaces=self.ns)[0].text
-        nItemPed = self.xml_assinado.xpath('//ns:det/ns:prod/ns:nItemPed', namespaces=self.ns)[0].text  # NOQA
-        nFCI = self.xml_assinado.xpath('//ns:det/ns:prod/ns:nFCI', namespaces=self.ns)[0].text
+        CFOP = self.xml_assinado.xpath("//ns:det/ns:prod/ns:CFOP", namespaces=self.ns)[0].text
+        uCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uCom", namespaces=self.ns)[0].text
+        qCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qCom", namespaces=self.ns)[0].text
+        vUnCom = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnCom", namespaces=self.ns)[0].text
+        vProd = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vProd", namespaces=self.ns)[0].text
+        cEANTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:cEANTrib", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        uTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:uTrib", namespaces=self.ns)[0].text
+        qTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:qTrib", namespaces=self.ns)[0].text
+        vUnTrib = self.xml_assinado.xpath("//ns:det/ns:prod/ns:vUnTrib", namespaces=self.ns)[0].text
+        indTot = self.xml_assinado.xpath("//ns:det/ns:prod/ns:indTot", namespaces=self.ns)[0].text
+        xPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:xPed", namespaces=self.ns)[0].text
+        nItemPed = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nItemPed", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        nFCI = self.xml_assinado.xpath("//ns:det/ns:prod/ns:nFCI", namespaces=self.ns)[0].text
 
-        self.assertEqual(cProd, '000328')
-        self.assertEqual(cEAN, '1234567890121')
-        self.assertEqual(xProd, 'Produto teste')
-        self.assertEqual(NCM, '99999999')
+        self.assertEqual(cProd, "000328")
+        self.assertEqual(cEAN, "1234567890121")
+        self.assertEqual(xProd, "Produto teste")
+        self.assertEqual(NCM, "99999999")
         self.assertEqual(CEST, None)
         self.assertEqual(indEscala, None)
-        self.assertEqual(CFOP, '3102')
-        self.assertEqual(uCom, 'UN')
-        self.assertEqual(qCom, '12')
-        self.assertEqual(vUnCom, '9.7500000000')
-        self.assertEqual(vProd, '117.00')
-        self.assertEqual(cEANTrib, 'SEM GTIN')
-        self.assertEqual(uTrib, 'UN')
-        self.assertEqual(qTrib, '12')
-        self.assertEqual(vUnTrib, '9.7500000000')
-        self.assertEqual(indTot, '1')
-        self.assertEqual(xPed, '12345')
-        self.assertEqual(nItemPed, '1')
-        self.assertEqual(nFCI, '12345678-AAAA-FFFF-1234-000000000000')
+        self.assertEqual(CFOP, "3102")
+        self.assertEqual(uCom, "UN")
+        self.assertEqual(qCom, "12")
+        self.assertEqual(vUnCom, "9.7500000000")
+        self.assertEqual(vProd, "117.00")
+        self.assertEqual(cEANTrib, "SEM GTIN")
+        self.assertEqual(uTrib, "UN")
+        self.assertEqual(qTrib, "12")
+        self.assertEqual(vUnTrib, "9.7500000000")
+        self.assertEqual(indTot, "1")
+        self.assertEqual(xPed, "12345")
+        self.assertEqual(nItemPed, "1")
+        self.assertEqual(nFCI, "12345678-AAAA-FFFF-1234-000000000000")
 
         # Impostos
         # ICMS
-        orig = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:orig', namespaces=self.ns)[0].text  # NOQA
-        CST = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:CST', namespaces=self.ns)[0].text  # NOQA
-        modBC = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:modBC', namespaces=self.ns)[0].text  # NOQA
-        vBC = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:vBC', namespaces=self.ns)[0].text  # NOQA
-        pICMS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:pICMS', namespaces=self.ns)[0].text  # NOQA
-        vICMS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:vICMS', namespaces=self.ns)[0].text  # NOQA
+        orig = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:orig", namespaces=self.ns
+        )[0].text  # NOQA
+        CST = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:CST", namespaces=self.ns
+        )[0].text  # NOQA
+        modBC = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:modBC", namespaces=self.ns
+        )[0].text  # NOQA
+        vBC = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:vBC", namespaces=self.ns
+        )[0].text  # NOQA
+        pICMS = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:pICMS", namespaces=self.ns
+        )[0].text  # NOQA
+        vICMS = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:vICMS", namespaces=self.ns
+        )[0].text  # NOQA
         # pFCP = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:pFCP', namespaces=self.ns)[0].text  # NOQA
         # vFCP = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:ICMS/ns:ICMS00/ns:vFCP', namespaces=self.ns)[0].text  # NOQA
         pFCP = None
         vFCP = None
 
-        self.assertEqual(orig, '0')
-        self.assertEqual(CST, '00')
-        self.assertEqual(modBC, '0')
-        self.assertEqual(vBC, '0')
-        self.assertEqual(pICMS, '0.00')
-        self.assertEqual(vICMS, '0.00')
+        self.assertEqual(orig, "0")
+        self.assertEqual(CST, "00")
+        self.assertEqual(modBC, "0")
+        self.assertEqual(vBC, "0")
+        self.assertEqual(pICMS, "0.00")
+        self.assertEqual(vICMS, "0.00")
         # self.assertEqual(pFCP, '0.00')
         # self.assertEqual(vFCP, '0.00')
         self.assertEqual(pFCP, None)
         self.assertEqual(vFCP, None)
 
         # PIS
-        CST_PIS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST', namespaces=self.ns)[0].text  # NOQA
-        self.assertEqual(CST_PIS, '51')
+        CST_PIS = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:PIS/ns:PISOutr/ns:CST", namespaces=self.ns
+        )[0].text  # NOQA
+        self.assertEqual(CST_PIS, "51")
 
         # # COFINS
-        CST_COFINS = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST', namespaces=self.ns)[0].text  # NOQA
-        self.assertEqual(CST_COFINS, '51')
+        CST_COFINS = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:COFINS/ns:COFINSOutr/ns:CST", namespaces=self.ns
+        )[0].text  # NOQA
+        self.assertEqual(CST_COFINS, "51")
 
         # Impostos - IPI Devolução
-        pDevol = self.xml_assinado.xpath('//ns:det/ns:impostoDevol/ns:pDevol', namespaces=self.ns)[0].text  # NOQA
-        vIPIDevol = self.xml_assinado.xpath('//ns:det/ns:impostoDevol/ns:IPI/ns:vIPIDevol', namespaces=self.ns)[0].text  # NOQA
-        self.assertEqual(pDevol, '1.00')
-        self.assertEqual(vIPIDevol, '10.00')
+        pDevol = self.xml_assinado.xpath("//ns:det/ns:impostoDevol/ns:pDevol", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vIPIDevol = self.xml_assinado.xpath(
+            "//ns:det/ns:impostoDevol/ns:IPI/ns:vIPIDevol", namespaces=self.ns
+        )[0].text  # NOQA
+        self.assertEqual(pDevol, "1.00")
+        self.assertEqual(vIPIDevol, "10.00")
 
         # IPI
-        ipi_codigo_enquadramento = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:CST', namespaces=self.ns)[0].text  # NOQA
-        ipi_valor_base_calculo = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:vBC', namespaces=self.ns)[0].text  # NOQA
-        ipi_aliquota = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:pIPI', namespaces=self.ns)[0].text  # NOQA
-        ipi_valor = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:vIPI', namespaces=self.ns)[0].text  # NOQA
-        self.assertEqual(ipi_codigo_enquadramento, '00')
-        self.assertEqual(ipi_valor_base_calculo, '117.00')
-        self.assertEqual(ipi_aliquota, '10.00')
-        self.assertEqual(ipi_valor, '11.70')
+        ipi_codigo_enquadramento = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:CST", namespaces=self.ns
+        )[0].text  # NOQA
+        ipi_valor_base_calculo = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:vBC", namespaces=self.ns
+        )[0].text  # NOQA
+        ipi_aliquota = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:pIPI", namespaces=self.ns
+        )[0].text  # NOQA
+        ipi_valor = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:IPI/ns:IPITrib/ns:vIPI", namespaces=self.ns
+        )[0].text  # NOQA
+        self.assertEqual(ipi_codigo_enquadramento, "00")
+        self.assertEqual(ipi_valor_base_calculo, "117.00")
+        self.assertEqual(ipi_aliquota, "10.00")
+        self.assertEqual(ipi_valor, "11.70")
 
         # ii
-        imposto_importacao_valor_base_calculo = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:II/ns:vBC', namespaces=self.ns)[0].text  # NOQA
-        imposto_importacao_valor_despesas_aduaneiras = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:II/ns:vDespAdu', namespaces=self.ns)[0].text  # NOQA
-        imposto_importacao_valor = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:II/ns:vII', namespaces=self.ns)[0].text  # NOQA
-        imposto_importacao_valor_iof = self.xml_assinado.xpath('//ns:det/ns:imposto/ns:II/ns:vIOF', namespaces=self.ns)[0].text  # NOQA
-        self.assertEqual(imposto_importacao_valor_base_calculo, '117.00')
-        self.assertEqual(imposto_importacao_valor_despesas_aduaneiras, '0.00')
-        self.assertEqual(imposto_importacao_valor, '0.00')
-        self.assertEqual(imposto_importacao_valor_iof, '1.11')
+        imposto_importacao_valor_base_calculo = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:II/ns:vBC", namespaces=self.ns
+        )[0].text  # NOQA
+        imposto_importacao_valor_despesas_aduaneiras = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:II/ns:vDespAdu", namespaces=self.ns
+        )[0].text  # NOQA
+        imposto_importacao_valor = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:II/ns:vII", namespaces=self.ns
+        )[0].text  # NOQA
+        imposto_importacao_valor_iof = self.xml_assinado.xpath(
+            "//ns:det/ns:imposto/ns:II/ns:vIOF", namespaces=self.ns
+        )[0].text  # NOQA
+        self.assertEqual(imposto_importacao_valor_base_calculo, "117.00")
+        self.assertEqual(imposto_importacao_valor_despesas_aduaneiras, "0.00")
+        self.assertEqual(imposto_importacao_valor, "0.00")
+        self.assertEqual(imposto_importacao_valor_iof, "1.11")
 
         # Declaração de Importação
-        numero_di_dsi_da = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:nDI', namespaces=self.ns)[0].text  # NOQA
-        data_registro = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:dDI', namespaces=self.ns)[0].text  # NOQA
-        desembaraco_aduaneiro_local = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:xLocDesemb', namespaces=self.ns)[0].text  # NOQA
-        desembaraco_aduaneiro_uf = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:UFDesemb', namespaces=self.ns)[0].text  # NOQA
-        desembaraco_aduaneiro_data = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:dDesemb', namespaces=self.ns)[0].text  # NOQA
-        tipo_via_transporte = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:tpViaTransp', namespaces=self.ns)[0].text  # NOQA
+        numero_di_dsi_da = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:nDI", namespaces=self.ns
+        )[0].text  # NOQA
+        data_registro = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:dDI", namespaces=self.ns
+        )[0].text  # NOQA
+        desembaraco_aduaneiro_local = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:xLocDesemb", namespaces=self.ns
+        )[0].text  # NOQA
+        desembaraco_aduaneiro_uf = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:UFDesemb", namespaces=self.ns
+        )[0].text  # NOQA
+        desembaraco_aduaneiro_data = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:dDesemb", namespaces=self.ns
+        )[0].text  # NOQA
+        tipo_via_transporte = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:tpViaTransp", namespaces=self.ns
+        )[0].text  # NOQA
         # valor_afrmm = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:vAFRMM', namespaces=self.ns)[0].text  # NOQA
-        tipo_intermediacao = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:tpIntermedio', namespaces=self.ns)[0].text  # NOQA
-        cnpj_adquirente = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:CNPJ', namespaces=self.ns)[0].text  # NOQA
+        tipo_intermediacao = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:tpIntermedio", namespaces=self.ns
+        )[0].text  # NOQA
+        cnpj_adquirente = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:CNPJ", namespaces=self.ns
+        )[0].text  # NOQA
         # uf_terceiro = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:UFTerceiro', namespaces=self.ns)[0].text  # NOQA
-        codigo_exportador = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:cExportador', namespaces=self.ns)[0].text  # NOQA
+        codigo_exportador = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:cExportador", namespaces=self.ns
+        )[0].text  # NOQA
 
-        adicao_numero = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:adi/ns:nAdicao', namespaces=self.ns)[0].text  # NOQA
-        adicao_sequencia = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:adi/ns:nSeqAdic', namespaces=self.ns)[0].text  # NOQA
-        adicao_codigo_fabricante = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:adi/ns:cFabricante', namespaces=self.ns)[0].text  # NOQA
+        adicao_numero = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:adi/ns:nAdicao", namespaces=self.ns
+        )[0].text  # NOQA
+        adicao_sequencia = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:adi/ns:nSeqAdic", namespaces=self.ns
+        )[0].text  # NOQA
+        adicao_codigo_fabricante = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:adi/ns:cFabricante", namespaces=self.ns
+        )[0].text  # NOQA
         # adicao_desconto = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:adi/ns:vDescDI', namespaces=self.ns)[0].text  # NOQA
-        adicao_numero_drawback = self.xml_assinado.xpath('//ns:det/ns:prod/ns:DI/ns:adi/ns:nDraw', namespaces=self.ns)[0].text  # NOQA
+        adicao_numero_drawback = self.xml_assinado.xpath(
+            "//ns:det/ns:prod/ns:DI/ns:adi/ns:nDraw", namespaces=self.ns
+        )[0].text  # NOQA
 
-        self.assertEqual(numero_di_dsi_da, '123456789')
-        self.assertEqual(data_registro, '2021-01-14')
-        self.assertEqual(desembaraco_aduaneiro_local, 'Santos')
-        self.assertEqual(desembaraco_aduaneiro_uf, 'SP')
-        self.assertEqual(desembaraco_aduaneiro_data, '2021-01-14')
-        self.assertEqual(tipo_via_transporte, '1')
+        self.assertEqual(numero_di_dsi_da, "123456789")
+        self.assertEqual(data_registro, "2021-01-14")
+        self.assertEqual(desembaraco_aduaneiro_local, "Santos")
+        self.assertEqual(desembaraco_aduaneiro_uf, "SP")
+        self.assertEqual(desembaraco_aduaneiro_data, "2021-01-14")
+        self.assertEqual(tipo_via_transporte, "1")
         # self.assertEqual(valor_afrmm, Decimal('0'))
-        self.assertEqual(tipo_intermediacao, '1')
-        self.assertEqual(cnpj_adquirente, '00111711999900')
+        self.assertEqual(tipo_intermediacao, "1")
+        self.assertEqual(cnpj_adquirente, "00111711999900")
         # self.assertEqual(uf_terceiro, '')
-        self.assertEqual(codigo_exportador, '1')
+        self.assertEqual(codigo_exportador, "1")
 
-        self.assertEqual(adicao_numero, '1')
-        self.assertEqual(adicao_sequencia, '1')
-        self.assertEqual(adicao_codigo_fabricante, '1')
+        self.assertEqual(adicao_numero, "1")
+        self.assertEqual(adicao_sequencia, "1")
+        self.assertEqual(adicao_codigo_fabricante, "1")
         # self.assertEqual(adicao_desconto, '0')
-        self.assertEqual(adicao_numero_drawback, '12345678')
+        self.assertEqual(adicao_numero_drawback, "12345678")
 
         # Informações Adicionais do produto
-        infAdProd = self.xml_assinado.xpath('//ns:det/ns:infAdProd', namespaces=self.ns)[0].text
-        self.assertEqual(infAdProd, 'Informacoes adicionais')
+        infAdProd = self.xml_assinado.xpath("//ns:det/ns:infAdProd", namespaces=self.ns)[0].text
+        self.assertEqual(infAdProd, "Informacoes adicionais")
 
         # Totalizadores
-        vBC = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vBC', namespaces=self.ns)[0].text  # NOQA
-        vICMS = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vICMS', namespaces=self.ns)[0].text  # NOQA
-        vICMSDeson = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vICMSDeson', namespaces=self.ns)[0].text  # NOQA
-        vFCP = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vFCP', namespaces=self.ns)[0].text  # NOQA
-        vBCST = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vBCST', namespaces=self.ns)[0].text  # NOQA
-        vST = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vST', namespaces=self.ns)[0].text  # NOQA
-        vFCPST = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vFCPST', namespaces=self.ns)[0].text  # NOQA
-        vFCPSTRet = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vFCPSTRet', namespaces=self.ns)[0].text  # NOQA
-        vProd = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vProd', namespaces=self.ns)[0].text  # NOQA
-        vFrete = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vFrete', namespaces=self.ns)[0].text  # NOQA
-        vSeg = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vSeg', namespaces=self.ns)[0].text  # NOQA
-        vDesc = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vDesc', namespaces=self.ns)[0].text  # NOQA
-        vII = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vII', namespaces=self.ns)[0].text  # NOQA
-        vIPI = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vIPI', namespaces=self.ns)[0].text  # NOQA
-        vIPIDevol = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vIPIDevol', namespaces=self.ns)[0].text  # NOQA
-        vPIS = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vPIS', namespaces=self.ns)[0].text  # NOQA
-        vCOFINS = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vCOFINS', namespaces=self.ns)[0].text  # NOQA
-        vOutro = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vOutro', namespaces=self.ns)[0].text  # NOQA
-        vNF = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vNF', namespaces=self.ns)[0].text  # NOQA
-        vTotTrib = self.xml_assinado.xpath('//ns:total/ns:ICMSTot/ns:vTotTrib', namespaces=self.ns)[0].text  # NOQA
+        vBC = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBC", namespaces=self.ns)[0].text  # NOQA
+        vICMS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vICMS", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vICMSDeson = self.xml_assinado.xpath(
+            "//ns:total/ns:ICMSTot/ns:vICMSDeson", namespaces=self.ns
+        )[0].text  # NOQA
+        vFCP = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCP", namespaces=self.ns)[0].text  # NOQA
+        vBCST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vBCST", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vST", namespaces=self.ns)[0].text  # NOQA
+        vFCPST = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFCPST", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vFCPSTRet = self.xml_assinado.xpath(
+            "//ns:total/ns:ICMSTot/ns:vFCPSTRet", namespaces=self.ns
+        )[0].text  # NOQA
+        vProd = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vProd", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vFrete = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vFrete", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vSeg = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vSeg", namespaces=self.ns)[0].text  # NOQA
+        vDesc = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vDesc", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vII = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vII", namespaces=self.ns)[0].text  # NOQA
+        vIPI = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vIPI", namespaces=self.ns)[0].text  # NOQA
+        vIPIDevol = self.xml_assinado.xpath(
+            "//ns:total/ns:ICMSTot/ns:vIPIDevol", namespaces=self.ns
+        )[0].text  # NOQA
+        vPIS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vPIS", namespaces=self.ns)[0].text  # NOQA
+        vCOFINS = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vCOFINS", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vOutro = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vOutro", namespaces=self.ns)[
+            0
+        ].text  # NOQA
+        vNF = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vNF", namespaces=self.ns)[0].text  # NOQA
+        vTotTrib = self.xml_assinado.xpath("//ns:total/ns:ICMSTot/ns:vTotTrib", namespaces=self.ns)[
+            0
+        ].text  # NOQA
 
-        self.assertEqual(vBC, '0.00')
-        self.assertEqual(vICMS, '0.00')
-        self.assertEqual(vICMSDeson, '0.00')
-        self.assertEqual(vFCP, '0.00')
-        self.assertEqual(vBCST, '0.00')
-        self.assertEqual(vST, '0.00')
-        self.assertEqual(vFCPST, '0.00')
-        self.assertEqual(vFCPSTRet, '0.00')
-        self.assertEqual(vProd, '117.00')
-        self.assertEqual(vFrete, '0.00')
-        self.assertEqual(vSeg, '0.00')
-        self.assertEqual(vDesc, '0.00')
-        self.assertEqual(vII, '0.00')
-        self.assertEqual(vIPI, '11.70')
-        self.assertEqual(vIPIDevol, '10.00')
-        self.assertEqual(vPIS, '0.76')
-        self.assertEqual(vCOFINS, '3.51')
-        self.assertEqual(vOutro, '0.00')
-        self.assertEqual(vNF, '138.70')
-        self.assertEqual(vTotTrib, '21.06')
+        self.assertEqual(vBC, "0.00")
+        self.assertEqual(vICMS, "0.00")
+        self.assertEqual(vICMSDeson, "0.00")
+        self.assertEqual(vFCP, "0.00")
+        self.assertEqual(vBCST, "0.00")
+        self.assertEqual(vST, "0.00")
+        self.assertEqual(vFCPST, "0.00")
+        self.assertEqual(vFCPSTRet, "0.00")
+        self.assertEqual(vProd, "117.00")
+        self.assertEqual(vFrete, "0.00")
+        self.assertEqual(vSeg, "0.00")
+        self.assertEqual(vDesc, "0.00")
+        self.assertEqual(vII, "0.00")
+        self.assertEqual(vIPI, "11.70")
+        self.assertEqual(vIPIDevol, "10.00")
+        self.assertEqual(vPIS, "0.76")
+        self.assertEqual(vCOFINS, "3.51")
+        self.assertEqual(vOutro, "0.00")
+        self.assertEqual(vNF, "138.70")
+        self.assertEqual(vTotTrib, "21.06")
 
     def test_notafiscal_produto_cst00(self):
         # Preenche as classes do pynfe
@@ -427,5 +510,5 @@ class SerializacaoNFeTestCase(unittest.TestCase):
         self.validacao_com_xsd_do_xml_gerado_sem_processar()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_nfse_serializacao.py
+++ b/tests/test_nfse_serializacao.py
@@ -1,4 +1,3 @@
-
 import pyxb.namespace
 from pynfe.entidades.cliente import Cliente
 from pynfe.entidades.emitente import Emitente
@@ -29,50 +28,50 @@ class SerializacaoNFSeTest:
     @staticmethod
     def get_notafiscal_servico() -> NotaFiscalServico:
         servico = Servico(
-            valor_servico=Decimal('100.00'),
+            valor_servico=Decimal("100.00"),
             iss_retido=1,  # 1 - Sim; 2 - Não
             exigibilidade=1,
-            item_lista='0101',
-            discriminacao='Mensalidade',
-            codigo_municipio=obter_codigo_por_municipio(
-                'Pedro Leopoldo', 'MG'),
+            item_lista="0101",
+            discriminacao="Mensalidade",
+            codigo_municipio=obter_codigo_por_municipio("Pedro Leopoldo", "MG"),
             # Dados opcionais
             codigo_cnae=6201501,
-            codigo_tributacao_municipio='1234',
-            valor_deducoes=Decimal('10.00'),
-            valor_pis=Decimal('10.00'),
-            valor_confins=Decimal('10.00'),
-            valor_inss=Decimal('10.00'),
-            valor_ir=Decimal('10.00'),
-            valor_csll=Decimal('10.00'),
-            valor_iss=Decimal('10.00'),
-            valor_iss_retido=Decimal('10.00'),
-            valor_liquido=Decimal('10.00'),
-            outras_retencoes=Decimal('10.00'),
-            base_calculo=Decimal('10.00'),
-            aliquota=Decimal('10.00'),
-            desconto_incondicionado=Decimal('10.00'),
-            desconto_condicionado=Decimal('10.00')
+            codigo_tributacao_municipio="1234",
+            valor_deducoes=Decimal("10.00"),
+            valor_pis=Decimal("10.00"),
+            valor_confins=Decimal("10.00"),
+            valor_inss=Decimal("10.00"),
+            valor_ir=Decimal("10.00"),
+            valor_csll=Decimal("10.00"),
+            valor_iss=Decimal("10.00"),
+            valor_iss_retido=Decimal("10.00"),
+            valor_liquido=Decimal("10.00"),
+            outras_retencoes=Decimal("10.00"),
+            base_calculo=Decimal("10.00"),
+            aliquota=Decimal("10.00"),
+            desconto_incondicionado=Decimal("10.00"),
+            desconto_condicionado=Decimal("10.00"),
         )
 
         return NotaFiscalServico(
-            identificador='50',
+            identificador="50",
             data_emissao=datetime.datetime.strptime(
-                SerializacaoNFSeTest.data_hora, "%Y-%m-%dT%H:%M:%S"),
+                SerializacaoNFSeTest.data_hora, "%Y-%m-%dT%H:%M:%S"
+            ),
             servico=servico,
             emitente=SerializacaoNFSeTest._get_emitente(),
             cliente=SerializacaoNFSeTest._get_destinatario(),
             # Optante Simples Nacional
-            simples=1,     # 1-Sim; 2-Não
+            simples=1,  # 1-Sim; 2-Não
             # 1 – Tributação no município 2 - Tributação fora do município 3 - Isenção 4 - Imune
             natureza_operacao=1,
             # 5 –Exigibilidade suspensa por decisão judicial 6 – Exigibilidade suspensa por procedimento administrativo
             # regime_especial=1, # Regime Especial de Tributação: 1 – Microempresa municipal 2 - Estimativa
             # 3 – Sociedade de profissionais 4 – Cooperativa 5 - Microempresário Individual (MEI)
             # 6 - Microempresário e Empresa de Pequeno Porte (ME EPP)
-            incentivo=2,   # Incentivador Cultural # 1-Sim; 2-Não
-            serie='A1',
-            tipo='1'
+            incentivo=2,  # Incentivador Cultural # 1-Sim; 2-Não
+            serie="A1",
+            tipo="1",
         )
 
     @staticmethod
@@ -116,35 +115,28 @@ class SerializacaoNFSeTest:
 
     @staticmethod
     def _get_config() -> SerializacaoNFSeConfigTest:
-        return SerializacaoNFSeConfigTest(
-            "./tests/certificado.pfx",
-            bytes("123456", "utf-8"),
-            True
-        )
+        return SerializacaoNFSeConfigTest("./tests/certificado.pfx", bytes("123456", "utf-8"), True)
 
     @staticmethod
     def _get_emitente() -> Emitente:
-        return Emitente(
-            cnpj='45111111111100',
-            inscricao_municipal='000000'
-        )
+        return Emitente(cnpj="45111111111100", inscricao_municipal="000000")
 
     @staticmethod
     def _get_destinatario() -> Cliente:
         return Cliente(
-            razao_social='NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL',
-            tipo_documento='CNPJ',                          # CPF ou CNPJ
+            razao_social="NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
+            tipo_documento="CNPJ",  # CPF ou CNPJ
             # apenas os numeros do CPF ou CNPJ
-            numero_documento='99999999999999',
-            inscricao_municipal='1234',                     # opcional
-            endereco_logradouro='Rua tal',
-            endereco_numero='0',
-            endereco_complemento='Ao lado de lugar nenhum',  # opcional
-            endereco_bairro='Centro',
-            endereco_cod_municipio='123',
-            endereco_uf='MG',
-            endereco_cep='33257010',
+            numero_documento="99999999999999",
+            inscricao_municipal="1234",  # opcional
+            endereco_logradouro="Rua tal",
+            endereco_numero="0",
+            endereco_complemento="Ao lado de lugar nenhum",  # opcional
+            endereco_bairro="Centro",
+            endereco_cod_municipio="123",
+            endereco_uf="MG",
+            endereco_cep="33257010",
             endereco_pais=CODIGO_BRASIL,
-            endereco_telefone='12365478945',                # opcional
-            email='nome@email.com.br'                       # opcional
+            endereco_telefone="12365478945",  # opcional
+            email="nome@email.com.br",  # opcional
         )

--- a/tests/test_nfse_serializacao_betha.py
+++ b/tests/test_nfse_serializacao_betha.py
@@ -7,7 +7,7 @@ from tests.test_nfse_serializacao import SerializacaoNFSeTest
 class SerializacaoNFSeBethaTestCase(unittest.TestCase):
     def test_notafiscal_geral(self):
         nfse = self._get_notafiscal_servico()
-        nfse_xml = SerializacaoNFSeTest.serializa_nfse(nfse, 'betha')
+        nfse_xml = SerializacaoNFSeTest.serializa_nfse(nfse, "betha")
 
         nfse_xml_assinado = SerializacaoNFSeTest.assina_xml(nfse_xml)
         nfse_esperada = self._get_nfse_esperada()

--- a/tests/test_nfse_serializacao_ginfes.py
+++ b/tests/test_nfse_serializacao_ginfes.py
@@ -32,7 +32,7 @@ class SerializacaoNFSeGinfesTestCase(unittest.TestCase):
         SerializacaoNFSeTest.limpa_namespace()
 
     def _serializa_nfse(self, nfse: NotaFiscalServico) -> str:
-        serializador = SerializacaoNfse('ginfes')
+        serializador = SerializacaoNfse("ginfes")
         xml = serializador.gerar_lote(nfse)
 
         return xml
@@ -40,7 +40,7 @@ class SerializacaoNFSeGinfesTestCase(unittest.TestCase):
     # a serialização gera os atributos xmlns:ns1 e xmlns:ns2
     # da tag ns1:EnviarLoteRpsEnvio em ordem randômica (!!!)
     def _ajusta_xml_test(self, xml: str) -> str:
-        return re.sub(r'<(ns1:EnviarLoteRpsEnvio)[^>]*>', r'<\1>', xml)
+        return re.sub(r"<(ns1:EnviarLoteRpsEnvio)[^>]*>", r"<\1>", xml)
 
     def _get_nfse_esperada(self) -> str:
         return SerializacaoNFSeTest.strip_xml(f"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ from pynfe.utils import (
     obter_uf_por_codigo,
     formatar_decimal,
     remover_acentos,
-    carregar_arquivo_municipios
+    carregar_arquivo_municipios,
 )
 from lxml import etree
 from pynfe.utils.descompactar import DescompactaGzip
@@ -46,13 +46,13 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(obter_pais_por_codigo(None), "Brasil")
 
     def test_obter_pais_por_codigo_paisesbaixos(self):
-        self.assertEqual(obter_pais_por_codigo("5738"), 'PAISES BAIXOS (HOLANDA)')
+        self.assertEqual(obter_pais_por_codigo("5738"), "PAISES BAIXOS (HOLANDA)")
 
     def test_obter_pais_por_codigo_reino_unido(self):
-        self.assertEqual(obter_pais_por_codigo("6289"), 'REINO UNIDO')
+        self.assertEqual(obter_pais_por_codigo("6289"), "REINO UNIDO")
 
     def test_obter_pais_por_codigo_ilhas_cayman(self):
-        self.assertEqual(obter_pais_por_codigo("1376"), 'CAYMAN, ILHAS')
+        self.assertEqual(obter_pais_por_codigo("1376"), "CAYMAN, ILHAS")
 
     # normalizar_municipio
     def test_normalizar_municipio_acento_til_na_letra_a(self):
@@ -86,9 +86,7 @@ class UtilsTestCase(unittest.TestCase):
         )
 
     def test_normalizar_municipio_acento_circunflexo_na_letra_o(self):
-        self.assertEqual(
-            normalizar_municipio("Santo Antônio de Posse"), "SANTO ANTONIO DE POSSE"
-        )
+        self.assertEqual(normalizar_municipio("Santo Antônio de Posse"), "SANTO ANTONIO DE POSSE")
 
     def test_normalizar_municipio_apostrofo(self):
         self.assertEqual(normalizar_municipio("Lambari D'Oeste"), "LAMBARI DOESTE")
@@ -260,6 +258,7 @@ class CidadesTestCase(unittest.TestCase):
     pelo arquivos MunIBGE-UFXX.txt
 
     """
+
     def test_quantidade_cidades_ac(self):
         self.assertEqual(len(carregar_arquivo_municipios(uf=12)), 22)
 
@@ -349,11 +348,33 @@ class CidadesTestCase(unittest.TestCase):
         """
         total = 0
         lista_de_codigos_uf = [
-            11, 12, 13, 14, 15, 16, 17,  # Norte
-            21, 22, 23, 24, 25, 26, 27, 28, 29,  # Nordeste
-            31, 32, 33, 35,  # Sudeste
-            41, 42, 43,  # Sul
-            50, 51, 52, 53  # Centro-Oeste
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,  # Norte
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,  # Nordeste
+            31,
+            32,
+            33,
+            35,  # Sudeste
+            41,
+            42,
+            43,  # Sul
+            50,
+            51,
+            52,
+            53,  # Centro-Oeste
         ]
         for uf in lista_de_codigos_uf:
             total += len(carregar_arquivo_municipios(uf=uf))


### PR DESCRIPTION
Hoje se você der um SAVE com formatting ativado no VSCODE, muitos arquivos vão sofrer várias alterações, trabalhando com LLM's como Cursor eles automaticamente vão formatando todos os arquivos causando muitas alterações que impossibilitam acompanhar o que está sendo alterado.
Então eu rodei um `ruff format .` e formatei todos os arquivos para evitar isso, e também inclui no CI para verificar se a formatação está sendo aplicada caso alguém tente contribuir sem ter o ruff instalado.

- Created requirements-dev.txt to include pytest and ruff for development.
- Updated requirements.txt to reference the new requirements-dev.txt for development dependencies.
- Modified CI configuration to install development dependencies and check formatting with ruff.
- Cleaned up some docstrings and improved code formatting in various files for consistency.